### PR TITLE
Fix: Resolve infinite sync loops causing gigantic unnecessary restorations and prevent deleted "ghost chapters" from reappearing during sync.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -143,6 +143,7 @@ class MangaRestorer(
             updateStrategy = newer.updateStrategy,
             initialized = this.initialized || newer.initialized,
             version = newer.version,
+            notes = newer.notes,
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -130,13 +130,17 @@ class MangaRestorer(
         return this.copy(
             favorite = this.favorite || newer.favorite,
             // SY -->
-            ogAuthor = newer.author,
-            ogArtist = newer.artist,
-            ogDescription = newer.description,
-            ogGenre = newer.genre,
-            ogThumbnailUrl = newer.thumbnailUrl,
-            ogStatus = newer.status,
+            ogTitle = newer.ogTitle,
+            ogAuthor = newer.ogAuthor,
+            ogArtist = newer.ogArtist,
+            ogDescription = newer.ogDescription,
+            ogGenre = newer.ogGenre,
+            ogThumbnailUrl = newer.ogThumbnailUrl,
+            ogStatus = newer.ogStatus,
             // SY <--
+            chapterFlags = newer.chapterFlags,
+            viewerFlags = newer.viewerFlags,
+            updateStrategy = newer.updateStrategy,
             initialized = this.initialized || newer.initialized,
             version = newer.version,
         )
@@ -194,7 +198,13 @@ class MangaRestorer(
 
                 when {
                     dbChapter == null -> chapter // New chapter
-                    chapter.forComparison() == dbChapter.forComparison() -> null // Same state; skip
+                    chapter.forComparison() == dbChapter.forComparison() -> {
+                        if (isSync && chapter.version != dbChapter.version) {
+                            chapter.copy(id = dbChapter.id)
+                        } else {
+                            null // Same state; skip
+                        }
+                    }
                     else -> updateChapterBasedOnSyncState(chapter, dbChapter) // Update existed chapter
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -182,14 +182,6 @@ class SyncManager(
             return
         }
 
-        // Check if it's first sync based on lastSyncTimestamp
-        if (syncPreferences.lastSyncTimestamp().get() == 0L && databaseManga.isNotEmpty()) {
-            // It's first sync no need to restore data. (just update remote data)
-            syncPreferences.lastSyncTimestamp().set(Date().time)
-            notifier.showSyncSuccess("Updated remote data successfully")
-            return
-        }
-
         val (filteredFavorites, nonFavorites) = filterFavoritesAndNonFavorites(remoteBackup)
         updateNonFavorites(nonFavorites)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -6,7 +6,6 @@ import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.tachiyomi.data.backup.create.BackupCreator
 import eu.kanade.tachiyomi.data.backup.create.BackupOptions
 import eu.kanade.tachiyomi.data.backup.models.Backup
-import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupChapter
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -123,6 +123,8 @@ class SyncManager(
             // Chimahon -->
             backupNovels = backupCreator.backupNovels(backupOptions),
             backupNovelCategories = backupCreator.backupNovelCategories(backupOptions),
+            backupMangaStats = backupCreator.backupMangaStats(backupOptions),
+            backupAnkiStats = backupCreator.backupAnkiStats(backupOptions),
             // Chimahon <--
         )
         logcat(LogPriority.DEBUG) { "End create backup" }
@@ -203,6 +205,8 @@ class SyncManager(
             // Chimahon -->
             backupNovels = remoteBackup.backupNovels,
             backupNovelCategories = remoteBackup.backupNovelCategories,
+            backupMangaStats = remoteBackup.backupMangaStats,
+            backupAnkiStats = remoteBackup.backupAnkiStats,
             // Chimahon <--
         )
 
@@ -229,7 +233,7 @@ class SyncManager(
                     savedSearchesFeeds = syncOptions.savedSearchesFeeds,
                     sourceSettings = syncOptions.sourceSettings,
                     // Chimahon -->
-                    novels = true,
+                    novels = syncOptions.novels,
                     // Chimahon <--
                 ),
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -226,6 +226,7 @@ class SyncManager(
                     sourceSettings = true,
                     libraryEntries = true,
                     extensionRepoSettings = true,
+                    savedSearchesFeeds = syncOptions.savedSearchesFeeds,
                     // Chimahon -->
                     novels = true,
                     // Chimahon <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -6,6 +6,7 @@ import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.tachiyomi.data.backup.create.BackupCreator
 import eu.kanade.tachiyomi.data.backup.create.BackupOptions
 import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupChapter
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
@@ -328,13 +329,13 @@ class SyncManager(
         val elapsedTimeMillis = measureTimeMillis {
             val databaseManga = getAllMangaFromDB()
             val localMangaMap = databaseManga.associateBy {
-                Triple(it.source, it.url, it.title)
+                Pair(it.source, it.url)
             }
 
             logcat(LogPriority.DEBUG, logTag) { "Starting to filter favorites and non-favorites from backup data." }
 
             backup.backupManga.forEach { remoteManga ->
-                val compositeKey = Triple(remoteManga.source, remoteManga.url, remoteManga.title)
+                val compositeKey = Pair(remoteManga.source, remoteManga.url)
                 val localManga = localMangaMap[compositeKey]
                 when {
                     // Checks if the manga is in favorites and needs updating or adding
@@ -372,10 +373,10 @@ class SyncManager(
     private suspend fun updateNonFavorites(nonFavorites: List<BackupManga>) {
         val localMangaList = getAllMangaFromDB()
 
-        val localMangaMap = localMangaList.associateBy { Triple(it.source, it.url, it.title) }
+        val localMangaMap = localMangaList.associateBy { Pair(it.source, it.url) }
 
         nonFavorites.forEach { nonFavorite ->
-            val key = Triple(nonFavorite.source, nonFavorite.url, nonFavorite.title)
+            val key = Pair(nonFavorite.source, nonFavorite.url)
             localMangaMap[key]?.let { localManga ->
                 if (localManga.favorite != nonFavorite.favorite) {
                     val updatedManga = localManga.copy(favorite = nonFavorite.favorite)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -182,6 +182,14 @@ class SyncManager(
             return
         }
 
+        // Check if it's first sync based on lastSyncTimestamp
+        if (syncPreferences.lastSyncTimestamp().get() == 0L && databaseManga.isNotEmpty()) {
+            // It's first sync no need to restore data. (just update remote data)
+            syncPreferences.lastSyncTimestamp().set(Date().time)
+            notifier.showSyncSuccess("Updated remote data successfully")
+            return
+        }
+
         val (filteredFavorites, nonFavorites) = filterFavoritesAndNonFavorites(remoteBackup)
         updateNonFavorites(nonFavorites)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -222,11 +222,12 @@ class SyncManager(
                 backupUri,
                 sync = true,
                 options = RestoreOptions(
-                    appSettings = true,
-                    sourceSettings = true,
-                    libraryEntries = true,
-                    extensionRepoSettings = true,
+                    appSettings = syncOptions.appSettings,
+                    categories = syncOptions.categories,
+                    extensionRepoSettings = syncOptions.extensionRepoSettings,
+                    libraryEntries = syncOptions.libraryEntries,
                     savedSearchesFeeds = syncOptions.savedSearchesFeeds,
+                    sourceSettings = syncOptions.sourceSettings,
                     // Chimahon -->
                     novels = true,
                     // Chimahon <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -132,7 +132,7 @@ abstract class SyncService(
         }
 
         fun mangaCompositeKey(manga: BackupManga): String {
-            return "${manga.source}|${manga.url}|${manga.title.lowercase().trim()}|${manga.author?.lowercase()?.trim()}"
+            return "${manga.source}|${manga.url}"
         }
 
         // Create maps using composite keys
@@ -224,7 +224,7 @@ abstract class SyncService(
         val logTag = "MergeChapters"
 
         fun chapterCompositeKey(chapter: BackupChapter): String {
-            return "${chapter.url}|${chapter.name}|${chapter.chapterNumber}"
+            return chapter.url
         }
 
         val localChapterMap = localChapters.associateBy { chapterCompositeKey(it) }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.data.sync.service
 
 import android.content.Context
+import com.canopus.chimareader.data.AnkiStats
+import com.canopus.chimareader.data.MangaStats
 import com.canopus.chimareader.data.NovelCategory
 import com.canopus.chimareader.data.md5Hex
 import eu.kanade.domain.sync.SyncPreferences
@@ -80,6 +82,14 @@ abstract class SyncService(
             remoteSyncData.backup?.backupNovelCategories ?: emptyList(),
             mergedNovelCategoriesList,
         )
+        val mergedMangaStatsList = mergeMangaStatsLists(
+            localSyncData.backup?.backupMangaStats,
+            remoteSyncData.backup?.backupMangaStats,
+        )
+        val mergedAnkiStatsList = mergeAnkiStatsLists(
+            localSyncData.backup?.backupAnkiStats,
+            remoteSyncData.backup?.backupAnkiStats,
+        )
         // Chimahon <--
 
         // Create the merged Backup object
@@ -97,6 +107,8 @@ abstract class SyncService(
             // Chimahon -->
             backupNovels = mergedNovelsList,
             backupNovelCategories = mergedNovelCategoriesList,
+            backupMangaStats = mergedMangaStatsList,
+            backupAnkiStats = mergedAnkiStatsList,
             // Chimahon <--
         )
 
@@ -632,13 +644,27 @@ abstract class SyncService(
         val localNovelMap = canonicalNovelMap(localNovelsSafe, localCategoriesById)
         val remoteNovelMap = canonicalNovelMap(remoteNovelsSafe, remoteCategoriesById)
 
+        val lastSyncTime = syncPreferences.lastSyncTimestamp().get().milliseconds.inWholeSeconds
+
         val mergedList = (localNovelMap.keys + remoteNovelMap.keys).distinct().mapNotNull { id ->
             val local = localNovelMap[id]
             val remote = remoteNovelMap[id]
 
             when {
-                local != null && remote == null -> local
-                local == null && remote != null -> remote
+                local != null && remote == null -> {
+                    if (lastSyncTime == 0L || local.lastModified.milliseconds.inWholeSeconds > lastSyncTime) {
+                        local
+                    } else {
+                        null
+                    }
+                }
+                local == null && remote != null -> {
+                    if (lastSyncTime == 0L || remote.lastModified.milliseconds.inWholeSeconds > lastSyncTime) {
+                        remote
+                    } else {
+                        null
+                    }
+                }
                 local != null && remote != null -> mergeNovelData(local, remote)
                 else -> null
             }
@@ -719,6 +745,58 @@ abstract class SyncService(
 
     private fun categoryKey(name: String): String {
         return name.trim().lowercase()
+    }
+
+    private fun mergeMangaStatsLists(
+        localStats: List<MangaStats>?,
+        remoteStats: List<MangaStats>?,
+    ): List<MangaStats> {
+        if (localStats == null) return remoteStats ?: emptyList()
+        if (remoteStats == null) return localStats
+
+        fun statsKey(stat: MangaStats): String = "${stat.dateKey}|${stat.mangaId}"
+
+        val localMap = localStats.associateBy { statsKey(it) }
+        val remoteMap = remoteStats.associateBy { statsKey(it) }
+
+        return (localMap.keys + remoteMap.keys).distinct().mapNotNull { key ->
+            val local = localMap[key]
+            val remote = remoteMap[key]
+            when {
+                local != null && remote == null -> local
+                local == null && remote != null -> remote
+                local != null && remote != null -> {
+                    if (local.readingTime >= remote.readingTime) local else remote
+                }
+                else -> null
+            }
+        }
+    }
+
+    private fun mergeAnkiStatsLists(
+        localStats: List<AnkiStats>?,
+        remoteStats: List<AnkiStats>?,
+    ): List<AnkiStats> {
+        if (localStats == null) return remoteStats ?: emptyList()
+        if (remoteStats == null) return localStats
+
+        fun statsKey(stat: AnkiStats): String = "${stat.dateKey}|${stat.profileId}|${stat.titleId.orEmpty()}"
+
+        val localMap = localStats.associateBy { statsKey(it) }
+        val remoteMap = remoteStats.associateBy { statsKey(it) }
+
+        return (localMap.keys + remoteMap.keys).distinct().mapNotNull { key ->
+            val local = localMap[key]
+            val remote = remoteMap[key]
+            when {
+                local != null && remote == null -> local
+                local == null && remote != null -> remote
+                local != null && remote != null -> {
+                    if ((local.mangaCards + local.novelCards) >= (remote.mangaCards + remote.novelCards)) local else remote
+                }
+                else -> null
+            }
+        }
     }
     // Chimahon <--
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import logcat.logcat
+import kotlin.time.Duration.Companion.milliseconds
 
 @Serializable
 data class SyncData(
@@ -157,14 +158,31 @@ abstract class SyncService(
             "Starting merge. Local list size: ${localMangaListSafe.size}, Remote list size: ${remoteMangaListSafe.size}"
         }
 
+        val lastSyncTime = syncPreferences.lastSyncTimestamp().get().milliseconds.inWholeSeconds
+        val syncOptions = syncPreferences.getSyncSettings()
+
         val mergedList = (localMangaMap.keys + remoteMangaMap.keys).distinct().mapNotNull { compositeKey ->
             val local = localMangaMap[compositeKey]
             val remote = remoteMangaMap[compositeKey]
 
             // New version comparison logic
             when {
-                local != null && remote == null -> updateCategories(local, localCategoriesMapByOrder)
-                local == null && remote != null -> updateCategories(remote, remoteCategoriesMapByOrder)
+                local != null && remote == null -> {
+                    if (lastSyncTime == 0L || local.lastModifiedAt > lastSyncTime) {
+                        updateCategories(local, localCategoriesMapByOrder)
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping local manga deleted on remote: ${local.title}." }
+                        null
+                    }
+                }
+                local == null && remote != null -> {
+                    if (lastSyncTime == 0L || remote.lastModifiedAt > lastSyncTime) {
+                        updateCategories(remote, remoteCategoriesMapByOrder)
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping deleted remote manga: ${remote.title}." }
+                        null
+                    }
+                }
                 local != null && remote != null -> {
                     // Compare versions to decide which manga to keep
                     if (local.version >= remote.version) {
@@ -172,7 +190,7 @@ abstract class SyncService(
                             "Keeping local version of ${local.title} with merged chapters."
                         }
                         updateCategories(
-                            local.copy(chapters = mergeChapters(local.chapters, remote.chapters)),
+                            local.copy(chapters = mergeChapters(local.chapters, remote.chapters, lastSyncTime, syncOptions.chapters)),
                             localCategoriesMapByOrder,
                         )
                     } else {
@@ -180,7 +198,7 @@ abstract class SyncService(
                             "Keeping remote version of ${remote.title} with merged chapters."
                         }
                         updateCategories(
-                            remote.copy(chapters = mergeChapters(local.chapters, remote.chapters)),
+                            remote.copy(chapters = mergeChapters(local.chapters, remote.chapters, lastSyncTime, syncOptions.chapters)),
                             remoteCategoriesMapByOrder,
                         )
                     }
@@ -220,8 +238,14 @@ abstract class SyncService(
     private fun mergeChapters(
         localChapters: List<BackupChapter>,
         remoteChapters: List<BackupChapter>,
+        lastSyncTime: Long,
+        syncingChapters: Boolean,
     ): List<BackupChapter> {
         val logTag = "MergeChapters"
+
+        if (!syncingChapters) {
+            return remoteChapters // If not syncing chapters, keep remote untouched
+        }
 
         fun chapterCompositeKey(chapter: BackupChapter): String {
             return chapter.url
@@ -246,12 +270,22 @@ abstract class SyncService(
 
             when {
                 localChapter != null && remoteChapter == null -> {
-                    logcat(LogPriority.DEBUG, logTag) { "Keeping local chapter: ${localChapter.name}." }
-                    localChapter
+                    if (lastSyncTime == 0L || localChapter.lastModifiedAt > lastSyncTime) {
+                        logcat(LogPriority.DEBUG, logTag) { "Keeping local chapter: ${localChapter.name}." }
+                        localChapter
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping local chapter deleted on remote: ${localChapter.name}." }
+                        null
+                    }
                 }
                 localChapter == null && remoteChapter != null -> {
-                    logcat(LogPriority.DEBUG, logTag) { "Taking remote chapter: ${remoteChapter.name}." }
-                    remoteChapter
+                    if (lastSyncTime == 0L || remoteChapter.lastModifiedAt > lastSyncTime) {
+                        logcat(LogPriority.DEBUG, logTag) { "Taking remote chapter: ${remoteChapter.name}." }
+                        remoteChapter
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping deleted remote chapter: ${remoteChapter.name}." }
+                        null
+                    }
                 }
                 localChapter != null && remoteChapter != null -> {
                     // Use version number to decide which chapter to keep


### PR DESCRIPTION
Consolidates [this PR for TachiyomiSY](https://github.com/jobobby04/TachiyomiSY/pull/1575) by @kaiserbh and [this PR by me](https://github.com/komikku-app/komikku/pull/1640) (my [upstream PR to TachiyomiSY](https://github.com/jobobby04/TachiyomiSY/pull/1594) was already merged, but this one has specifics to Komikku) into one PR that fixes the biggest remaining issues to sync.
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
