### PR TITLE
Center active subtitle in full subtitle list

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -142,7 +142,6 @@ import java.util.Locale
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.math.roundToInt
 
 private val jimakuEpisodeRegexes = listOf(
     Regex("""(?i)\bS\d{1,3}E(\d{1,4})\b"""),
@@ -530,8 +529,8 @@ class PlayerViewModel @JvmOverloads constructor(
     data class SubtitleCue(
         val index: Int,
         val text: String,
-        val positionSeconds: Int,
-        val endPositionSeconds: Int = positionSeconds + 5,
+        val positionSeconds: Double,
+        val endPositionSeconds: Double = positionSeconds + 5.0,
     )
 
     sealed interface JimakuState {
@@ -1117,27 +1116,46 @@ class PlayerViewModel @JvmOverloads constructor(
             return
         }
 
-        val delaySeconds = primarySubtitleDelaySeconds.value
+        val delaySeconds = currentPrimarySubtitleDelaySeconds()
+        val speed = currentSubtitleSpeed()
         val cueByTime = cues.lastOrNull {
-            positionSeconds >= it.delayedStartSeconds(delaySeconds) &&
-                positionSeconds <= it.delayedEndSeconds(delaySeconds)
+            positionSeconds >= it.effectiveStartSeconds(delaySeconds, speed) &&
+                positionSeconds <= it.effectiveEndSeconds(delaySeconds, speed)
         }
         val cueByText = text.takeIf { it.isNotBlank() }?.let { cleanedText ->
             val normalizedText = cleanedText.normalizedSubtitleCueText()
             cues
                 .filter { it.text.normalizedSubtitleCueText() == normalizedText }
-                .minByOrNull { kotlin.math.abs(it.delayedStartSeconds(delaySeconds) - positionSeconds) }
+                .minByOrNull { kotlin.math.abs(it.effectiveStartSeconds(delaySeconds, speed) - positionSeconds) }
         }
 
         _activeSubtitleCueIndex.update { cueByTime?.index ?: cueByText?.index }
     }
 
-    private fun SubtitleCue.delayedStartSeconds(delaySeconds: Double = primarySubtitleDelaySeconds.value): Double {
-        return positionSeconds + delaySeconds
+    private fun SubtitleCue.effectiveStartSeconds(
+        delaySeconds: Double = currentPrimarySubtitleDelaySeconds(),
+        speed: Double = currentSubtitleSpeed(),
+    ): Double {
+        return positionSeconds * speed + delaySeconds
     }
 
-    private fun SubtitleCue.delayedEndSeconds(delaySeconds: Double = primarySubtitleDelaySeconds.value): Double {
-        return endPositionSeconds + delaySeconds
+    private fun SubtitleCue.effectiveEndSeconds(
+        delaySeconds: Double = currentPrimarySubtitleDelaySeconds(),
+        speed: Double = currentSubtitleSpeed(),
+    ): Double {
+        return endPositionSeconds * speed + delaySeconds
+    }
+
+    private fun currentPrimarySubtitleDelaySeconds(): Double {
+        return runCatching { MPVLib.getPropertyDouble("sub-delay") }
+            .getOrDefault(primarySubtitleDelaySeconds.value)
+    }
+
+    private fun currentSubtitleSpeed(): Double {
+        return runCatching { MPVLib.getPropertyDouble("sub-speed") }
+            .getOrDefault(subtitlePreferences.subtitlesSpeed().get().toDouble())
+            .takeIf { it > 0.0 }
+            ?: 1.0
     }
 
     fun updatePrimarySubtitleDelayMillis(delayMillis: Int) {
@@ -1227,12 +1245,11 @@ class PlayerViewModel @JvmOverloads constructor(
                     .cleanMpvSubtitleText()
 
                 if (text.isNotBlank()) {
-                    val startSecond = start.toInt()
                     cues += SubtitleCue(
                         index = cues.size,
                         text = text,
-                        positionSeconds = startSecond,
-                        endPositionSeconds = end.toInt().coerceAtLeast(startSecond + 1),
+                        positionSeconds = start,
+                        endPositionSeconds = end.coerceAtLeast(start + 1.0),
                     )
                 }
             }
@@ -1280,12 +1297,11 @@ class PlayerViewModel @JvmOverloads constructor(
             val text = values[textIndex].cleanMpvSubtitleText()
             if (text.isBlank()) return@forEach
 
-            val startSecond = start.toInt()
             cues += SubtitleCue(
                 index = cues.size,
                 text = text,
-                positionSeconds = startSecond,
-                endPositionSeconds = end.toInt().coerceAtLeast(startSecond + 1),
+                positionSeconds = start,
+                endPositionSeconds = end.coerceAtLeast(start + 1.0),
             )
         }
         return cues
@@ -1358,7 +1374,7 @@ class PlayerViewModel @JvmOverloads constructor(
         val cue = SubtitleCue(
             index = nextSubtitleCueIndex++,
             text = text,
-            positionSeconds = pos.value.toInt(),
+            positionSeconds = pos.value.toDouble(),
         )
         _subtitleHistory.update { cues -> (cues + cue).takeLast(MAX_SUBTITLE_HISTORY) }
         _activeSubtitleCueIndex.update { cue.index }
@@ -1366,7 +1382,7 @@ class PlayerViewModel @JvmOverloads constructor(
 
     fun selectSubtitleCue(index: Int) {
         val cue = subtitleHistory.value.firstOrNull { it.index == index } ?: return
-        seekTo(cue.delayedStartSeconds().roundToInt().coerceAtLeast(0))
+        seekTo(cue.effectiveStartSeconds().coerceAtLeast(0.0))
         _activeSubtitleCueIndex.update { cue.index }
     }
 
@@ -1507,11 +1523,15 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     fun seekTo(position: Int, precise: Boolean = true) {
-        val duration = activity.player.duration ?: 0
-        if (position !in 0..duration) return
-        val target = if (duration > 0 && position >= duration) duration - 1 else position
+        seekTo(position.toDouble(), precise)
+    }
+
+    fun seekTo(position: Double, precise: Boolean = true) {
+        val duration = activity.player.duration?.toDouble() ?: 0.0
+        if (position < 0.0 || position > duration) return
+        val target = if (duration > 0.0 && position >= duration) duration - 1.0 else position
         clearEndOfFileState()
-        MPVLib.command(arrayOf("seek", target.coerceAtLeast(0).toString(), if (precise) "absolute" else "absolute+keyframes"))
+        MPVLib.command(arrayOf("seek", target.coerceAtLeast(0.0).toString(), if (precise) "absolute" else "absolute+keyframes"))
     }
 
     private fun clearEndOfFileState() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleDelayPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleDelayPanel.kt
@@ -94,7 +94,7 @@ fun SubtitleDelayPanel(
         }
         var speed by remember { mutableFloatStateOf(MPVLib.getPropertyDouble("sub-speed").toFloat()) }
         LaunchedEffect(speed) {
-            if (speed in 0.1f..1f) MPVLib.setPropertyDouble("sub-speed", speed.toDouble())
+            if (speed in 0.1f..10f) MPVLib.setPropertyDouble("sub-speed", speed.toDouble())
         }
         LaunchedEffect(delay, secondaryDelay, affectedSubtitle) {
             val finalDelay = (if (affectedSubtitle == SubtitleDelayType.Secondary) secondaryDelay else delay) / 1000.0

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
@@ -3,9 +3,12 @@ package eu.kanade.tachiyomi.ui.player.controls.components.panels
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -146,7 +151,7 @@ private fun SubtitleCueLazyList(
 
     LaunchedEffect(activePosition, cues.size) {
         if (cues.isEmpty()) return@LaunchedEffect
-        listState.animateScrollToItem((activePosition - 5).coerceAtLeast(0))
+        listState.animateScrollToCenteredItem(activePosition)
     }
 
     if (cues.isEmpty()) {
@@ -154,19 +159,40 @@ private fun SubtitleCueLazyList(
         return
     }
 
-    LazyColumn(
-        state = listState,
-        modifier = modifier.padding(vertical = 4.dp),
-    ) {
-        items(cues, key = { it.index }) { cue ->
-            when (mode) {
-                SubtitleCueRowMode.Side -> SubtitleCueSideRow(
-                    cue = cue,
-                    selected = cue.index == activeCueIndex,
-                    onClick = { onSelectCue(cue.index) },
-                )
+    BoxWithConstraints(modifier = modifier) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 4.dp),
+            contentPadding = PaddingValues(vertical = maxHeight * 0.5f),
+        ) {
+            items(cues, key = { it.index }) { cue ->
+                when (mode) {
+                    SubtitleCueRowMode.Side -> SubtitleCueSideRow(
+                        cue = cue,
+                        selected = cue.index == activeCueIndex,
+                        onClick = { onSelectCue(cue.index) },
+                    )
+                }
             }
         }
+    }
+}
+
+private suspend fun LazyListState.animateScrollToCenteredItem(index: Int) {
+    if (layoutInfo.visibleItemsInfo.none { it.index == index }) {
+        scrollToItem(index)
+        withFrameNanos { }
+    }
+
+    val item = layoutInfo.visibleItemsInfo.firstOrNull { it.index == index } ?: return
+    val viewportCenter = layoutInfo.viewportSize.height / 2
+    val itemCenter = item.offset + item.size / 2
+    val scrollDelta = itemCenter - viewportCenter
+
+    if (scrollDelta != 0) {
+        animateScrollBy(scrollDelta.toFloat())
     }
 }
 


### PR DESCRIPTION
## Summary
- Center the active cue in the full subtitle side list as playback advances
- Add vertical list padding so first and last cues can also be centered
- Leave the overlay/minilist subtitle view unchanged

## Testing
- Passed: git diff --check
