### PR TITLE
Improved statistics

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenContent.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import chimahon.anki.AnkiProfile
 import eu.kanade.presentation.more.stats.data.StatsData
 import eu.kanade.presentation.more.stats.data.StatsType
 import tachiyomi.i18n.MR
@@ -100,6 +101,7 @@ fun StatsScreenContent(
     onDateScaleSelect: (StatsDateScale) -> Unit,
     onDateOffsetChange: (Int) -> Unit,
     onStatsTypeSelect: (StatsType) -> Unit,
+    onProfileSelect: (String?) -> Unit,
     allRead: Boolean = false,
 ) {
     LazyColumn(
@@ -113,6 +115,9 @@ fun StatsScreenContent(
                 onStatsTypeSelect = onStatsTypeSelect,
                 dateScale = state.dateScale,
                 onDateScaleSelect = onDateScaleSelect,
+                activeProfileId = state.activeProfileId,
+                profiles = state.profiles,
+                onProfileSelect = onProfileSelect,
             )
         }
 
@@ -143,6 +148,9 @@ private fun FiltersRow(
     onStatsTypeSelect: (StatsType) -> Unit,
     dateScale: StatsDateScale,
     onDateScaleSelect: (StatsDateScale) -> Unit,
+    activeProfileId: String?,
+    profiles: List<AnkiProfile>,
+    onProfileSelect: (String?) -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -198,6 +206,59 @@ private fun FiltersRow(
                         onClick = {
                             onDateScaleSelect(scale)
                             showMenu = false
+                        },
+                    )
+                }
+            }
+        }
+
+        var showProfileMenu by remember { mutableStateOf(false) }
+        val activeProfile = remember(activeProfileId, profiles) {
+            profiles.find { it.id == activeProfileId }
+        }
+        val isProfileSelected = activeProfileId != null
+        val profileLabel = if (activeProfile != null) {
+            stringResource(SYMR.strings.stats_profile_filter_label, activeProfile.name)
+        } else {
+            stringResource(SYMR.strings.stats_all_profiles)
+        }
+
+        Box {
+            FilterChip(
+                selected = isProfileSelected,
+                onClick = { showProfileMenu = true },
+                label = { Text(profileLabel) },
+                trailingIcon = { Icon(Icons.Outlined.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+                border = FilterChipDefaults.filterChipBorder(
+                    enabled = true,
+                    selected = isProfileSelected,
+                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    selectedBorderColor = Color.Transparent,
+                    borderWidth = 1.dp,
+                ),
+                shape = RoundedCornerShape(8.dp),
+            )
+            DropdownMenu(
+                expanded = showProfileMenu,
+                onDismissRequest = { showProfileMenu = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(SYMR.strings.stats_all_profiles)) },
+                    onClick = {
+                        onProfileSelect(null)
+                        showProfileMenu = false
+                    },
+                )
+                profiles.forEach { profile ->
+                    DropdownMenuItem(
+                        text = { Text(profile.name) },
+                        onClick = {
+                            onProfileSelect(profile.id)
+                            showProfileMenu = false
                         },
                     )
                 }

--- a/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenContent.kt
@@ -103,6 +103,9 @@ fun StatsScreenContent(
     onStatsTypeSelect: (StatsType) -> Unit,
     onProfileSelect: (String?) -> Unit,
     allRead: Boolean = false,
+    isSingleTitle: Boolean = false,
+    titleName: String? = null,
+    onLibraryCardClick: (() -> Unit)? = null,
 ) {
     LazyColumn(
         contentPadding = paddingValues,
@@ -118,6 +121,7 @@ fun StatsScreenContent(
                 activeProfileId = state.activeProfileId,
                 profiles = state.profiles,
                 onProfileSelect = onProfileSelect,
+                isSingleTitle = isSingleTitle,
             )
         }
 
@@ -137,7 +141,12 @@ fun StatsScreenContent(
         }
 
         item {
-            StatsGrid(state, allRead)
+            StatsGrid(
+                state = state,
+                allRead = allRead,
+                isSingleTitle = isSingleTitle,
+                onLibraryCardClick = onLibraryCardClick,
+            )
         }
     }
 }
@@ -151,6 +160,7 @@ private fun FiltersRow(
     activeProfileId: String?,
     profiles: List<AnkiProfile>,
     onProfileSelect: (String?) -> Unit,
+    isSingleTitle: Boolean = false,
 ) {
     Row(
         modifier = Modifier
@@ -160,25 +170,27 @@ private fun FiltersRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        StatsType.values().forEach { type ->
-            val isSelected = statsType == type
-            FilterChip(
-                selected = isSelected,
-                onClick = { onStatsTypeSelect(type) },
-                label = { Text(type.name) },
-                colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-                border = FilterChipDefaults.filterChipBorder(
-                    enabled = true,
+        if (!isSingleTitle) {
+            StatsType.values().forEach { type ->
+                val isSelected = statsType == type
+                FilterChip(
                     selected = isSelected,
-                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                    selectedBorderColor = Color.Transparent,
-                    borderWidth = 1.dp,
-                ),
-                shape = RoundedCornerShape(8.dp),
-            )
+                    onClick = { onStatsTypeSelect(type) },
+                    label = { Text(type.name) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                    border = FilterChipDefaults.filterChipBorder(
+                        enabled = true,
+                        selected = isSelected,
+                        borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                        selectedBorderColor = Color.Transparent,
+                        borderWidth = 1.dp,
+                    ),
+                    shape = RoundedCornerShape(8.dp),
+                )
+            }
         }
 
         var showMenu by remember { mutableStateOf(false) }
@@ -212,60 +224,63 @@ private fun FiltersRow(
             }
         }
 
-        var showProfileMenu by remember { mutableStateOf(false) }
-        val activeProfile = remember(activeProfileId, profiles) {
-            profiles.find { it.id == activeProfileId }
-        }
-        val isProfileSelected = activeProfileId != null
-        val profileLabel = if (activeProfile != null) {
-            stringResource(SYMR.strings.stats_profile_filter_label, activeProfile.name)
-        } else {
-            stringResource(SYMR.strings.stats_all_profiles)
-        }
+        if (!isSingleTitle) {
+            var showProfileMenu by remember { mutableStateOf(false) }
+            val activeProfile = remember(activeProfileId, profiles) {
+                profiles.find { it.id == activeProfileId }
+            }
+            val isProfileSelected = activeProfileId != null
+            val profileLabel = if (activeProfile != null) {
+                stringResource(SYMR.strings.stats_profile_filter_label, activeProfile.name)
+            } else {
+                stringResource(SYMR.strings.stats_all_profiles)
+            }
 
-        Box {
-            FilterChip(
-                selected = isProfileSelected,
-                onClick = { showProfileMenu = true },
-                label = { Text(profileLabel) },
-                trailingIcon = { Icon(Icons.Outlined.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
-                colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-                border = FilterChipDefaults.filterChipBorder(
-                    enabled = true,
+            Box {
+                FilterChip(
                     selected = isProfileSelected,
-                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                    selectedBorderColor = Color.Transparent,
-                    borderWidth = 1.dp,
-                ),
-                shape = RoundedCornerShape(8.dp),
-            )
-            DropdownMenu(
-                expanded = showProfileMenu,
-                onDismissRequest = { showProfileMenu = false },
-            ) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(SYMR.strings.stats_all_profiles)) },
-                    onClick = {
-                        onProfileSelect(null)
-                        showProfileMenu = false
-                    },
+                    onClick = { showProfileMenu = true },
+                    label = { Text(profileLabel) },
+                    trailingIcon = { Icon(Icons.Outlined.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                    border = FilterChipDefaults.filterChipBorder(
+                        enabled = true,
+                        selected = isProfileSelected,
+                        borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                        selectedBorderColor = Color.Transparent,
+                        borderWidth = 1.dp,
+                    ),
+                    shape = RoundedCornerShape(8.dp),
                 )
-                profiles.forEach { profile ->
+                DropdownMenu(
+                    expanded = showProfileMenu,
+                    onDismissRequest = { showProfileMenu = false },
+                ) {
                     DropdownMenuItem(
-                        text = { Text(profile.name) },
+                        text = { Text(stringResource(SYMR.strings.stats_all_profiles)) },
                         onClick = {
-                            onProfileSelect(profile.id)
+                            onProfileSelect(null)
                             showProfileMenu = false
                         },
                     )
+                    profiles.forEach { profile ->
+                        DropdownMenuItem(
+                            text = { Text(profile.name) },
+                            onClick = {
+                                onProfileSelect(profile.id)
+                                showProfileMenu = false
+                            },
+                        )
+                    }
                 }
             }
         }
     }
 }
+
 
 @Composable
 private fun DateNavigation(
@@ -477,7 +492,12 @@ private fun HeroSection(
 }
 
 @Composable
-private fun StatsGrid(state: StatsScreenState.Success, allRead: Boolean = false) {
+private fun StatsGrid(
+    state: StatsScreenState.Success,
+    allRead: Boolean = false,
+    isSingleTitle: Boolean = false,
+    onLibraryCardClick: (() -> Unit)? = null,
+) {
     val iconColor = MaterialTheme.colorScheme.primary
     
     Column(
@@ -508,28 +528,33 @@ private fun StatsGrid(state: StatsScreenState.Success, allRead: Boolean = false)
         }
 
         // Library Section
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text(
-                text = "Library",
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(start = 4.dp),
-            )
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Box(modifier = Modifier.weight(1f)) {
-                    MetricCard(MetricData(state.overview.libraryMangaCount.toCountString(), if (allRead) "All read" else "In library", null, Icons.Outlined.LibraryBooks, iconColor))
+        if (!isSingleTitle) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Library",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 4.dp),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        MetricCard(
+                            data = MetricData(state.overview.libraryMangaCount.toCountString(), if (allRead) "All read" else "In library", null, Icons.Outlined.LibraryBooks, iconColor),
+                            onClick = onLibraryCardClick,
+                        )
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        MetricCard(MetricData(state.titles.localMangaCount.toCountString(), "Local", null, Icons.Outlined.SdCard, iconColor))
+                    }
                 }
-                Box(modifier = Modifier.weight(1f)) {
-                    MetricCard(MetricData(state.titles.localMangaCount.toCountString(), "Local", null, Icons.Outlined.SdCard, iconColor))
-                }
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Box(modifier = Modifier.weight(1f)) {
-                    MetricCard(MetricData(state.titles.startedMangaCount.toCountString(), "Started", null, Icons.Outlined.PlayArrow, iconColor))
-                }
-                Box(modifier = Modifier.weight(1f)) {
-                    MetricCard(MetricData(state.overview.completedMangaCount.toCountString(), "Completed", null, Icons.Outlined.DoneAll, iconColor))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        MetricCard(MetricData(state.titles.startedMangaCount.toCountString(), "Started", null, Icons.Outlined.PlayArrow, iconColor))
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        MetricCard(MetricData(state.overview.completedMangaCount.toCountString(), "Completed", null, Icons.Outlined.DoneAll, iconColor))
+                    }
                 }
             }
         }
@@ -551,7 +576,7 @@ private fun StatsGrid(state: StatsScreenState.Success, allRead: Boolean = false)
                     MetricCard(MetricData(state.chapters.readChapterCount.toCountString(), "Read", null, Icons.Outlined.History, iconColor))
                 }
             }
-            if (state.statsType != StatsType.Novels) {
+            if (state.statsType != StatsType.Novels && !isSingleTitle) {
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     Box(modifier = Modifier.weight(1f)) {
                         MetricCard(MetricData(state.chapters.downloadCount.toCountString(), "Downloaded", null, Icons.Outlined.Download, iconColor))
@@ -562,7 +587,7 @@ private fun StatsGrid(state: StatsScreenState.Success, allRead: Boolean = false)
         }
 
         // Trackers Section
-        if (state.statsType != StatsType.Novels) {
+        if (state.statsType != StatsType.Novels && !isSingleTitle) {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
                     text = "Trackers",
@@ -600,22 +625,39 @@ data class MetricData(
 )
 
 @Composable
-private fun MetricCard(data: MetricData) {
+private fun MetricCard(data: MetricData, onClick: (() -> Unit)? = null) {
     Surface(
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
         shape = RoundedCornerShape(24.dp),
-        modifier = Modifier.fillMaxWidth().height(114.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(114.dp)
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it },
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            Icon(
-                imageVector = data.icon,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-                tint = data.accentColor,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = data.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = data.accentColor,
+                )
+                if (onClick != null) {
+                    Icon(
+                        imageVector = Icons.Outlined.ChevronRight,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                }
+            }
             Column {
                 Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(

--- a/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenState.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/stats/StatsScreenState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Immutable
 import eu.kanade.presentation.more.stats.data.StatsData
 import eu.kanade.presentation.more.stats.data.StatsType
 
+import chimahon.anki.AnkiProfile
+
 enum class StatsDateScale {
     Day, Week, Month, Year, AllTime
 }
@@ -21,5 +23,7 @@ sealed interface StatsScreenState {
         val dateScale: StatsDateScale,
         val dateOffset: Int,
         val statsType: StatsType,
+        val activeProfileId: String?,
+        val profiles: List<AnkiProfile>,
     ) : StatsScreenState
 }

--- a/app/src/main/java/eu/kanade/presentation/more/stats/StatsTitlesContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/stats/StatsTitlesContent.kt
@@ -1,0 +1,186 @@
+package eu.kanade.presentation.more.stats
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.presentation.manga.components.MangaCoverHide
+import eu.kanade.tachiyomi.ui.stats.StatsTitleItem
+import eu.kanade.tachiyomi.ui.stats.StatsTitlesState
+import eu.kanade.tachiyomi.util.lang.toCountString
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.asMangaCover
+import java.io.File
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun StatsTitlesContent(
+    state: StatsTitlesState.Success,
+    paddingValues: PaddingValues,
+    onTitleClick: (StatsTitleItem) -> Unit,
+) {
+    if (state.titles.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "No titles found matching this profile.",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        contentPadding = paddingValues,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        items(state.titles, key = { "${it.isNovel}_${it.id}" }) { item ->
+            StatsTitleListItem(
+                item = item,
+                onClick = { onTitleClick(item) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatsTitleListItem(
+    item: StatsTitleItem,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(96.dp)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Cover Art
+        Box(
+            modifier = Modifier
+                .width(56.dp)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(4.dp))
+        ) {
+            if (item.isNovel) {
+                val file = item.coverData as? File
+                if (file != null && file.exists()) {
+                    AsyncImage(
+                        model = file,
+                        contentDescription = item.title,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop,
+                    )
+                } else {
+                    MangaCoverHide.Book(
+                        modifier = Modifier.fillMaxSize(),
+                        size = MangaCover.Size.Medium,
+                    )
+                }
+            } else {
+                val manga = item.coverData as? Manga
+                if (manga != null) {
+                    MangaCover.Book(
+                        modifier = Modifier.fillMaxSize(),
+                        data = manga.asMangaCover(),
+                        size = MangaCover.Size.Medium,
+                    )
+                } else {
+                    MangaCoverHide.Book(
+                        modifier = Modifier.fillMaxSize(),
+                        size = MangaCover.Size.Medium,
+                    )
+                }
+            }
+        }
+
+        // Details
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 16.dp, end = 8.dp),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            item.author?.let { author ->
+                Text(
+                    text = author,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+            
+            val infoText = buildString {
+                if (item.readDurationMs > 0) {
+                    append(formatDuration(item.readDurationMs))
+                    append(" read")
+                    if (item.charactersRead > 0) {
+                        append(" • ")
+                        append(item.charactersRead.toCountString())
+                        append(" characters")
+                    }
+                } else if (item.lastReadDate != null) {
+                    append("Last read: ")
+                    append(item.lastReadDate.format(DateTimeFormatter.ofPattern("MMM d, yyyy")))
+                } else {
+                    append("Unread")
+                }
+            }
+            Text(
+                text = infoText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+private fun formatDuration(durationMs: Long): String {
+    val hours = durationMs / 3600000
+    val minutes = (durationMs % 3600000) / 60000
+    return buildString {
+        if (hours > 0) append("${hours}h ")
+        append("${minutes}m")
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/stats/MangaStatsSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/stats/MangaStatsSheet.kt
@@ -51,6 +51,8 @@ data class MangaStatsDisplay(
 data class MangaStatsEstimate(
     val remainingBookCharacters: Int = 0,
     val remainingChapterCharacters: Int = 0,
+    val remainingBookSeconds: Double = 0.0,
+    val remainingChapterSeconds: Double = 0.0,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -120,19 +122,21 @@ fun MangaStatsSheet(
                 }
             }
 
-            Section(title = "Session") {
-                val speed = sessionSpeed(sessionCharacters, sessionTimeMs)
-                StatRow("Characters Read", sessionCharacters.toString())
-                StatRow("Reading Speed", "$speed /h")
-                StatRow("Reading Time", formatDuration(sessionTimeMs / 1000))
-                StatRow(
-                    "Time to finish Book",
-                    formatDurationSeconds(secondsRemaining(estimate.remainingBookCharacters, speed)),
-                )
-                StatRow(
-                    "Time to finish Chapter",
-                    formatDurationSeconds(secondsRemaining(estimate.remainingChapterCharacters, speed)),
-                )
+            if (onToggleTracking != null) {
+                Section(title = "Session") {
+                    val speed = sessionSpeed(sessionCharacters, sessionTimeMs)
+                    StatRow("Characters Read", sessionCharacters.toString())
+                    StatRow("Reading Speed", "$speed /h")
+                    StatRow("Reading Time", formatDuration(sessionTimeMs / 1000))
+                    StatRow(
+                        "Time to finish Book",
+                        formatDurationSeconds(estimate.remainingBookSeconds),
+                    )
+                    StatRow(
+                        "Time to finish Chapter",
+                        formatDurationSeconds(estimate.remainingChapterSeconds),
+                    )
+                }
             }
 
             Section(title = "Today") {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -356,6 +356,7 @@ data object DictionaryTab : Tab {
                             forceOpen = forceOpen,
                             type = "novel",
                             syncOnCreate = ankiSyncOnCreate,
+                            profileId = activeProfile.id,
                         )
                         if (ankiResult is AnkiResult.Success || ankiResult is AnkiResult.CardExists || ankiResult is AnkiResult.OpenCard) {
                             val frame = lookupStack.getOrNull(frameIndex)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/novels/ChimaReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/novels/ChimaReaderActivity.kt
@@ -428,6 +428,7 @@ class ChimaReaderActivity : NovelReaderActivity() {
                     onTermMatched = null,
                     onContentReadyChange = ::onPopupContentReady,
                     modifier = Modifier,
+                    titleId = bookMetadata?.id,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -790,6 +790,7 @@ class ReaderActivity : BaseActivity() {
                         )
                     }
                 },
+                titleId = viewModel.state.value.manga?.id?.toString(),
             )
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -2499,18 +2499,18 @@ class ReaderViewModel @JvmOverloads constructor(
             consumedMangaStatsPages.add(prevPage.index)
             viewModelScope.launchIO {
                 val blocks = getCachedOcrBlocks(prevPage)
-                if (blocks.isNotEmpty()) {
-                    val chars = blocks.sumOf { block -> block.fullText.length }
-                    if (chars > 0) {
-                        com.canopus.chimareader.data.MangaStatsStorage.addStats(application, chars, timeSpent, manga?.id ?: 0)
-                        if (mangaStatsTracking) {
-                            mangaStatsSessionCharacters += chars
-                            mangaStatsSessionTimeMs += timeSpent
-                        }
-                        if (showMangaStats) {
-                            refreshMangaStatsEstimate()
-                        }
-                    }
+                val chars = if (blocks.isNotEmpty()) {
+                    blocks.sumOf { block -> block.fullText.length }
+                } else {
+                    0
+                }
+                com.canopus.chimareader.data.MangaStatsStorage.addStats(application, chars, timeSpent, manga?.id ?: 0)
+                if (mangaStatsTracking) {
+                    mangaStatsSessionCharacters += chars
+                    mangaStatsSessionTimeMs += timeSpent
+                }
+                if (showMangaStats) {
+                    refreshMangaStatsEstimate()
                 }
             }
         }
@@ -2571,9 +2571,26 @@ class ReaderViewModel @JvmOverloads constructor(
         val remainingBookCharacters = remainingChapterCharacters +
             (remainingFuturePages * averageCharsPerPage).toInt()
 
+        // Page-based estimation calculation
+        val remainingChapterPages = (currentPages.size - currentPageIndex).coerceAtLeast(0)
+        val remainingBookPages = remainingChapterPages + remainingFuturePages
+
+        val sessionPagesRead = consumedMangaStatsPages.size
+        val avgTimePerPageMs = if (sessionPagesRead > 0 && mangaStatsSessionTimeMs > 0) {
+            val calculatedAvg = mangaStatsSessionTimeMs.toDouble() / sessionPagesRead.toDouble()
+            calculatedAvg.coerceIn(5000.0, 120000.0) // Clamp between 5s and 120s
+        } else {
+            20000.0 // Default fallback of 20 seconds per page
+        }
+
+        val remainingChapterSeconds = (remainingChapterPages * avgTimePerPageMs) / 1000.0
+        val remainingBookSeconds = (remainingBookPages * avgTimePerPageMs) / 1000.0
+
         return MangaStatsEstimate(
             remainingBookCharacters = remainingBookCharacters,
             remainingChapterCharacters = remainingChapterCharacters,
+            remainingBookSeconds = remainingBookSeconds,
+            remainingChapterSeconds = remainingChapterSeconds,
         )
     }
 
@@ -2588,7 +2605,8 @@ class ReaderViewModel @JvmOverloads constructor(
                 .sumOf { block -> block.fullText.length }
                 .takeIf { it > 0 }
         }
-        return knownPageCharacters.takeIf { it.isNotEmpty() }?.average() ?: 0.0
+        val avg = knownPageCharacters.takeIf { it.isNotEmpty() }?.average() ?: 0.0
+        return if (avg > 0.0) avg else 100.0
     }
 
     private suspend fun estimateMangaPageCharacters(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -428,6 +428,7 @@ fun OcrLookupPopup(
                     forceOpen = forceOpen,
                     type = type,
                     syncOnCreate = ankiSyncOnCreate,
+                    profileId = activeProfile.id,
                 )
                 if (ankiResult is AnkiResult.Success || ankiResult is AnkiResult.CardExists || ankiResult is AnkiResult.OpenCard) {
                     withContext(kotlinx.coroutines.Dispatchers.Main) {
@@ -475,6 +476,7 @@ fun OcrLookupPopup(
                     forceOpen = forceOpen,
                     type = type,
                     syncOnCreate = ankiSyncOnCreate,
+                    profileId = activeProfile.id,
                 )
                 withContext(kotlinx.coroutines.Dispatchers.Main) {
                     when (ankiResult) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -112,6 +112,7 @@ fun OcrLookupPopup(
     onTermMatched: ((Int, Int) -> Unit)? = null,
     onContentReadyChange: ((Boolean) -> Unit)? = null,
     modifier: Modifier = Modifier,
+    titleId: String? = null,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -443,6 +444,7 @@ fun OcrLookupPopup(
                     type = type,
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
+                    titleId = titleId,
                 )
                 if (ankiResult is AnkiResult.Success || ankiResult is AnkiResult.CardExists || ankiResult is AnkiResult.OpenCard) {
                     withContext(kotlinx.coroutines.Dispatchers.Main) {
@@ -491,6 +493,7 @@ fun OcrLookupPopup(
                     type = type,
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
+                    titleId = titleId,
                 )
                 withContext(kotlinx.coroutines.Dispatchers.Main) {
                     when (ankiResult) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreen.kt
@@ -16,38 +16,47 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
+import eu.kanade.presentation.more.stats.data.StatsType
 import tachiyomi.presentation.core.screens.LoadingScreen
 
-class StatsScreen : Screen() {
+class StatsScreen(
+    private val titleId: String? = null,
+    private val isNovel: Boolean = false,
+    private val titleName: String? = null,
+) : Screen() {
 
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
 
-        val screenModel = rememberScreenModel { StatsScreenModel() }
+        val screenModel = rememberScreenModel {
+            StatsScreenModel(titleId = titleId, isNovel = isNovel, titleName = titleName)
+        }
         val state by screenModel.state.collectAsState()
         val allRead by screenModel.allRead.collectAsState()
 
         Scaffold(
             topBar = { scrollBehavior ->
                 AppBar(
-                    title = stringResource(MR.strings.label_stats),
+                    title = titleName ?: stringResource(MR.strings.label_stats),
                     navigateUp = navigator::pop,
                     scrollBehavior = scrollBehavior,
                     // SY -->
                     actions = {
-                        AppBarActions(
-                            persistentListOf(
-                                AppBar.OverflowAction(
-                                    title = if (allRead) {
-                                        stringResource(SYMR.strings.ignore_non_library_entries)
-                                    } else {
-                                        stringResource(SYMR.strings.include_all_read_entries)
-                                    },
-                                    onClick = screenModel::toggleReadManga,
+                        if (titleId == null) {
+                            AppBarActions(
+                                persistentListOf(
+                                    AppBar.OverflowAction(
+                                        title = if (allRead) {
+                                            stringResource(SYMR.strings.ignore_non_library_entries)
+                                        } else {
+                                            stringResource(SYMR.strings.include_all_read_entries)
+                                        },
+                                        onClick = screenModel::toggleReadManga,
+                                    ),
                                 ),
-                            ),
-                        )
+                            )
+                        }
                     },
                     // SY <--
                 )
@@ -66,6 +75,20 @@ class StatsScreen : Screen() {
                 onStatsTypeSelect = screenModel::setStatsType,
                 onProfileSelect = screenModel::setProfileFilter,
                 allRead = allRead,
+                isSingleTitle = titleId != null,
+                titleName = titleName,
+                onLibraryCardClick = if (titleId == null) {
+                    {
+                        val successState = state as? StatsScreenState.Success ?: return@StatsScreenContent
+                        navigator.push(
+                            StatsTitlesScreen(
+                                activeProfileId = successState.activeProfileId,
+                                allRead = allRead,
+                                statsType = successState.statsType
+                            )
+                        )
+                    }
+                } else null,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreen.kt
@@ -64,6 +64,7 @@ class StatsScreen : Screen() {
                 onDateScaleSelect = screenModel::setDateScale,
                 onDateOffsetChange = screenModel::setDateOffset,
                 onStatsTypeSelect = screenModel::setStatsType,
+                onProfileSelect = screenModel::setProfileFilter,
                 allRead = allRead,
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -7,6 +7,7 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.canopus.chimareader.data.BookStorage
 import com.canopus.chimareader.data.Statistics
+import chimahon.anki.AnkiProfile
 import eu.kanade.core.util.fastCountNot
 import eu.kanade.presentation.more.stats.StatsDateScale
 import eu.kanade.presentation.more.stats.StatsScreenState
@@ -15,6 +16,8 @@ import eu.kanade.presentation.more.stats.data.StatsType
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
+import tachiyomi.domain.source.service.SourceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -58,6 +61,8 @@ class StatsScreenModel(
     private val trackerManager: TrackerManager = Injekt.get(),
     private val getReadMangaNotInLibraryView: GetReadMangaNotInLibraryView = Injekt.get(),
     private val context: Application = Injekt.get(),
+    private val dictionaryPreferences: DictionaryPreferences = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
 ) : StateScreenModel<StatsScreenState>(StatsScreenState.Loading) {
 
     private val loggedInTrackers by lazy { trackerManager.loggedInTrackers() }
@@ -74,8 +79,45 @@ class StatsScreenModel(
     private val _statsType = MutableStateFlow(StatsType.All)
     val statsType = _statsType.asStateFlow()
 
+    private val _activeProfileId = MutableStateFlow<String?>(null)
+    val activeProfileId = _activeProfileId.asStateFlow()
+
+    private val _profiles = MutableStateFlow<List<AnkiProfile>>(emptyList())
+    val profiles = _profiles.asStateFlow()
+
+    fun setProfileFilter(profileId: String?) {
+        _activeProfileId.value = profileId
+    }
+
+    private data class CombinedFilters(
+        val allRead: Boolean,
+        val dateScale: StatsDateScale,
+        val dateOffset: Int,
+        val statsType: StatsType,
+        val activeProfileId: String?,
+    )
+
     init {
-        combine(_allRead, _dateScale, _dateOffset, _statsType) { allRead, dateScale, dateOffset, statsType ->
+        val combinedFlow = combine(
+            _allRead,
+            _dateScale,
+            _dateOffset,
+            _statsType,
+            _activeProfileId
+        ) { allRead, dateScale, dateOffset, statsType, activeProfileId ->
+            CombinedFilters(allRead, dateScale, dateOffset, statsType, activeProfileId)
+        }
+
+        combine(
+            combinedFlow,
+            dictionaryPreferences.rawProfiles().changes()
+        ) { tuple, rawProfilesJson ->
+            val allRead = tuple.allRead
+            val dateScale = tuple.dateScale
+            val dateOffset = tuple.dateOffset
+            val statsType = tuple.statsType
+            val activeProfileId = tuple.activeProfileId
+
             val libraryManga = getLibraryManga.await() + if (allRead) {
                 getReadMangaNotInLibraryView.await()
             } else {
@@ -90,29 +132,66 @@ class StatsScreenModel(
                 StatsType.Novels -> emptyList()
             }
 
+            val profilesList = dictionaryPreferences.profileStore.getProfiles()
+            _profiles.value = profilesList
+
+            // Build dynamic resolver map for manga
+            val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
+            val uniqueMangaIds = allMangaStats.map { it.mangaId }.distinct()
+            val resolver = dictionaryPreferences.profileResolver
+            val mangaProfileMap = uniqueMangaIds.associateWith { mangaId ->
+                if (mangaId == 0L) {
+                    ""
+                } else {
+                    val dbManga = distinctLibraryManga.find { it.id == mangaId }?.manga
+                    val source = dbManga?.source?.let { sourceManager.getOrStub(it) }
+                    resolver.resolve(
+                        mangaId = mangaId,
+                        sourceId = dbManga?.source ?: 0L,
+                        sourceLang = source?.lang ?: "",
+                    ).id
+                }
+            }
+
+            // Filter manga stats by profile
+            val profileFilteredMangaStats = if (activeProfileId != null) {
+                allMangaStats.filter { mangaProfileMap[it.mangaId] == activeProfileId }
+            } else {
+                allMangaStats
+            }
+
+            val libraryMangaIds = distinctLibraryManga.map { it.id }.toSet()
+            val libraryFilteredMangaStats = if (allRead) profileFilteredMangaStats else profileFilteredMangaStats.filter { it.mangaId in libraryMangaIds || it.mangaId == 0L }
+            val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
+
+            // Load and filter novels
             val allNovels = if (statsType == StatsType.All || statsType == StatsType.Novels) {
                 BookStorage.loadAllBooks(context)
             } else {
                 emptyList()
             }
             
+            // Build dynamic resolver map for novels
+            val novelProfileMap = allNovels.associate { novel ->
+                novel.id to resolver.resolve(novelId = novel.id).id
+            }
+
             val novelStats = allNovels.associate { novel ->
                 val bookDir = BookStorage.getBookDirectory(context, novel.id)
                 novel.id to (BookStorage.loadStatistics(bookDir) ?: emptyList())
             }
+
+            // Filter novel stats by profile
+            val profileFilteredNovelStatsMap = if (activeProfileId != null) {
+                novelStats.filter { (novelId, _) -> novelProfileMap[novelId] == activeProfileId }
+            } else {
+                novelStats
+            }
             
-            val allNovelStatsList = novelStats.values.flatten()
+            val allNovelStatsList = profileFilteredNovelStatsMap.values.flatten()
             val filteredNovelStats = filterNovelStatsByScale(allNovelStatsList, dateScale, dateOffset)
 
-            val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
-            val libraryMangaIds = distinctLibraryManga.map { it.id }.toSet()
-            val libraryFilteredMangaStats = if (allRead) allMangaStats else allMangaStats.filter { it.mangaId in libraryMangaIds || it.mangaId == 0L }
-            val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
-
-            val mangaChars = filteredMangaStats.sumOf { it.charactersRead }
-            val mangaTimeMs = filteredMangaStats.sumOf { it.readingTime }
-            
-            val mangaReadDuration = mangaTimeMs
+            val mangaReadDuration = filteredMangaStats.sumOf { it.readingTime }
             val novelReadDurationSeconds = filteredNovelStats.sumOf { it.readingTime }
             val novelReadDurationMs = (novelReadDurationSeconds * 1000).toLong()
             
@@ -122,6 +201,9 @@ class StatsScreenModel(
                 StatsType.Novels -> novelReadDurationMs
             }
 
+            val mangaChars = filteredMangaStats.sumOf { it.charactersRead }
+            val mangaTimeMs = filteredMangaStats.sumOf { it.readingTime }
+            
             val novelChars = filteredNovelStats.sumOf { it.charactersRead }
             val novelTimeMs = novelReadDurationMs
 
@@ -185,11 +267,13 @@ class StatsScreenModel(
             var novelReadChapters = 0
             if (statsType == StatsType.All || statsType == StatsType.Novels) {
                 allNovels.forEach { novel ->
-                    val bookDir = BookStorage.getBookDirectory(context, novel.id)
-                    val info = BookStorage.loadBookInfo(bookDir)
-                    val bookmark = BookStorage.loadBookmark(bookDir)
-                    novelTotalChapters += info?.chapterInfo?.size ?: 0
-                    novelReadChapters += bookmark?.chapterIndex ?: 0
+                    if (activeProfileId == null || novelProfileMap[novel.id] == activeProfileId) {
+                        val bookDir = BookStorage.getBookDirectory(context, novel.id)
+                        val info = BookStorage.loadBookInfo(bookDir)
+                        val bookmark = BookStorage.loadBookmark(bookDir)
+                        novelTotalChapters += info?.chapterInfo?.size ?: 0
+                        novelReadChapters += bookmark?.chapterIndex ?: 0
+                    }
                 }
             }
 
@@ -229,6 +313,8 @@ class StatsScreenModel(
                     dateScale = dateScale,
                     dateOffset = dateOffset,
                     statsType = statsType,
+                    activeProfileId = activeProfileId,
+                    profiles = profilesList,
                 )
             }
         }.onEach { }.launchIn(screenModelScope)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -67,7 +67,7 @@ class StatsScreenModel(
 
     private val loggedInTrackers by lazy { trackerManager.loggedInTrackers() }
 
-    private val _allRead = MutableStateFlow(false)
+    private val _allRead = MutableStateFlow(true)
     val allRead = _allRead.asStateFlow()
 
     private val _dateScale = MutableStateFlow(StatsDateScale.Day)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -126,19 +126,38 @@ class StatsScreenModel(
 
             val distinctLibraryManga = libraryManga.fastDistinctBy { it.id }
             
-            val filteredLibraryManga = when (statsType) {
-                StatsType.All -> distinctLibraryManga
-                StatsType.Manga -> distinctLibraryManga
-                StatsType.Novels -> emptyList()
-            }
-
             val profilesList = dictionaryPreferences.profileStore.getProfiles()
             _profiles.value = profilesList
+
+            val resolver = dictionaryPreferences.profileResolver
+
+            // Build full resolver map for all distinct library manga
+            val libraryMangaProfileMap = distinctLibraryManga.associate { lm ->
+                val dbManga = lm.manga
+                val source = dbManga.source.let { sourceManager.getOrStub(it) }
+                lm.id to resolver.resolve(
+                    mangaId = lm.id,
+                    sourceId = dbManga.source,
+                    sourceLang = source.lang,
+                ).id
+            }
+
+            // Filter library manga by active profile
+            val profileFilteredLibraryManga = if (activeProfileId != null) {
+                distinctLibraryManga.filter { libraryMangaProfileMap[it.id] == activeProfileId }
+            } else {
+                distinctLibraryManga
+            }
+            
+            val filteredLibraryManga = when (statsType) {
+                StatsType.All -> profileFilteredLibraryManga
+                StatsType.Manga -> profileFilteredLibraryManga
+                StatsType.Novels -> emptyList()
+            }
 
             // Build dynamic resolver map for manga
             val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
             val uniqueMangaIds = allMangaStats.map { it.mangaId }.distinct()
-            val resolver = dictionaryPreferences.profileResolver
             val mangaProfileMap = uniqueMangaIds.associateWith { mangaId ->
                 if (mangaId == 0L) {
                     ""
@@ -160,7 +179,7 @@ class StatsScreenModel(
                 allMangaStats
             }
 
-            val libraryMangaIds = distinctLibraryManga.map { it.id }.toSet()
+            val libraryMangaIds = profileFilteredLibraryManga.map { it.id }.toSet()
             val libraryFilteredMangaStats = if (allRead) profileFilteredMangaStats else profileFilteredMangaStats.filter { it.mangaId in libraryMangaIds || it.mangaId == 0L }
             val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
 
@@ -176,17 +195,19 @@ class StatsScreenModel(
                 novel.id to resolver.resolve(novelId = novel.id).id
             }
 
-            val novelStats = allNovels.associate { novel ->
+            val profileFilteredNovels = if (activeProfileId != null) {
+                allNovels.filter { novelProfileMap[it.id] == activeProfileId }
+            } else {
+                allNovels
+            }
+
+            val novelStats = profileFilteredNovels.associate { novel ->
                 val bookDir = BookStorage.getBookDirectory(context, novel.id)
                 novel.id to (BookStorage.loadStatistics(bookDir) ?: emptyList())
             }
 
-            // Filter novel stats by profile
-            val profileFilteredNovelStatsMap = if (activeProfileId != null) {
-                novelStats.filter { (novelId, _) -> novelProfileMap[novelId] == activeProfileId }
-            } else {
-                novelStats
-            }
+            // Filter novel stats by profile (keys are already filtered)
+            val profileFilteredNovelStatsMap = novelStats
             
             val allNovelStatsList = profileFilteredNovelStatsMap.values.flatten()
             val filteredNovelStats = filterNovelStatsByScale(allNovelStatsList, dateScale, dateOffset)
@@ -235,15 +256,23 @@ class StatsScreenModel(
 
             val ankiStats = com.canopus.chimareader.data.AnkiStatsStorage.loadAll(context)
             val filteredAnkiStats = filterAnkiStatsByScale(ankiStats, dateScale, dateOffset)
+            val firstProfileId = profilesList.firstOrNull()?.id
+            val profileFilteredAnkiStats = if (activeProfileId != null) {
+                filteredAnkiStats.filter {
+                    it.profileId == activeProfileId || (it.profileId.isEmpty() && activeProfileId == firstProfileId)
+                }
+            } else {
+                filteredAnkiStats
+            }
             val totalAnkiCards = when (statsType) {
-                StatsType.All -> filteredAnkiStats.sumOf { it.mangaCards + it.novelCards }
-                StatsType.Manga -> filteredAnkiStats.sumOf { it.mangaCards }
-                StatsType.Novels -> filteredAnkiStats.sumOf { it.novelCards }
+                StatsType.All -> profileFilteredAnkiStats.sumOf { it.mangaCards + it.novelCards }
+                StatsType.Manga -> profileFilteredAnkiStats.sumOf { it.mangaCards }
+                StatsType.Novels -> profileFilteredAnkiStats.sumOf { it.novelCards }
             }
 
             val overviewStatData = StatsData.Overview(
-                libraryMangaCount = if (statsType == StatsType.Novels) allNovels.size else filteredLibraryManga.size,
-                completedMangaCount = calculateCompletedCount(filteredLibraryManga, allNovels, statsType),
+                libraryMangaCount = if (statsType == StatsType.Novels) profileFilteredNovels.size else filteredLibraryManga.size,
+                completedMangaCount = calculateCompletedCount(filteredLibraryManga, profileFilteredNovels, statsType),
                 totalReadDuration = totalReadDuration,
                 readingStreak = streak,
                 historyPoints = historyPoints,
@@ -256,9 +285,9 @@ class StatsScreenModel(
             val titlesStatData = StatsData.Titles(
                 startedMangaCount = calculateStartedCount(filteredLibraryManga, allNovelStatsList, statsType),
                 localMangaCount = when (statsType) {
-                    StatsType.All -> filteredLibraryManga.count { it.manga.isLocal() } + allNovels.size
+                    StatsType.All -> filteredLibraryManga.count { it.manga.isLocal() } + profileFilteredNovels.size
                     StatsType.Manga -> filteredLibraryManga.count { it.manga.isLocal() }
-                    StatsType.Novels -> allNovels.size
+                    StatsType.Novels -> profileFilteredNovels.size
                 },
             )
 
@@ -266,14 +295,12 @@ class StatsScreenModel(
             var novelTotalChapters = 0
             var novelReadChapters = 0
             if (statsType == StatsType.All || statsType == StatsType.Novels) {
-                allNovels.forEach { novel ->
-                    if (activeProfileId == null || novelProfileMap[novel.id] == activeProfileId) {
-                        val bookDir = BookStorage.getBookDirectory(context, novel.id)
-                        val info = BookStorage.loadBookInfo(bookDir)
-                        val bookmark = BookStorage.loadBookmark(bookDir)
-                        novelTotalChapters += info?.chapterInfo?.size ?: 0
-                        novelReadChapters += bookmark?.chapterIndex ?: 0
-                    }
+                profileFilteredNovels.forEach { novel ->
+                    val bookDir = BookStorage.getBookDirectory(context, novel.id)
+                    val info = BookStorage.loadBookInfo(bookDir)
+                    val bookmark = BookStorage.loadBookmark(bookDir)
+                    novelTotalChapters += info?.chapterInfo?.size ?: 0
+                    novelReadChapters += bookmark?.chapterIndex ?: 0
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -31,9 +31,6 @@ import tachiyomi.domain.history.model.ReadingSession
 import tachiyomi.domain.history.repository.HistoryRepository
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.library.service.LibraryPreferences
-import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_HAS_UNREAD
-import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_COMPLETED
-import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_READ
 import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetReadMangaNotInLibraryView
 import tachiyomi.domain.track.interactor.GetTracks
@@ -51,6 +48,9 @@ import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 class StatsScreenModel(
+    val titleId: String? = null,
+    val isNovel: Boolean = false,
+    val titleName: String? = null,
     private val downloadManager: DownloadManager = Injekt.get(),
     private val getLibraryManga: GetLibraryManga = Injekt.get(),
     private val getTotalReadDuration: GetTotalReadDuration = Injekt.get(),
@@ -118,10 +118,20 @@ class StatsScreenModel(
             val statsType = tuple.statsType
             val activeProfileId = tuple.activeProfileId
 
-            val libraryManga = getLibraryManga.await() + if (allRead) {
-                getReadMangaNotInLibraryView.await()
+            val libraryManga = if (titleId != null) {
+                if (!isNovel) {
+                    val lm = getLibraryManga.await().find { it.id.toString() == titleId }
+                        ?: getReadMangaNotInLibraryView.await().find { it.id.toString() == titleId }
+                    if (lm != null) listOf(lm) else emptyList()
+                } else {
+                    emptyList()
+                }
             } else {
-                emptyList()
+                getLibraryManga.await() + if (allRead) {
+                    getReadMangaNotInLibraryView.await()
+                } else {
+                    emptyList()
+                }
             }
 
             val distinctLibraryManga = libraryManga.fastDistinctBy { it.id }
@@ -156,7 +166,15 @@ class StatsScreenModel(
             }
 
             // Build dynamic resolver map for manga
-            val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
+            val allMangaStats = if (titleId != null) {
+                if (!isNovel) {
+                    com.canopus.chimareader.data.MangaStatsStorage.loadAll(context).filter { it.mangaId.toString() == titleId }
+                } else {
+                    emptyList()
+                }
+            } else {
+                com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
+            }
             val uniqueMangaIds = allMangaStats.map { it.mangaId }.distinct()
             val mangaProfileMap = uniqueMangaIds.associateWith { mangaId ->
                 if (mangaId == 0L) {
@@ -184,7 +202,13 @@ class StatsScreenModel(
             val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
 
             // Load and filter novels
-            val allNovels = if (statsType == StatsType.All || statsType == StatsType.Novels) {
+            val allNovels = if (titleId != null) {
+                if (isNovel) {
+                    BookStorage.loadAllBooks(context).filter { it.id == titleId }
+                } else {
+                    emptyList()
+                }
+            } else if (statsType == StatsType.All || statsType == StatsType.Novels) {
                 BookStorage.loadAllBooks(context)
             } else {
                 emptyList()
@@ -216,7 +240,13 @@ class StatsScreenModel(
             val novelReadDurationSeconds = filteredNovelStats.sumOf { it.readingTime }
             val novelReadDurationMs = (novelReadDurationSeconds * 1000).toLong()
             
-            val totalReadDuration = when (statsType) {
+            val currentStatsType = if (titleId != null) {
+                if (isNovel) StatsType.Novels else StatsType.Manga
+            } else {
+                statsType
+            }
+
+            val totalReadDuration = when (currentStatsType) {
                 StatsType.All -> mangaReadDuration + novelReadDurationMs
                 StatsType.Manga -> mangaReadDuration
                 StatsType.Novels -> novelReadDurationMs
@@ -228,13 +258,13 @@ class StatsScreenModel(
             val novelChars = filteredNovelStats.sumOf { it.charactersRead }
             val novelTimeMs = novelReadDurationMs
 
-            val totalChars = when (statsType) {
+            val totalChars = when (currentStatsType) {
                 StatsType.All -> mangaChars + novelChars
                 StatsType.Manga -> mangaChars
                 StatsType.Novels -> novelChars
             }
 
-            val totalTimeMs = when (statsType) {
+            val totalTimeMs = when (currentStatsType) {
                 StatsType.All -> mangaTimeMs + novelTimeMs
                 StatsType.Manga -> mangaTimeMs
                 StatsType.Novels -> novelTimeMs
@@ -255,7 +285,12 @@ class StatsScreenModel(
             } else null
 
             val ankiStats = com.canopus.chimareader.data.AnkiStatsStorage.loadAll(context)
-            val filteredAnkiStats = filterAnkiStatsByScale(ankiStats, dateScale, dateOffset)
+            val titleFilteredAnkiStats = if (titleId != null) {
+                ankiStats.filter { it.titleId == titleId }
+            } else {
+                ankiStats
+            }
+            val filteredAnkiStats = filterAnkiStatsByScale(titleFilteredAnkiStats, dateScale, dateOffset)
             val firstProfileId = profilesList.firstOrNull()?.id
             val profileFilteredAnkiStats = if (activeProfileId != null) {
                 filteredAnkiStats.filter {
@@ -264,15 +299,19 @@ class StatsScreenModel(
             } else {
                 filteredAnkiStats
             }
-            val totalAnkiCards = when (statsType) {
+            val totalAnkiCards = when (currentStatsType) {
                 StatsType.All -> profileFilteredAnkiStats.sumOf { it.mangaCards + it.novelCards }
                 StatsType.Manga -> profileFilteredAnkiStats.sumOf { it.mangaCards }
                 StatsType.Novels -> profileFilteredAnkiStats.sumOf { it.novelCards }
             }
 
             val overviewStatData = StatsData.Overview(
-                libraryMangaCount = if (statsType == StatsType.Novels) profileFilteredNovels.size else filteredLibraryManga.size,
-                completedMangaCount = calculateCompletedCount(filteredLibraryManga, profileFilteredNovels, statsType),
+                libraryMangaCount = when (currentStatsType) {
+                    StatsType.All -> filteredLibraryManga.size + profileFilteredNovels.size
+                    StatsType.Manga -> filteredLibraryManga.size
+                    StatsType.Novels -> profileFilteredNovels.size
+                },
+                completedMangaCount = calculateCompletedCount(filteredLibraryManga, profileFilteredNovels, currentStatsType),
                 totalReadDuration = totalReadDuration,
                 readingStreak = streak,
                 historyPoints = historyPoints,
@@ -283,8 +322,8 @@ class StatsScreenModel(
             )
 
             val titlesStatData = StatsData.Titles(
-                startedMangaCount = calculateStartedCount(filteredLibraryManga, allNovelStatsList, statsType),
-                localMangaCount = when (statsType) {
+                startedMangaCount = calculateStartedCount(filteredLibraryManga, allNovelStatsList, currentStatsType),
+                localMangaCount = when (currentStatsType) {
                     StatsType.All -> filteredLibraryManga.count { it.manga.isLocal() } + profileFilteredNovels.size
                     StatsType.Manga -> filteredLibraryManga.count { it.manga.isLocal() }
                     StatsType.Novels -> profileFilteredNovels.size
@@ -294,42 +333,48 @@ class StatsScreenModel(
             // Chapter calculations for novels
             var novelTotalChapters = 0
             var novelReadChapters = 0
-            if (statsType == StatsType.All || statsType == StatsType.Novels) {
+            if (currentStatsType == StatsType.All || currentStatsType == StatsType.Novels) {
                 profileFilteredNovels.forEach { novel ->
                     val bookDir = BookStorage.getBookDirectory(context, novel.id)
-                    val info = BookStorage.loadBookInfo(bookDir)
                     val bookmark = BookStorage.loadBookmark(bookDir)
-                    novelTotalChapters += info?.chapterInfo?.size ?: 0
-                    novelReadChapters += bookmark?.chapterIndex ?: 0
+                    val chapterStarts = novel.chapterStarts
+                    if (chapterStarts != null && chapterStarts.size > 1) {
+                        val exploredChars = bookmark?.characterCount ?: 0
+                        novelTotalChapters += chapterStarts.size - 1
+                        novelReadChapters += chapterStarts.drop(1).count { it <= exploredChars }
+                    } else {
+                        val info = BookStorage.loadBookInfo(bookDir)
+                        novelTotalChapters += info?.chapterInfo?.size ?: 0
+                        novelReadChapters += bookmark?.chapterIndex ?: 0
+                    }
                 }
             }
 
             val chapterStatData = StatsData.Chapters(
-                totalChapterCount = when (statsType) {
+                totalChapterCount = when (currentStatsType) {
                     StatsType.All -> filteredLibraryManga.sumOf { it.totalChapters }.toInt() + novelTotalChapters
                     StatsType.Manga -> filteredLibraryManga.sumOf { it.totalChapters }.toInt()
                     StatsType.Novels -> novelTotalChapters
                 },
-                readChapterCount = when (statsType) {
+                readChapterCount = when (currentStatsType) {
                     StatsType.All -> filteredLibraryManga.sumOf { it.readCount }.toInt() + novelReadChapters
                     StatsType.Manga -> filteredLibraryManga.sumOf { it.readCount }.toInt()
                     StatsType.Novels -> novelReadChapters
                 },
-                downloadCount = when (statsType) {
+                downloadCount = when (currentStatsType) {
                     StatsType.All -> filteredLibraryManga.sumOf { downloadManager.getDownloadCount(it.manga) }
                     StatsType.Manga -> filteredLibraryManga.sumOf { downloadManager.getDownloadCount(it.manga) }
-                    StatsType.Novels -> 0 // Hide/Ignore for novels as requested
+                    StatsType.Novels -> 0
                 },
             )
 
-            val trackers = getMangaTrackMap(filteredLibraryManga)
+            val trackers = if (titleId != null) emptyMap() else getMangaTrackMap(filteredLibraryManga)
             val scoredTrackers = getScoredMangaTrackMap(trackers)
             val trackerStatData = StatsData.Trackers(
                 trackedTitleCount = trackers.size,
                 meanScore = getTrackMeanScore(scoredTrackers),
-                trackerCount = loggedInTrackers.size,
+                trackerCount = if (titleId != null) 0 else loggedInTrackers.size,
             )
-
 
             mutableState.update {
                 StatsScreenState.Success(
@@ -339,9 +384,9 @@ class StatsScreenModel(
                     trackers = trackerStatData,
                     dateScale = dateScale,
                     dateOffset = dateOffset,
-                    statsType = statsType,
-                    activeProfileId = activeProfileId,
-                    profiles = profilesList,
+                    statsType = currentStatsType,
+                    activeProfileId = if (titleId != null) null else activeProfileId,
+                    profiles = if (titleId != null) emptyList() else profilesList,
                 )
             }
         }.onEach { }.launchIn(screenModelScope)
@@ -528,7 +573,6 @@ class StatsScreenModel(
 
         return when (scale) {
             StatsDateScale.Day -> {
-                // Snap to the week containing the selected day (Mon-Sun)
                 val weekStart = start.with(DayOfWeek.MONDAY)
                 (0..6).map { daysIntoWeek ->
                     val date = weekStart.plusDays(daysIntoWeek.toLong())
@@ -539,12 +583,8 @@ class StatsScreenModel(
                 }
             }
             StatsDateScale.Week -> {
-                // Snap to the month containing the selected week (using Thursday to determine the month)
                 val monthStart = start.plusDays(3).withDayOfMonth(1)
                 val monthEnd = monthStart.plusMonths(1).minusDays(1)
-                
-                // Calculate weeks from the Monday of the first week of the month 
-                // to the Monday of the week containing the end of the month
                 val firstMonday = monthStart.with(DayOfWeek.MONDAY)
                 val lastMonday = monthEnd.with(DayOfWeek.MONDAY)
                 val weeksInMonth = (ChronoUnit.WEEKS.between(firstMonday, lastMonday).toInt() + 1).coerceAtLeast(4)
@@ -562,7 +602,6 @@ class StatsScreenModel(
                 }
             }
             StatsDateScale.Month -> {
-                // Snap to the year containing the selected month
                 val yearStart = start.withDayOfYear(1)
                 (0..11).map { monthsIntoYear ->
                     val mDate = yearStart.plusMonths(monthsIntoYear.toLong())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -90,14 +90,6 @@ class StatsScreenModel(
                 StatsType.Novels -> emptyList()
             }
 
-            val allMangaHistory = getAllHistory.await()
-            val allSessions = if (allRead) {
-                historyRepository.getAllSessions()
-            } else {
-                historyRepository.getLibrarySessions()
-            }
-            val filteredSessions = filterSessionsByScale(allSessions, dateScale, dateOffset)
-            
             val allNovels = if (statsType == StatsType.All || statsType == StatsType.Novels) {
                 BookStorage.loadAllBooks(context)
             } else {
@@ -112,7 +104,15 @@ class StatsScreenModel(
             val allNovelStatsList = novelStats.values.flatten()
             val filteredNovelStats = filterNovelStatsByScale(allNovelStatsList, dateScale, dateOffset)
 
-            val mangaReadDuration = filteredSessions.sumOf { it.duration }
+            val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
+            val libraryMangaIds = distinctLibraryManga.map { it.id }.toSet()
+            val libraryFilteredMangaStats = if (allRead) allMangaStats else allMangaStats.filter { it.mangaId in libraryMangaIds || it.mangaId == 0L }
+            val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
+
+            val mangaChars = filteredMangaStats.sumOf { it.charactersRead }
+            val mangaTimeMs = filteredMangaStats.sumOf { it.readingTime }
+            
+            val mangaReadDuration = mangaTimeMs
             val novelReadDurationSeconds = filteredNovelStats.sumOf { it.readingTime }
             val novelReadDurationMs = (novelReadDurationSeconds * 1000).toLong()
             
@@ -122,14 +122,6 @@ class StatsScreenModel(
                 StatsType.Novels -> novelReadDurationMs
             }
 
-            val allMangaStats = com.canopus.chimareader.data.MangaStatsStorage.loadAll(context)
-            val libraryMangaIds = distinctLibraryManga.map { it.id }.toSet()
-            val libraryFilteredMangaStats = if (allRead) allMangaStats else allMangaStats.filter { it.mangaId in libraryMangaIds || it.mangaId == 0L }
-            val filteredMangaStats = filterMangaStatsByScale(libraryFilteredMangaStats, dateScale, dateOffset)
-
-            val mangaChars = filteredMangaStats.sumOf { it.charactersRead }
-            val mangaTimeMs = filteredMangaStats.sumOf { it.readingTime }
-            
             val novelChars = filteredNovelStats.sumOf { it.charactersRead }
             val novelTimeMs = novelReadDurationMs
 
@@ -149,8 +141,8 @@ class StatsScreenModel(
                 (totalChars.toDouble() / (totalTimeMs / 3600000.0)).toInt()
             } else null
 
-            val streak = calculateStreak(allMangaHistory, allNovelStatsList)
-            val historyPoints = calculateHistoryPoints(allSessions, allNovelStatsList, dateScale, dateOffset)
+            val streak = calculateStreak(libraryFilteredMangaStats, allNovelStatsList)
+            val historyPoints = calculateHistoryPoints(libraryFilteredMangaStats, allNovelStatsList, dateScale, dateOffset)
             
             // Calculate avg per day
             val avgDurationPerDay = if (dateScale != StatsDateScale.Day && dateScale != StatsDateScale.AllTime) {
@@ -308,8 +300,10 @@ class StatsScreenModel(
         return stats.filter { it.dateKey in startStr..endStr }
     }
 
-    private fun calculateStreak(mangaHistory: List<History>, novelStats: List<Statistics>): Int {
-        val mangaDays = mangaHistory.mapNotNull { it.readAt?.toInstant()?.atZone(ZoneId.systemDefault())?.toLocalDate() }.toSet()
+    private fun calculateStreak(mangaStats: List<com.canopus.chimareader.data.MangaStats>, novelStats: List<Statistics>): Int {
+        val mangaDays = mangaStats.mapNotNull { 
+            try { LocalDate.parse(it.dateKey) } catch (e: Exception) { null }
+        }.toSet()
         val novelDays = novelStats.mapNotNull { 
             try { LocalDate.parse(it.dateKey) } catch (e: Exception) { null }
         }.toSet()
@@ -411,7 +405,7 @@ class StatsScreenModel(
     }
 
     private fun calculateHistoryPoints(
-        mangaSessions: List<ReadingSession>,
+        mangaStats: List<com.canopus.chimareader.data.MangaStats>,
         novelStats: List<Statistics>,
         scale: StatsDateScale,
         offset: Int,
@@ -426,7 +420,7 @@ class StatsScreenModel(
                 (0..6).map { daysIntoWeek ->
                     val date = weekStart.plusDays(daysIntoWeek.toLong())
                     val label = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())
-                    val value = aggregateForDate(date, mangaSessions, novelStats)
+                    val value = aggregateForDate(date, mangaStats, novelStats)
                     val pOffset = ChronoUnit.DAYS.between(now, date).toInt()
                     StatsData.HistoryPoint(label, value, pOffset)
                 }
@@ -446,7 +440,7 @@ class StatsScreenModel(
                     val wStart = firstMonday.plusWeeks(weeksIntoMonth.toLong())
                     val wEnd = wStart.plusDays(6)
                     val label = "W${wStart.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR)}"
-                    val value = aggregateForRange(wStart, wEnd, mangaSessions, novelStats)
+                    val value = aggregateForRange(wStart, wEnd, mangaStats, novelStats)
                     val pOffset = ChronoUnit.WEEKS.between(
                         now.with(DayOfWeek.MONDAY),
                         wStart
@@ -460,7 +454,7 @@ class StatsScreenModel(
                 (0..11).map { monthsIntoYear ->
                     val mDate = yearStart.plusMonths(monthsIntoYear.toLong())
                     val label = mDate.month.getDisplayName(TextStyle.SHORT, Locale.getDefault())
-                    val value = aggregateForMonth(mDate, mangaSessions, novelStats)
+                    val value = aggregateForMonth(mDate, mangaStats, novelStats)
                     val pOffset = ChronoUnit.MONTHS.between(
                         now.withDayOfMonth(1),
                         mDate.withDayOfMonth(1)
@@ -474,7 +468,7 @@ class StatsScreenModel(
                     val label = yDate.year.toString()
                     val yStart = yDate.withDayOfYear(1)
                     val yEnd = yDate.withDayOfYear(yDate.lengthOfYear())
-                    val value = aggregateForRange(yStart, yEnd, mangaSessions, novelStats)
+                    val value = aggregateForRange(yStart, yEnd, mangaStats, novelStats)
                     val pOffset = -yearsAgo
                     StatsData.HistoryPoint(label, value, pOffset)
                 }
@@ -484,17 +478,14 @@ class StatsScreenModel(
 
     private fun aggregateForDate(
         date: LocalDate,
-        mangaSessions: List<ReadingSession>,
+        mangaStats: List<com.canopus.chimareader.data.MangaStats>,
         novelStats: List<Statistics>,
     ): Long {
-        val startMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        val endMillis = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-
-        val mangaValue = mangaSessions
-            .filter { it.readAt.time in startMillis until endMillis }
-            .sumOf { it.duration }
-
         val dateKey = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val mangaValue = mangaStats
+            .filter { it.dateKey == dateKey }
+            .sumOf { it.readingTime }
+
         val novelValue = novelStats
             .filter { it.dateKey == dateKey }
             .sumOf { (it.readingTime * 1000).toLong() }
@@ -505,18 +496,16 @@ class StatsScreenModel(
     private fun aggregateForRange(
         start: LocalDate,
         end: LocalDate,
-        mangaSessions: List<ReadingSession>,
+        mangaStats: List<com.canopus.chimareader.data.MangaStats>,
         novelStats: List<Statistics>,
     ): Long {
-        val startMillis = start.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        val endMillis = end.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-
-        val mangaValue = mangaSessions
-            .filter { it.readAt.time in startMillis until endMillis }
-            .sumOf { it.duration }
-
         val startStr = start.toString()
         val endStr = end.toString()
+        
+        val mangaValue = mangaStats
+            .filter { it.dateKey in startStr..endStr }
+            .sumOf { it.readingTime }
+
         val novelValue = novelStats
             .filter { it.dateKey in startStr..endStr }
             .sumOf { (it.readingTime * 1000).toLong() }
@@ -526,13 +515,21 @@ class StatsScreenModel(
 
     private fun aggregateForMonth(
         monthDate: LocalDate,
-        mangaSessions: List<ReadingSession>,
+        mangaStats: List<com.canopus.chimareader.data.MangaStats>,
         novelStats: List<Statistics>,
     ): Long {
         val yearMonth = YearMonth.from(monthDate)
-        val mangaValue = mangaSessions
-            .filter { YearMonth.from(it.readAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()) == yearMonth }
-            .sumOf { it.duration }
+        
+        val mangaValue = mangaStats
+            .filter { s ->
+                try {
+                    val entryDate = LocalDate.parse(s.dateKey)
+                    YearMonth.from(entryDate) == yearMonth
+                } catch (e: Exception) {
+                    false
+                }
+            }
+            .sumOf { it.readingTime }
 
         val novelValue = novelStats
             .filter { s ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsTitlesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsTitlesScreen.kt
@@ -1,0 +1,344 @@
+package eu.kanade.tachiyomi.ui.stats
+
+import android.app.Application
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.canopus.chimareader.data.BookStorage
+import com.canopus.chimareader.data.MangaStatsStorage
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.more.stats.StatsTitlesContent
+import eu.kanade.presentation.more.stats.data.StatsType
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.interactor.GetReadMangaNotInLibraryView
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.LoadingScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+import java.time.LocalDate
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Sort
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import eu.kanade.presentation.components.AppBarTitle
+import eu.kanade.presentation.components.SearchToolbar
+
+enum class StatsTitlesSort {
+    Alphabetical,
+    LastRead,
+    DateAdded
+}
+
+sealed interface StatsTitlesState {
+    data object Loading : StatsTitlesState
+    data class Success(
+        val titles: List<StatsTitleItem>,
+        val searchQuery: String? = null,
+        val sortOption: StatsTitlesSort = StatsTitlesSort.LastRead,
+    ) : StatsTitlesState
+}
+
+data class StatsTitleItem(
+    val id: String,
+    val title: String,
+    val author: String?,
+    val coverData: Any?,
+    val isNovel: Boolean,
+    val lastReadDate: LocalDate?,
+    val readDurationMs: Long,
+    val charactersRead: Int,
+    val manga: Manga? = null,
+    val novelId: String? = null,
+    val dateAdded: Long = 0L,
+)
+
+class StatsTitlesScreenModel(
+    private val activeProfileId: String?,
+    private val allRead: Boolean,
+    private val statsType: StatsType,
+    private val getLibraryManga: GetLibraryManga = Injekt.get(),
+    private val getReadMangaNotInLibraryView: GetReadMangaNotInLibraryView = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val dictionaryPreferences: DictionaryPreferences = Injekt.get(),
+    private val context: Application = Injekt.get(),
+) : StateScreenModel<StatsTitlesState>(StatsTitlesState.Loading) {
+
+    private var rawTitles = emptyList<StatsTitleItem>()
+    val searchQuery = MutableStateFlow<String?>(null)
+    val sortOption = MutableStateFlow(StatsTitlesSort.LastRead)
+
+    init {
+        screenModelScope.launch {
+            loadRawTitles()
+            combine(searchQuery, sortOption) { query, sort ->
+                val filtered = if (query.isNullOrBlank()) {
+                    rawTitles
+                } else {
+                    rawTitles.filter {
+                        it.title.contains(query, ignoreCase = true) ||
+                            (it.author?.contains(query, ignoreCase = true) == true)
+                    }
+                }
+
+                val sorted = when (sort) {
+                    StatsTitlesSort.Alphabetical -> filtered.sortedWith(
+                        compareBy<StatsTitleItem> { it.title.lowercase() }
+                    )
+                    StatsTitlesSort.LastRead -> filtered.sortedWith(
+                        compareByDescending<StatsTitleItem> { it.lastReadDate != null }
+                            .thenByDescending { it.lastReadDate }
+                            .thenByDescending { it.readDurationMs }
+                            .thenBy { it.title }
+                    )
+                    StatsTitlesSort.DateAdded -> filtered.sortedWith(
+                        compareByDescending<StatsTitleItem> { it.dateAdded }
+                            .thenBy { it.title }
+                    )
+                }
+
+                StatsTitlesState.Success(
+                    titles = sorted,
+                    searchQuery = query,
+                    sortOption = sort,
+                )
+            }.collect { nextState ->
+                mutableState.update { nextState }
+            }
+        }
+    }
+
+    fun search(query: String?) {
+        searchQuery.value = query
+    }
+
+    fun sort(sort: StatsTitlesSort) {
+        sortOption.value = sort
+    }
+
+    private suspend fun loadRawTitles() {
+        withContext(Dispatchers.IO) {
+            val resolver = dictionaryPreferences.profileResolver
+
+            // 1. Get filtered Manga
+            val mangaList = if (statsType == StatsType.All || statsType == StatsType.Manga) {
+                val libraryManga = getLibraryManga.await() + if (allRead) {
+                    getReadMangaNotInLibraryView.await()
+                } else {
+                    emptyList()
+                }
+                val distinctLibraryManga = libraryManga.distinctBy { it.id }
+
+                // Filter by profile
+                distinctLibraryManga.filter { lm ->
+                    val dbManga = lm.manga
+                    val source = dbManga.source.let { sourceManager.getOrStub(it) }
+                    val profileId = resolver.resolve(
+                        mangaId = lm.id,
+                        sourceId = dbManga.source,
+                        sourceLang = source.lang,
+                    ).id
+                    activeProfileId == null || profileId == activeProfileId
+                }.map { it.manga }
+            } else {
+                emptyList()
+            }
+
+            // 2. Get filtered Novels
+            val novelList = if (statsType == StatsType.All || statsType == StatsType.Novels) {
+                val allNovels = BookStorage.loadAllBooks(context)
+                allNovels.filter { novel ->
+                    val profileId = resolver.resolve(novelId = novel.id).id
+                    activeProfileId == null || profileId == activeProfileId
+                }
+            } else {
+                emptyList()
+            }
+
+            // 3. Load Stats to compute last read time, duration, and characters
+            val allMangaStats = MangaStatsStorage.loadAll(context)
+            val mangaStatsGrouped = allMangaStats.groupBy { it.mangaId }
+
+            val titleItems = mutableListOf<StatsTitleItem>()
+
+            // Process Manga
+            mangaList.forEach { manga ->
+                val stats = mangaStatsGrouped[manga.id] ?: emptyList()
+                val totalDuration = stats.sumOf { it.readingTime }
+                val totalChars = stats.sumOf { it.charactersRead }
+                val lastRead = stats.mapNotNull {
+                    runCatching { LocalDate.parse(it.dateKey) }.getOrNull()
+                }.maxOrNull()
+
+                titleItems.add(
+                    StatsTitleItem(
+                        id = manga.id.toString(),
+                        title = manga.title,
+                        author = manga.author,
+                        coverData = manga,
+                        isNovel = false,
+                        lastReadDate = lastRead,
+                        readDurationMs = totalDuration,
+                        charactersRead = totalChars,
+                        manga = manga,
+                        dateAdded = manga.dateAdded,
+                    )
+                )
+            }
+
+            // Process Novels
+            novelList.forEach { novel ->
+                val bookDir = BookStorage.getBookDirectory(context, novel.id)
+                val stats = BookStorage.loadStatistics(bookDir) ?: emptyList()
+                val totalDurationSeconds = stats.sumOf { it.readingTime }
+                val totalDurationMs = (totalDurationSeconds * 1000).toLong()
+                val totalChars = stats.sumOf { it.charactersRead }
+                val lastRead = stats.mapNotNull {
+                    runCatching { LocalDate.parse(it.dateKey) }.getOrNull()
+                }.maxOrNull()
+
+                titleItems.add(
+                    StatsTitleItem(
+                        id = novel.id,
+                        title = novel.title ?: "Unknown Title",
+                        author = novel.author,
+                        coverData = novel.cover?.let { File(it) },
+                        isNovel = true,
+                        lastReadDate = lastRead,
+                        readDurationMs = totalDurationMs,
+                        charactersRead = totalChars,
+                        novelId = novel.id,
+                        dateAdded = novel.dateAdded,
+                    )
+                )
+            }
+
+            rawTitles = titleItems
+        }
+    }
+}
+
+class StatsTitlesScreen(
+    private val activeProfileId: String?,
+    private val allRead: Boolean,
+    private val statsType: StatsType,
+) : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        val screenModel = rememberScreenModel {
+            StatsTitlesScreenModel(activeProfileId, allRead, statsType)
+        }
+        val state by screenModel.state.collectAsState()
+
+        val successState = state as? StatsTitlesState.Success
+
+        Scaffold(
+            topBar = { scrollBehavior ->
+                val titleText = stringResource(MR.strings.label_stats) + " - " + if (allRead) "All read" else "In library"
+                SearchToolbar(
+                    titleContent = { AppBarTitle(titleText) },
+                    searchQuery = successState?.searchQuery,
+                    onChangeSearchQuery = { screenModel.search(it) },
+                    navigateUp = navigator::pop,
+                    actions = {
+                        var sortMenuExpanded by remember { mutableStateOf(false) }
+                        IconButton(onClick = { sortMenuExpanded = true }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Sort,
+                                contentDescription = stringResource(MR.strings.action_sort),
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = sortMenuExpanded,
+                            onDismissRequest = { sortMenuExpanded = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(MR.strings.action_sort_alpha)) },
+                                onClick = {
+                                    screenModel.sort(StatsTitlesSort.Alphabetical)
+                                    sortMenuExpanded = false
+                                },
+                                trailingIcon = {
+                                    if (successState?.sortOption == StatsTitlesSort.Alphabetical) {
+                                        Icon(Icons.Default.Check, contentDescription = null)
+                                    }
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(MR.strings.action_sort_last_read)) },
+                                onClick = {
+                                    screenModel.sort(StatsTitlesSort.LastRead)
+                                    sortMenuExpanded = false
+                                },
+                                trailingIcon = {
+                                    if (successState?.sortOption == StatsTitlesSort.LastRead) {
+                                        Icon(Icons.Default.Check, contentDescription = null)
+                                    }
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(MR.strings.action_sort_date_added)) },
+                                onClick = {
+                                    screenModel.sort(StatsTitlesSort.DateAdded)
+                                    sortMenuExpanded = false
+                                },
+                                trailingIcon = {
+                                    if (successState?.sortOption == StatsTitlesSort.DateAdded) {
+                                        Icon(Icons.Default.Check, contentDescription = null)
+                                    }
+                                }
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+        ) { paddingValues ->
+            when (val actualState = state) {
+                is StatsTitlesState.Loading -> LoadingScreen()
+                is StatsTitlesState.Success -> {
+                    StatsTitlesContent(
+                        state = actualState,
+                        paddingValues = paddingValues,
+                        onTitleClick = { item ->
+                            navigator.push(
+                                StatsScreen(
+                                    titleId = item.id,
+                                    isNovel = item.isNovel,
+                                    titleName = item.title,
+                                )
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -264,6 +264,7 @@ object AnkiCardCreator {
         forceOpen: Boolean = false,
         type: String? = null,
         syncOnCreate: Boolean = false,
+        profileId: String = "",
     ): AnkiResult {
         android.util.Log.d(TAG, "addToAnki: deck=$deck, model=$model, forceOpen=$forceOpen, glossaryIndex=$glossaryIndex")
 
@@ -387,7 +388,7 @@ object AnkiCardCreator {
                         "open" -> return AnkiResult.OpenCard(existing.first())
                         "overwrite" -> {
                             bridge.updateNoteFields(existing.first(), fields)
-                            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type)
+                            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId)
                             if (syncOnCreate) bridge.triggerSync()
                             return AnkiResult.Success(existing.first())
                         }
@@ -396,7 +397,7 @@ object AnkiCardCreator {
             }
 
             val noteId = bridge.addNote(deckName = effectiveDeck, modelName = effectiveModel, fields = fields, tags = tagList)
-            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type)
+            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId)
             if (syncOnCreate) bridge.triggerSync()
             AnkiResult.Success(noteId)
         } catch (e: SecurityException) {

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -265,6 +265,7 @@ object AnkiCardCreator {
         type: String? = null,
         syncOnCreate: Boolean = false,
         profileId: String = "",
+        titleId: String? = null,
     ): AnkiResult {
         android.util.Log.d(TAG, "addToAnki: deck=$deck, model=$model, forceOpen=$forceOpen, glossaryIndex=$glossaryIndex")
 
@@ -388,7 +389,7 @@ object AnkiCardCreator {
                         "open" -> return AnkiResult.OpenCard(existing.first())
                         "overwrite" -> {
                             bridge.updateNoteFields(existing.first(), fields)
-                            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId)
+                            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId, titleId = titleId)
                             if (syncOnCreate) bridge.triggerSync()
                             return AnkiResult.Success(existing.first())
                         }
@@ -397,7 +398,7 @@ object AnkiCardCreator {
             }
 
             val noteId = bridge.addNote(deckName = effectiveDeck, modelName = effectiveModel, fields = fields, tags = tagList)
-            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId)
+            com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId, titleId = titleId)
             if (syncOnCreate) bridge.triggerSync()
             AnkiResult.Success(noteId)
         } catch (e: SecurityException) {

--- a/chimahon/src/main/java/com/canopus/chimareader/data/AnkiStatsStorage.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/data/AnkiStatsStorage.kt
@@ -20,11 +20,11 @@ object AnkiStatsStorage {
         BookStorage.save(stats, context.filesDir, FileNames.ankiStats)
     }
 
-    fun addCard(context: Context, type: String? = null, date: LocalDate = LocalDate.now(), profileId: String = "") {
+    fun addCard(context: Context, type: String? = null, date: LocalDate = LocalDate.now(), profileId: String = "", titleId: String? = null) {
         val dateKey = date.toString()
         val allStats = loadAll(context).toMutableList()
-        val existing = allStats.find { it.dateKey == dateKey && it.profileId == profileId }
-        android.util.Log.d("AnkiStatsStorage", "addCard: type=$type, date=$dateKey, profile=$profileId")
+        val existing = allStats.find { it.dateKey == dateKey && it.profileId == profileId && it.titleId == titleId }
+        android.util.Log.d("AnkiStatsStorage", "addCard: type=$type, date=$dateKey, profile=$profileId, titleId=$titleId")
         if (existing != null) {
             if (type == "manga") {
                 existing.mangaCards++
@@ -33,7 +33,7 @@ object AnkiStatsStorage {
             }
             android.util.Log.d("AnkiStatsStorage", "Updated existing: manga=${existing.mangaCards}, novel=${existing.novelCards}")
         } else {
-            val stats = AnkiStats(dateKey, profileId = profileId)
+            val stats = AnkiStats(dateKey, profileId = profileId, titleId = titleId)
             if (type == "manga") {
                 stats.mangaCards = 1
             } else {
@@ -50,7 +50,7 @@ object AnkiStatsStorage {
         val local = loadAll(context).toMutableList()
         var changed = false
         incoming.forEach { remote ->
-            val existing = local.find { it.dateKey == remote.dateKey && it.profileId == remote.profileId }
+            val existing = local.find { it.dateKey == remote.dateKey && it.profileId == remote.profileId && it.titleId == remote.titleId }
             if (existing != null) {
                 if (remote.mangaCards > existing.mangaCards) {
                     existing.mangaCards = remote.mangaCards

--- a/chimahon/src/main/java/com/canopus/chimareader/data/AnkiStatsStorage.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/data/AnkiStatsStorage.kt
@@ -20,11 +20,11 @@ object AnkiStatsStorage {
         BookStorage.save(stats, context.filesDir, FileNames.ankiStats)
     }
 
-    fun addCard(context: Context, type: String? = null, date: LocalDate = LocalDate.now()) {
+    fun addCard(context: Context, type: String? = null, date: LocalDate = LocalDate.now(), profileId: String = "") {
         val dateKey = date.toString()
         val allStats = loadAll(context).toMutableList()
-        val existing = allStats.find { it.dateKey == dateKey }
-        android.util.Log.d("AnkiStatsStorage", "addCard: type=$type, date=$dateKey")
+        val existing = allStats.find { it.dateKey == dateKey && it.profileId == profileId }
+        android.util.Log.d("AnkiStatsStorage", "addCard: type=$type, date=$dateKey, profile=$profileId")
         if (existing != null) {
             if (type == "manga") {
                 existing.mangaCards++
@@ -33,7 +33,7 @@ object AnkiStatsStorage {
             }
             android.util.Log.d("AnkiStatsStorage", "Updated existing: manga=${existing.mangaCards}, novel=${existing.novelCards}")
         } else {
-            val stats = AnkiStats(dateKey)
+            val stats = AnkiStats(dateKey, profileId = profileId)
             if (type == "manga") {
                 stats.mangaCards = 1
             } else {
@@ -50,7 +50,7 @@ object AnkiStatsStorage {
         val local = loadAll(context).toMutableList()
         var changed = false
         incoming.forEach { remote ->
-            val existing = local.find { it.dateKey == remote.dateKey }
+            val existing = local.find { it.dateKey == remote.dateKey && it.profileId == remote.profileId }
             if (existing != null) {
                 if (remote.mangaCards > existing.mangaCards) {
                     existing.mangaCards = remote.mangaCards

--- a/chimahon/src/main/java/com/canopus/chimareader/data/BookMetadata.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/data/BookMetadata.kt
@@ -16,4 +16,5 @@ data class BookMetadata(
     val categoryIds: List<String> = emptyList(),
     val lang: String? = null,
     val ttuFolderName: String? = null,
+    val chapterStarts: List<Int>? = null,
 )

--- a/chimahon/src/main/java/com/canopus/chimareader/data/Statistics.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/data/Statistics.kt
@@ -35,6 +35,7 @@ data class AnkiStats(
     val dateKey: String,
     var mangaCards: Int = 0,
     var novelCards: Int = 0,
+    var profileId: String = "",
 )
 
 @Serializable

--- a/chimahon/src/main/java/com/canopus/chimareader/data/Statistics.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/data/Statistics.kt
@@ -36,6 +36,7 @@ data class AnkiStats(
     var mangaCards: Int = 0,
     var novelCards: Int = 0,
     var profileId: String = "",
+    var titleId: String? = null,
 )
 
 @Serializable

--- a/chimahon/src/main/java/com/canopus/chimareader/ui/reader/ReaderViewModel.kt
+++ b/chimahon/src/main/java/com/canopus/chimareader/ui/reader/ReaderViewModel.kt
@@ -317,6 +317,24 @@ class ReaderViewModel(
                 runningTotal += document.getChapterCharacters(i)
             }
             accumulatedCharCounts[document.linearSpineItems.size] = runningTotal
+
+            val toc = getFlattenedToc()
+            val chapterStartsList = if (toc.isNotEmpty()) {
+                toc.map { entry ->
+                    val spineIndex = entry.href?.let { getSpineIndexForHref(it) } ?: 0
+                    accumulatedCharCounts[spineIndex] ?: 0
+                }
+            } else {
+                document.linearSpineItems.indices.map { index ->
+                    accumulatedCharCounts[index] ?: 0
+                }
+            }
+            val chapterStartsListWithEnd = chapterStartsList + runningTotal
+
+            val metadata = BookStorage.loadMetadata(rootUrl)
+            if (metadata != null && metadata.chapterStarts != chapterStartsListWithEnd) {
+                BookStorage.saveMetadata(metadata.copy(chapterStarts = chapterStartsListWithEnd), rootUrl)
+            }
         }
 
         getCurrentChapter()?.let { file ->

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -761,6 +761,8 @@
     <string name="stats_characters_read">Characters read</string>
     <string name="stats_avg_speed">Avg speed</string>
     <string name="stats_reading_time">Reading time</string>
+    <string name="stats_all_profiles">All profiles</string>
+    <string name="stats_profile_filter_label">Profile: %1$s</string>
 
     <!-- Humanize time -->
     <string name="humanize_fallback">moments ago</string>

--- a/i18n-sy/src/commonMain/moko-resources/ru/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ru/strings.xml
@@ -694,4 +694,6 @@
     <string name="file_extension">Расширение файла</string>
     <string name="base_url">Главный URL</string>
     <string name="final_chapter">Последняя глава</string>
+    <string name="stats_all_profiles">Все профили</string>
+    <string name="stats_profile_filter_label">Профиль: %1$s</string>
 </resources>


### PR DESCRIPTION
* **Stats for individual titles:** Users can now view detailed reading history, time, streaks, and Anki cards for a specific book or manga.
* **Profile-based stats:** Library counts, novel progress, and Anki card stats are now separated and tracked per user profile.
* **Show all read entries by default:** The stats screen now includes non-library read entries by default to show the user's full history.
* **Calculation fixes:** Fixed bugs in reading time, speed estimation, and stats aggregation on the charts.