### PR TITLE
Fix anime subtitle lookup timing and Jimaku season matching

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -142,6 +142,7 @@ import java.util.Locale
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.roundToInt
 
 private val jimakuEpisodeRegexes = listOf(
     Regex("""(?i)\bS\d{1,3}E(\d{1,4})\b"""),
@@ -156,6 +157,12 @@ private val jimakuStandaloneEpisodeRegex = Regex("""(?<![A-Za-z0-9])(\d{1,4})(?!
 private val jimakuEpisodeCleanupRegex = Regex(
     """(?i)\bS\d{1,3}E\d{1,4}\b|\b\d{1,3}x\d{1,4}\b|\b(?:ep|episode|e)\.?\s*\d{1,4}\b|第\s*\d{1,4}\s*話|\d{1,4}\s*話""",
 )
+private val jimakuSeasonRegexes = listOf(
+    Regex("""(?i)\bS(\d{1,3})E\d{1,4}\b"""),
+    Regex("""(?i)\b(\d{1,3})x\d{1,4}\b"""),
+    Regex("""(?i)\bseason[ ._-]*(\d{1,3})\b"""),
+)
+private val jimakuSeasonCleanupRegex = Regex("""(?i)\bseason[ ._-]*\d{1,3}\b""")
 private val jimakuFilenameJunkRegex = Regex(
     """(?i)\b(?:480p|720p|1080p|2160p|x264|x265|h264|h265|hevc|web[- ]?dl|webrip|bluray|aac|flac|multi|proper|repack)\b|\[[^\]]*]|\([^)]*\)""",
 )
@@ -242,6 +249,8 @@ class PlayerViewModel @JvmOverloads constructor(
     val subtitleHistory = _subtitleHistory.asStateFlow()
     private val _activeSubtitleCueIndex = MutableStateFlow<Int?>(null)
     val activeSubtitleCueIndex = _activeSubtitleCueIndex.asStateFlow()
+    private val _primarySubtitleDelaySeconds = MutableStateFlow(0.0)
+    val primarySubtitleDelaySeconds = _primarySubtitleDelaySeconds.asStateFlow()
     private var lastSubtitleHistoryText = ""
     private var nextSubtitleCueIndex = 0
     private val parsedSubtitleCuesByTrackId = mutableMapOf<Int, List<SubtitleCue>>()
@@ -538,6 +547,7 @@ class PlayerViewModel @JvmOverloads constructor(
     private data class JimakuMediaGuess(
         val title: String,
         val episode: Int?,
+        val season: Int? = null,
     )
 
     fun loadChapters() {
@@ -647,6 +657,7 @@ class PlayerViewModel @JvmOverloads constructor(
             currentEpisode.value?.id?.toString().orEmpty(),
             currentVideo.value?.videoUrl.orEmpty(),
             guess.title,
+            guess.season?.toString().orEmpty(),
             guess.episode?.toString().orEmpty(),
         ).joinToString("|")
         if (lastAutoJimakuKey == key) return
@@ -790,8 +801,11 @@ class PlayerViewModel @JvmOverloads constructor(
             animeTitle.value.takeIf { it.isNotBlank() },
             mediaTitle.value.takeIf { it.isNotBlank() },
             currentVideo.value?.videoTitle?.takeIf { it.isNotBlank() },
+            currentVideo.value?.videoUrl?.takeIf { it.isNotBlank() },
         )
-        val parsed = candidates.mapNotNull { guessitLite(it) }.firstOrNull()
+        val parsedCandidates = candidates.mapNotNull { guessitLite(it) }
+        val parsed = parsedCandidates.firstOrNull { it.season != null || it.episode != null }
+            ?: parsedCandidates.firstOrNull()
         val title = overrideTitle
             .ifBlank { currentAnime.value?.title.orEmpty() }
             .ifBlank { parsed?.title.orEmpty() }
@@ -801,12 +815,16 @@ class PlayerViewModel @JvmOverloads constructor(
             ?.takeIf { it >= 0f }
             ?.toInt()
             ?: parsed?.episode
+        val season = parsed?.season
 
-        return JimakuMediaGuess(title.trim(), episode)
+        return JimakuMediaGuess(title.trim(), episode, season)
     }
 
     private fun guessitLite(value: String): JimakuMediaGuess? {
         val withoutExtension = value.substringBeforeLast('.', value)
+        val season = jimakuSeasonRegexes.firstNotNullOfOrNull { regex ->
+            regex.find(withoutExtension)?.groupValues?.getOrNull(1)?.toIntOrNull()
+        }
         val episode = jimakuEpisodeRegexes.firstNotNullOfOrNull { regex ->
             regex.find(withoutExtension)?.groupValues?.lastOrNull()?.toIntOrNull()
         } ?: jimakuStandaloneEpisodeRegex.findAll(withoutExtension)
@@ -817,12 +835,13 @@ class PlayerViewModel @JvmOverloads constructor(
         val title = withoutExtension
             .replace(Regex("""\u7b2c\s*\d{1,4}\s*\u8a71|\d{1,4}\s*\u8a71"""), " ")
             .replace(jimakuEpisodeCleanupRegex, " ")
+            .replace(jimakuSeasonCleanupRegex, " ")
             .replace(jimakuFilenameJunkRegex, " ")
             .replace(Regex("""[._-]+"""), " ")
             .replace(Regex("""\s+"""), " ")
             .trim()
 
-        return title.takeIf { it.isNotBlank() }?.let { JimakuMediaGuess(it, episode) }
+        return title.takeIf { it.isNotBlank() }?.let { JimakuMediaGuess(it, episode, season) }
     }
 
     private fun selectBestJimakuEntry(entries: List<JimakuEntry>, title: String): JimakuEntry? {
@@ -879,7 +898,16 @@ class PlayerViewModel @JvmOverloads constructor(
     private fun jimakuFileScore(file: JimakuFile, guess: JimakuMediaGuess): Int {
         val parsed = guessitLite(file.name)
         val parsedEpisode = parsed?.episode
+        val parsedSeason = parsed?.season
         var score = 0
+
+        if (guess.season != null) {
+            score += when (parsedSeason) {
+                guess.season -> 60
+                null -> 0
+                else -> -160
+            }
+        }
 
         if (guess.episode != null) {
             score += when (parsedEpisode) {
@@ -911,10 +939,17 @@ class PlayerViewModel @JvmOverloads constructor(
     private fun List<JimakuFile>.matchedSrtFiles(guess: JimakuMediaGuess, episodeFiltered: Boolean): List<JimakuFile> {
         return filter { file -> file.name.lowercase().endsWith(".srt") }
             .filter { file ->
-                val parsedEpisode = guessitLite(file.name)?.episode
-                guess.episode == null ||
+                val parsed = guessitLite(file.name)
+                val parsedEpisode = parsed?.episode
+                val parsedSeason = parsed?.season
+                val seasonMatches = guess.season == null ||
+                    parsedSeason == null ||
+                    parsedSeason == guess.season
+                seasonMatches && (
+                    guess.episode == null ||
                     parsedEpisode == guess.episode ||
                     (episodeFiltered && parsedEpisode == null)
+                    )
             }
             .sortedWith(
                 compareByDescending<JimakuFile> { jimakuFileScore(it, guess) }
@@ -923,7 +958,9 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     private fun JimakuMediaGuess.displayName(): String {
-        return if (episode == null) title else "$title episode $episode"
+        val seasonText = season?.let { " season $it" }.orEmpty()
+        val episodeText = episode?.let { " episode $it" }.orEmpty()
+        return "$title$seasonText$episodeText"
     }
 
     private fun String.normalizedJimakuText(): String {
@@ -1070,27 +1107,42 @@ class PlayerViewModel @JvmOverloads constructor(
         lastSubtitleHistoryText = ""
         nextSubtitleCueIndex = cues.maxOfOrNull { it.index + 1 } ?: 0
         _subtitleHistory.update { cues }
-        updateActiveSubtitleCueFromPosition(pos.value.toInt())
+        updateActiveSubtitleCueFromPosition(pos.value.toDouble())
     }
 
-    private fun updateActiveSubtitleCueFromPosition(positionSeconds: Int, text: String = currentSubtitleText.value) {
+    private fun updateActiveSubtitleCueFromPosition(positionSeconds: Double, text: String = currentSubtitleText.value) {
         val cues = subtitleHistory.value
         if (cues.isEmpty()) {
             _activeSubtitleCueIndex.update { null }
             return
         }
 
+        val delaySeconds = primarySubtitleDelaySeconds.value
         val cueByTime = cues.lastOrNull {
-            positionSeconds >= it.positionSeconds && positionSeconds <= it.endPositionSeconds
+            positionSeconds >= it.delayedStartSeconds(delaySeconds) &&
+                positionSeconds <= it.delayedEndSeconds(delaySeconds)
         }
         val cueByText = text.takeIf { it.isNotBlank() }?.let { cleanedText ->
             val normalizedText = cleanedText.normalizedSubtitleCueText()
             cues
                 .filter { it.text.normalizedSubtitleCueText() == normalizedText }
-                .minByOrNull { kotlin.math.abs(it.positionSeconds - positionSeconds) }
+                .minByOrNull { kotlin.math.abs(it.delayedStartSeconds(delaySeconds) - positionSeconds) }
         }
 
         _activeSubtitleCueIndex.update { cueByTime?.index ?: cueByText?.index }
+    }
+
+    private fun SubtitleCue.delayedStartSeconds(delaySeconds: Double = primarySubtitleDelaySeconds.value): Double {
+        return positionSeconds + delaySeconds
+    }
+
+    private fun SubtitleCue.delayedEndSeconds(delaySeconds: Double = primarySubtitleDelaySeconds.value): Double {
+        return endPositionSeconds + delaySeconds
+    }
+
+    fun updatePrimarySubtitleDelayMillis(delayMillis: Int) {
+        _primarySubtitleDelaySeconds.update { delayMillis / 1000.0 }
+        updateActiveSubtitleCueFromPosition(pos.value.toDouble())
     }
 
     private fun String.normalizedSubtitleCueText(): String {
@@ -1283,7 +1335,7 @@ class PlayerViewModel @JvmOverloads constructor(
         val cleaned = text.orEmpty().cleanMpvSubtitleText()
         _currentSubtitleText.update { cleaned }
         if (showingParsedSubtitleTrackId != null) {
-            updateActiveSubtitleCueFromPosition(pos.value.toInt(), cleaned)
+            updateActiveSubtitleCueFromPosition(pos.value.toDouble(), cleaned)
             return
         }
         updateSubtitleHistory(cleaned)
@@ -1314,7 +1366,7 @@ class PlayerViewModel @JvmOverloads constructor(
 
     fun selectSubtitleCue(index: Int) {
         val cue = subtitleHistory.value.firstOrNull { it.index == index } ?: return
-        seekTo(cue.positionSeconds.coerceAtLeast(0))
+        seekTo(cue.delayedStartSeconds().roundToInt().coerceAtLeast(0))
         _activeSubtitleCueIndex.update { cue.index }
     }
 
@@ -1322,7 +1374,7 @@ class PlayerViewModel @JvmOverloads constructor(
         onSecondReached(pos.toInt(), duration.value.toInt())
         _pos.update { pos }
         if (showingParsedSubtitleTrackId != null) {
-            updateActiveSubtitleCueFromPosition(pos.toInt())
+            updateActiveSubtitleCueFromPosition(pos.toDouble())
         }
     }
 
@@ -2374,14 +2426,16 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     private fun applySubtitleDelayForAnime(animeId: Long) {
+        val primaryDelayMillis = subtitlePreferences.subtitlesDelayForAnime(animeId).get()
         MPVLib.setPropertyDouble(
             "sub-delay",
-            subtitlePreferences.subtitlesDelayForAnime(animeId).get() / 1000.0,
+            primaryDelayMillis / 1000.0,
         )
         MPVLib.setPropertyDouble(
             "secondary-sub-delay",
             subtitlePreferences.subtitlesSecondaryDelayForAnime(animeId).get() / 1000.0,
         )
+        updatePrimarySubtitleDelayMillis(primaryDelayMillis)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -159,6 +159,7 @@ fun PlayerControls(
     val currentSubtitleText by viewModel.currentSubtitleText.collectAsState()
     val subtitleCues by viewModel.subtitleHistory.collectAsState()
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
+    val primarySubtitleDelaySeconds by viewModel.primarySubtitleDelaySeconds.collectAsState()
     val activeSubtitleCue = remember(subtitleCues, activeSubtitleCueIndex) {
         subtitleCues.firstOrNull { it.index == activeSubtitleCueIndex }
     }
@@ -253,6 +254,7 @@ fun PlayerControls(
     PlayerSubtitleTextLayer(
         text = currentSubtitleText,
         cue = activeSubtitleCue,
+        subtitleDelaySeconds = primarySubtitleDelaySeconds,
         request = subtitleLookupRequest,
         onLookup = openSubtitleLookup,
     )
@@ -787,6 +789,7 @@ fun PlayerControls(
             activeSubtitleCueIndex = activeSubtitleCueIndex,
             animeId = anime?.id,
             onSelectSubtitleCue = viewModel::selectSubtitleCue,
+            onPrimarySubtitleDelayMillisChange = viewModel::updatePrimarySubtitleDelayMillis,
             onDismissRequest = { viewModel.showPanel(Panels.None) },
         )
 
@@ -846,6 +849,7 @@ fun PlayerControls(
 private fun PlayerSubtitleTextLayer(
     text: String,
     cue: PlayerViewModel.SubtitleCue?,
+    subtitleDelaySeconds: Double,
     request: SubtitleLookupRequest?,
     onLookup: (SubtitleLookupSelection) -> Unit,
     modifier: Modifier = Modifier,
@@ -914,17 +918,17 @@ private fun PlayerSubtitleTextLayer(
                         )
                     }
                 }
-                .pointerInput(subtitleText, textLayout, textLayerOrigin) {
+                .pointerInput(subtitleText, textLayout, textLayerOrigin, subtitleDelaySeconds) {
                     detectTapGestures(
                         onTap = { position ->
                             val layout = textLayout ?: return@detectTapGestures
-                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue)
+                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue, subtitleDelaySeconds)
                                 ?.offsetBy(textLayerOrigin)
                                 ?.let(onLookup)
                         },
                         onLongPress = { position ->
                             val layout = textLayout ?: return@detectTapGestures
-                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue)
+                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue, subtitleDelaySeconds)
                                 ?.offsetBy(textLayerOrigin)
                                 ?.let(onLookup)
                         },
@@ -971,19 +975,20 @@ private data class SubtitleLookupSelection(
     val cueEndSeconds: Double? = null,
 )
 
-private fun String.hasLookupCharacters(): Boolean = any { it.isLetterOrDigit() }
+private fun String.hasLookupCharacters(): Boolean = any { it.isSubtitleLookupChar() }
 
 private fun TextLayoutResult.subtitleLookupSelectionForTap(
     text: String,
     position: Offset,
     cue: PlayerViewModel.SubtitleCue?,
+    subtitleDelaySeconds: Double,
 ): SubtitleLookupSelection? {
     if (text.isBlank()) return null
     val offset = lookupOffsetForPosition(text, position) ?: return null
-    val lookupStart = text.lookupStartNear(offset) ?: return null
-    val lookupString = extractOcrLookupString(text, lookupStart).take(80).trim()
+    if (offset !in text.indices || !isLookupStartChar(text[offset])) return null
+    val lookupString = extractOcrLookupString(text, offset).take(80).trim()
     if (lookupString.isBlank()) return null
-    val anchor = lookupAnchorRect(text, lookupStart, lookupString) ?: return null
+    val anchor = lookupAnchorRect(text, offset, lookupString) ?: return null
     val lineIndex = getLineForOffset(offset.coerceIn(0, text.lastIndex))
     val lineStart = getLineStart(lineIndex)
     val lineEnd = getLineEnd(lineIndex, visibleEnd = true).coerceAtLeast(lineStart)
@@ -993,7 +998,7 @@ private fun TextLayoutResult.subtitleLookupSelectionForTap(
     return SubtitleLookupSelection(
         lookupString = lookupString,
         fullText = text,
-        charOffset = lookupStart,
+        charOffset = offset,
         tapCharOffset = offset,
         lineText = lineText,
         lineIndex = lineIndex,
@@ -1006,8 +1011,8 @@ private fun TextLayoutResult.subtitleLookupSelectionForTap(
         lineTop = lineBounds.top,
         lineWidth = lineBounds.width,
         lineHeight = lineBounds.height,
-        cueStartSeconds = cue?.positionSeconds?.toDouble(),
-        cueEndSeconds = cue?.endPositionSeconds?.toDouble(),
+        cueStartSeconds = cue?.positionSeconds?.plus(subtitleDelaySeconds),
+        cueEndSeconds = cue?.endPositionSeconds?.plus(subtitleDelaySeconds),
     )
 }
 
@@ -1029,35 +1034,11 @@ private fun SubtitleLookupSelection.offsetBy(offset: Offset): SubtitleLookupSele
 
 private fun TextLayoutResult.lookupOffsetForPosition(text: String, position: Offset): Int? {
     if (text.isBlank()) return null
-    val rawOffset = getOffsetForPosition(position).coerceIn(0, text.lastIndex)
-    val candidates = buildList {
-        add(rawOffset)
-        add(rawOffset - 1)
-        add(rawOffset + 1)
-        add(rawOffset - 2)
-        add(rawOffset + 2)
-    }.filter { it in text.indices }.distinct()
-
-    for (offset in candidates) {
-        val char = text[offset]
-        if (!isLookupStartChar(char) && !char.isLetterOrDigit()) continue
-        val box = getBoundingBox(offset)
-        val slop = (box.height * 0.35f).coerceIn(6f, 18f)
-        if (
-            position.x >= box.left - slop &&
-            position.x <= box.right + slop &&
-            position.y >= box.top - slop &&
-            position.y <= box.bottom + slop
-        ) {
-            return offset
-        }
-    }
-
-    val lineIndex = getLineForOffset(rawOffset)
+    val lineIndex = getLineForVerticalPosition(position.y).coerceIn(0, lineCount - 1)
     val lineStart = getLineStart(lineIndex).coerceIn(0, text.length)
     val lineEnd = getLineEnd(lineIndex, visibleEnd = true).coerceIn(lineStart, text.length)
     val lineBounds = lineBounds(lineIndex)
-    val verticalSlop = (lineBounds.height * 0.75f).coerceIn(12f, 34f)
+    val verticalSlop = (lineBounds.height * 0.55f).coerceIn(10f, 28f)
     if (position.y < lineBounds.top - verticalSlop || position.y > lineBounds.bottom + verticalSlop) {
         return null
     }
@@ -1065,7 +1046,7 @@ private fun TextLayoutResult.lookupOffsetForPosition(text: String, position: Off
     return (lineStart until lineEnd)
         .filter { offset ->
             val char = text[offset]
-            isLookupStartChar(char) || char.isLetterOrDigit()
+            char.isSubtitleLookupChar()
         }
         .mapNotNull { offset ->
             val box = getBoundingBox(offset)
@@ -1080,10 +1061,13 @@ private fun TextLayoutResult.lookupOffsetForPosition(text: String, position: Off
                 position.y > box.bottom -> position.y - box.bottom
                 else -> 0f
             }
-            val horizontalLimit = (box.width * 1.8f).coerceIn(18f, 42f)
-            val verticalLimit = (box.height * 1.1f).coerceIn(16f, 38f)
+            val horizontalLimit = (box.width * 0.9f).coerceIn(10f, 28f)
+            val verticalLimit = (box.height * 0.8f).coerceIn(12f, 30f)
             if (dx <= horizontalLimit && dy <= verticalLimit) {
-                offset to (dx * 1.35f + dy)
+                val centerX = (box.left + box.right) / 2f
+                val centerY = (box.top + box.bottom) / 2f
+                val centerDistance = abs(position.x - centerX) + abs(position.y - centerY) * 0.55f
+                offset to (dx * 2.2f + dy * 1.4f + centerDistance * 0.2f)
             } else {
                 null
             }
@@ -1097,7 +1081,7 @@ private fun TextLayoutResult.lookupAnchorRect(
     lookupStart: Int,
     lookupString: String,
 ): SubtitleAnchorRect? {
-    val matchLength = lookupString.takeWhile { it.isLetterOrDigit() || it.isKanji() || it.isKana() }
+    val matchLength = lookupString.takeWhile { isLookupStartChar(it) }
         .length
         .takeIf { it > 0 }
         ?: 1
@@ -1160,71 +1144,7 @@ private fun Char.subtitleDisplayUnits(): Double {
     }
 }
 
-private fun String.lookupStartNear(index: Int): Int? {
-    if (isEmpty()) return null
-    val start = index.coerceIn(indices)
-    if (isLookupStartChar(this[start])) return lookupTermStart(start)
-
-    for (distance in 1..3) {
-        val left = start - distance
-        if (left in indices && isLookupStartChar(this[left])) return lookupTermStart(left)
-        val right = start + distance
-        if (right in indices && isLookupStartChar(this[right])) return lookupTermStart(right)
-    }
-    return null
-}
-
-private fun String.lookupTermStart(index: Int): Int {
-    if (index !in indices) return 0
-    var start = index
-    val char = this[start]
-
-    when {
-        char.isKanji() -> {
-            while (start > 0 && this[start - 1].isKanji()) {
-                start--
-            }
-        }
-        char.isKana() -> {
-            while (start > 0 && this[start - 1].isKana()) {
-                start--
-            }
-            if (start == index && char !in commonKanaParticles && start > 0 && this[start - 1].isKanji()) {
-                start--
-                while (start > 0 && this[start - 1].isKanji()) {
-                    start--
-                }
-            }
-        }
-        char.isLetterOrDigit() -> {
-            while (start > 0 && this[start - 1].isLetterOrDigit() && this[start - 1].code <= 0x7F) {
-                start--
-            }
-        }
-    }
-
-    return start
-}
-
-private val commonKanaParticles = setOf(
-    '\u306F',
-    '\u304C',
-    '\u3092',
-    '\u306B',
-    '\u3078',
-    '\u3068',
-    '\u3082',
-    '\u3067',
-    '\u3084',
-    '\u306E',
-    '\u304B',
-    '\u306D',
-    '\u3088',
-)
-
-private fun Char.isKanji(): Boolean = this in '\u3400'..'\u9FFF' || this in '\uF900'..'\uFAFF'
-
-private fun Char.isKana(): Boolean = this in '\u3040'..'\u30FF' || this in '\u31F0'..'\u31FF'
+private fun Char.isSubtitleLookupChar(): Boolean = isLookupStartChar(this)
 
 private fun String.collapseHorizontalWhitespace(): String {
     var lastWasSpace = false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
@@ -53,6 +53,7 @@ fun PlayerPanels(
     activeSubtitleCueIndex: Int?,
     animeId: Long?,
     onSelectSubtitleCue: (Int) -> Unit,
+    onPrimarySubtitleDelayMillisChange: (Int) -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -94,6 +95,7 @@ fun PlayerPanels(
             Panels.SubtitleDelay -> {
                 SubtitleDelayPanel(
                     animeId = animeId,
+                    onPrimaryDelayChange = onPrimarySubtitleDelayMillisChange,
                     onDismissRequest = onDismissRequest,
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleDelayPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleDelayPanel.kt
@@ -74,6 +74,7 @@ import kotlin.math.roundToInt
 @Composable
 fun SubtitleDelayPanel(
     animeId: Long?,
+    onPrimaryDelayChange: (Int) -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -95,14 +96,18 @@ fun SubtitleDelayPanel(
         LaunchedEffect(speed) {
             if (speed in 0.1f..1f) MPVLib.setPropertyDouble("sub-speed", speed.toDouble())
         }
-        LaunchedEffect(delay, secondaryDelay) {
+        LaunchedEffect(delay, secondaryDelay, affectedSubtitle) {
             val finalDelay = (if (affectedSubtitle == SubtitleDelayType.Secondary) secondaryDelay else delay) / 1000.0
             when (affectedSubtitle) {
-                SubtitleDelayType.Primary -> MPVLib.setPropertyDouble("sub-delay", finalDelay)
+                SubtitleDelayType.Primary -> {
+                    MPVLib.setPropertyDouble("sub-delay", finalDelay)
+                    onPrimaryDelayChange(delay)
+                }
                 SubtitleDelayType.Secondary -> MPVLib.setPropertyDouble("secondary-sub-delay", finalDelay)
                 else -> {
                     MPVLib.setPropertyDouble("sub-delay", finalDelay)
                     MPVLib.setPropertyDouble("secondary-sub-delay", finalDelay)
+                    onPrimaryDelayChange(delay)
                 }
             }
         }
@@ -130,11 +135,13 @@ fun SubtitleDelayPanel(
             onApply = {
                 preferences.subtitlesDelayForAnime(animeId).set(delay)
                 preferences.subtitlesSecondaryDelayForAnime(animeId).set(secondaryDelay)
+                onPrimaryDelayChange(delay)
                 if (speed in 0.1f..10f) preferences.subtitlesSpeed().set(speed)
             },
             onReset = {
                 delay = 0
                 secondaryDelay = 0
+                onPrimaryDelayChange(0)
                 speed = 1f
             },
             onClose = onDismissRequest,


### PR DESCRIPTION
## Summary
- Make anime subtitle lookup follow the same exact-character behavior as manga OCR/LN lookup: tap detection still uses rendered subtitle glyph bounds, but the dictionary query now starts from the pressed character instead of walking backward into a guessed word.
- Allow short particles and endings to be looked up directly, so tapping `に` queries `に`, tapping `よ` in `よね` queries `よね`, and tapping `ね` queries `ね`.
- Propagate anime subtitle delay into parsed subtitle UI timing, including active transcript/list highlighting, click-to-seek from subtitle rows, and Anki sentence audio cuts.
- Keep the parsed subtitle timing in sync when the subtitle delay panel changes primary delay, applies saved anime-specific delay, or resets delay.
- Improve Jimaku subtitle matching by parsing season numbers from filenames such as `S01E05`, `1x05`, and `Season 1`.
- Prefer parsed media candidates that include episode/season data, include season in the auto-load cache key, score same-season files higher, and reject explicit wrong-season SRTs when the current video has a known season.

## Verification
- Ran `./gradlew.bat :app:assembleDebug --console=plain`