### PR TITLE
Fix player stream and subtitle state persistence

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1199,13 +1199,21 @@ class PlayerActivity : BaseActivity() {
                     arrayOf(
                         "set",
                         "start",
-                        "${resumePosition.resetIfCompleted(episode.total_seconds) / 1000F}",
+                        "${resumePosition.resetIfCompleted(episode.total_seconds, episode.seen) / 1000F}",
                     ),
                 )
             }
         } else {
             player.timePos?.let {
-                MPVLib.command(arrayOf("set", "start", "${player.timePos}"))
+                val currentPosition = it * 1000L
+                val currentDuration = player.duration?.toLong()?.times(1000L) ?: 0L
+                MPVLib.command(
+                    arrayOf(
+                        "set",
+                        "start",
+                        "${currentPosition.resetIfCompleted(currentDuration) / 1000F}",
+                    ),
+                )
             }
         }
         if (video.videoUrl.startsWith(TorrentServerUtils.hostUrl) ||
@@ -1305,9 +1313,13 @@ class PlayerActivity : BaseActivity() {
         // MPVLib.setOptionString("cache-dir", cacheDir)
     }
 
-    private fun Long.resetIfCompleted(total: Long): Long {
-        if (this <= 0L || total <= 0L) return this.coerceAtLeast(0L)
-        return if (this >= total - COMPLETED_RESUME_GRACE_MS) 0L else this
+    private fun Long.resetIfCompleted(total: Long, seen: Boolean = false): Long {
+        val position = coerceAtLeast(0L)
+        if (position == 0L) return position
+        if (total > 0L) {
+            return if (position >= total - COMPLETED_RESUME_GRACE_MS) 0L else position
+        }
+        return if (seen) 0L else position
     }
 
     /**
@@ -1396,10 +1408,11 @@ class PlayerActivity : BaseActivity() {
 
         val audioTracks = viewModel.currentVideo.value?.audioTracks?.takeIf { it.isNotEmpty() }
         val subtitleTracks = viewModel.currentVideo.value?.subtitleTracks?.takeIf { it.isNotEmpty() }
+        val restoredSubtitleCount = viewModel.restoreAddedSubtitlesForCurrentEpisode()
 
         // If no external audio or subtitle tracks are present, loadTracks() won't be
         // called and we need to call onFinishLoadingTracks() manually
-        if (audioTracks == null && subtitleTracks == null) {
+        if (audioTracks == null && subtitleTracks == null && restoredSubtitleCount == 0) {
             viewModel.onFinishLoadingTracks()
             return
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -502,11 +502,13 @@ class PlayerViewModel @JvmOverloads constructor(
      * or select the first one in the list if trackSelect fails.
      */
     fun onFinishLoadingTracks() {
-        val preferredSubtitle = trackSelect.getPreferredTrackIndex(subtitleTracks.value)
-        (preferredSubtitle ?: subtitleTracks.value.firstOrNull())?.let {
-            activity.player.sid = it.id
-            activity.player.secondarySid = -1
-            applyParsedSubtitleCuesForTrack(it.id)
+        if (!restoreSubtitleSelectionForCurrentEpisode()) {
+            val preferredSubtitle = trackSelect.getPreferredTrackIndex(subtitleTracks.value)
+            (preferredSubtitle ?: subtitleTracks.value.firstOrNull())?.let {
+                activity.player.sid = it.id
+                activity.player.secondarySid = -1
+                applyParsedSubtitleCuesForTrack(it.id)
+            }
         }
 
         val preferredAudio = trackSelect.getPreferredTrackIndex(audioTracks.value, subtitle = false)
@@ -610,12 +612,21 @@ class PlayerViewModel @JvmOverloads constructor(
             ?: return
         val name = if (isContentUri) uri.getFileName(activity) else null
         val parsedCues = parseSubtitleUriOrPath(uri, path, name)
+        val title = name ?: subtitleTitleFromUriOrPath(uri, path)
+        rememberAddedSubtitleForCurrentEpisode(
+            AddedSubtitleTrack(
+                uriString = url,
+                path = path,
+                title = title,
+                isContentUri = isContentUri,
+            ),
+        )
         if (name == null) {
             MPVLib.command(arrayOf("sub-add", path, "cached"))
         } else {
             MPVLib.command(arrayOf("sub-add", path, "cached", name))
         }
-        rememberParsedSubtitleCues(name ?: subtitleTitleFromUriOrPath(uri, path), parsedCues)
+        rememberParsedSubtitleCues(title, parsedCues)
         loadTracks()
     }
 
@@ -624,7 +635,7 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     fun updateJimakuTitle(title: String) {
-        subtitlePreferences.jimakuTitle().set(title.trim())
+        subtitlePreferences.jimakuTitleForAnime(currentAnime.value?.id).set(title.trim())
     }
 
     fun getCurrentJimakuTitle(): String {
@@ -746,6 +757,14 @@ class PlayerViewModel @JvmOverloads constructor(
                 _jimakuState.update { JimakuState.Downloading(file) }
                 val subtitleFile = jimakuApi.downloadFile(apiKey, file, outputDir)
                 rememberParsedSubtitleFile(subtitleFile, file.name)
+                rememberAddedSubtitleForCurrentEpisode(
+                    AddedSubtitleTrack(
+                        uriString = subtitleFile.toURI().toString(),
+                        path = subtitleFile.absolutePath,
+                        title = file.name,
+                        isContentUri = false,
+                    ),
+                )
                 withUIContext {
                     MPVLib.command(arrayOf("sub-add", subtitleFile.absolutePath, "cached", file.name))
                 }
@@ -796,7 +815,7 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     private fun guessCurrentJimakuMedia(): JimakuMediaGuess {
-        val overrideTitle = subtitlePreferences.jimakuTitle().get().trim()
+        val overrideTitle = subtitlePreferences.jimakuTitleForAnime(currentAnime.value?.id).get().trim()
         val candidates = listOfNotNull(
             currentAnime.value?.title,
             animeTitle.value.takeIf { it.isNotBlank() },
@@ -1343,6 +1362,7 @@ class PlayerViewModel @JvmOverloads constructor(
         activity.player.secondarySid = _selectedSubtitles.value.second
         activity.player.sid = _selectedSubtitles.value.first
         applyParsedSubtitleCuesForSelectedTrack()
+        rememberSubtitleSelectionForCurrentEpisode()
     }
 
     fun updateSubtitle(sid: Int, secondarySid: Int) {
@@ -1943,6 +1963,34 @@ class PlayerViewModel @JvmOverloads constructor(
             field = value
         }
 
+    private var preferredHosterKey = savedState.get<String>("preferred_hoster_key")
+        set(value) {
+            savedState["preferred_hoster_key"] = value
+            field = value
+        }
+
+    private var preferredVideoKey = savedState.get<String>("preferred_video_key")
+        set(value) {
+            savedState["preferred_video_key"] = value
+            field = value
+        }
+
+    private data class AddedSubtitleTrack(
+        val uriString: String,
+        val path: String,
+        val title: String?,
+        val isContentUri: Boolean,
+    )
+
+    private data class SubtitleTrackSelection(
+        val primaryKey: String?,
+        val secondaryKey: String?,
+    )
+
+    private val addedSubtitleTracksByEpisodeId = mutableMapOf<Long, MutableList<AddedSubtitleTrack>>()
+    private val subtitleTrackSelectionsByEpisodeId = mutableMapOf<Long, SubtitleTrackSelection>()
+    private var pendingSubtitleSelectionKey: String? = null
+
     /**
      * The episode id of the currently loaded episode. Used to restore from process kill.
      */
@@ -2061,6 +2109,158 @@ class PlayerViewModel @JvmOverloads constructor(
         message: String,
         val stringResource: StringResource,
     ) : Exception(message)
+
+    private fun Hoster.selectionKey(): String {
+        return hosterName.trim()
+    }
+
+    private fun Video.selectionKey(): String {
+        return listOf(
+            videoTitle,
+            resolution?.toString().orEmpty(),
+            bitrate?.toString().orEmpty(),
+        ).joinToString("\u001f")
+    }
+
+    private fun rememberPreferredVideoSelection(hosterIndex: Int, videoIndex: Int) {
+        val hoster = hosterList.value.getOrNull(hosterIndex) ?: return
+        val video = (_hosterState.value.getOrNull(hosterIndex) as? HosterState.Ready)
+            ?.videoList
+            ?.getOrNull(videoIndex)
+            ?: return
+
+        preferredHosterKey = hoster.selectionKey()
+        preferredVideoKey = video.selectionKey()
+    }
+
+    private fun findRememberedVideoIndex(hoster: Hoster, videoList: List<Video>): Int {
+        val rememberedHosterKey = preferredHosterKey ?: return -1
+        val rememberedVideoKey = preferredVideoKey ?: return -1
+        if (hoster.selectionKey() != rememberedHosterKey) return -1
+        return videoList.indexOfFirst { it.selectionKey() == rememberedVideoKey }
+    }
+
+    private fun findRequestedVideoIndex(
+        hoster: Hoster,
+        videoList: List<Video>,
+        hosterIndex: Int,
+        requestedHosterIndex: Int,
+        requestedVideoIndex: Int,
+    ): Int {
+        if (requestedHosterIndex != -1) {
+            return if (hosterIndex == requestedHosterIndex && requestedVideoIndex in videoList.indices) {
+                requestedVideoIndex
+            } else {
+                -1
+            }
+        }
+
+        return findRememberedVideoIndex(hoster, videoList)
+    }
+
+    private fun subtitleSelectionKey(title: String?, path: String?, language: String? = null): String {
+        val displayName = title?.takeIf { it.isNotBlank() }
+            ?: path?.let { File(it).name }?.takeIf { it.isNotBlank() }
+            ?: path.orEmpty()
+        return listOf(displayName, language.orEmpty()).joinToString("\u001f")
+    }
+
+    private fun VideoTrack.selectionKey(): String {
+        return subtitleSelectionKey(
+            title = name,
+            path = externalFilename,
+            language = language,
+        )
+    }
+
+    private fun AddedSubtitleTrack.selectionKey(): String {
+        return subtitleSelectionKey(
+            title = title,
+            path = if (isContentUri) uriString else path,
+        )
+    }
+
+    private fun currentSubtitleEpisodeId(): Long? {
+        return currentEpisode.value?.id
+    }
+
+    private fun rememberAddedSubtitleForCurrentEpisode(track: AddedSubtitleTrack) {
+        val episodeId = currentSubtitleEpisodeId() ?: return
+        val tracks = addedSubtitleTracksByEpisodeId.getOrPut(episodeId) { mutableListOf() }
+        val sourceKey = if (track.isContentUri) track.uriString else track.path
+        if (tracks.none { existing ->
+                existing.isContentUri == track.isContentUri &&
+                    (if (existing.isContentUri) existing.uriString else existing.path) == sourceKey
+            }
+        ) {
+            tracks += track
+        }
+        pendingSubtitleSelectionKey = track.selectionKey()
+    }
+
+    private fun rememberSubtitleSelectionForCurrentEpisode() {
+        val episodeId = currentSubtitleEpisodeId() ?: return
+        val (primarySid, secondarySid) = selectedSubtitles.value
+        val tracks = subtitleTracks.value
+        subtitleTrackSelectionsByEpisodeId[episodeId] = SubtitleTrackSelection(
+            primaryKey = tracks.firstOrNull { it.id == primarySid }?.selectionKey(),
+            secondaryKey = tracks.firstOrNull { it.id == secondarySid }?.selectionKey(),
+        )
+    }
+
+    fun restoreAddedSubtitlesForCurrentEpisode(): Int {
+        val episodeId = currentSubtitleEpisodeId() ?: return 0
+        val tracks = addedSubtitleTracksByEpisodeId[episodeId].orEmpty()
+        var restored = 0
+        tracks.forEach { track ->
+            val path = if (track.isContentUri) {
+                Uri.parse(track.uriString).openContentFd(activity)
+            } else {
+                track.path
+            } ?: return@forEach
+
+            if (track.title == null) {
+                MPVLib.command(arrayOf("sub-add", path, "cached"))
+            } else {
+                MPVLib.command(arrayOf("sub-add", path, "cached", track.title))
+            }
+            restored += 1
+        }
+        return restored
+    }
+
+    private fun restoreSubtitleSelectionForCurrentEpisode(): Boolean {
+        val episodeId = currentSubtitleEpisodeId() ?: return false
+        val tracks = subtitleTracks.value
+        val savedSelection = subtitleTrackSelectionsByEpisodeId[episodeId]
+
+        if (savedSelection != null && savedSelection.primaryKey == null) {
+            activity.player.secondarySid = -1
+            activity.player.sid = -1
+            _selectedSubtitles.update { Pair(-1, -1) }
+            applyParsedSubtitleCuesForTrack(-1)
+            pendingSubtitleSelectionKey = null
+            return true
+        }
+
+        val primaryKey = savedSelection?.primaryKey
+            ?: pendingSubtitleSelectionKey
+            ?: addedSubtitleTracksByEpisodeId[episodeId]?.lastOrNull()?.selectionKey()
+            ?: return false
+        val primaryTrack = tracks.firstOrNull { it.selectionKey() == primaryKey } ?: return false
+        val secondaryTrack = savedSelection
+            ?.secondaryKey
+            ?.let { secondaryKey ->
+                tracks.firstOrNull { track -> track.id != primaryTrack.id && track.selectionKey() == secondaryKey }
+            }
+
+        activity.player.secondarySid = secondaryTrack?.id ?: -1
+        activity.player.sid = primaryTrack.id
+        _selectedSubtitles.update { Pair(primaryTrack.id, secondaryTrack?.id ?: -1) }
+        applyParsedSubtitleCuesForTrack(primaryTrack.id)
+        pendingSubtitleSelectionKey = null
+        return true
+    }
 
     fun loadStandaloneVideo(video: Video) {
         currentHosterList = null
@@ -2207,6 +2407,7 @@ class PlayerViewModel @JvmOverloads constructor(
      */
     fun loadHosters(source: AnimeSource, hosterList: List<Hoster>, hosterIndex: Int, videoIndex: Int) {
         val hasFoundPreferredVideo = AtomicBoolean(false)
+        val hasRequestedVideo = hosterIndex != -1 || (preferredHosterKey != null && preferredVideoKey != null)
 
         _hosterList.update { _ -> hosterList }
         _hosterExpandedList.update { _ ->
@@ -2239,10 +2440,23 @@ class PlayerViewModel @JvmOverloads constructor(
                             _hosterState.updateAt(hosterIdx, hosterState)
 
                             if (hosterState is HosterState.Ready) {
-                                if (hosterIdx == hosterIndex) {
-                                    hosterState.videoList.getOrNull(videoIndex)?.let {
+                                val targetVideoIndex = findRequestedVideoIndex(
+                                    hoster = hoster,
+                                    videoList = hosterState.videoList,
+                                    hosterIndex = hosterIdx,
+                                    requestedHosterIndex = hosterIndex,
+                                    requestedVideoIndex = videoIndex,
+                                )
+                                if (targetVideoIndex != -1 && hasFoundPreferredVideo.compareAndSet(false, true)) {
+                                    hosterState.videoList.getOrNull(targetVideoIndex)?.let {
                                         hasFoundPreferredVideo.set(true)
-                                        val success = loadVideo(source, it, hosterIndex, videoIndex)
+                                        val success = loadVideo(
+                                            source,
+                                            it,
+                                            hosterIdx,
+                                            targetVideoIndex,
+                                            rememberSelection = hosterIndex != -1,
+                                        )
                                         if (!success) {
                                             hasFoundPreferredVideo.set(false)
                                         }
@@ -2250,7 +2464,7 @@ class PlayerViewModel @JvmOverloads constructor(
                                 }
 
                                 val prefIndex = hosterState.videoList.indexOfFirst { it.preferred }
-                                if (prefIndex != -1 && hosterIndex == -1) {
+                                if (prefIndex != -1 && hosterIndex == -1 && !hasRequestedVideo) {
                                     if (hasFoundPreferredVideo.compareAndSet(false, true)) {
                                         if (selectedHosterVideoIndex.value == Pair(-1, -1)) {
                                             val success =
@@ -2259,6 +2473,7 @@ class PlayerViewModel @JvmOverloads constructor(
                                                     hosterState.videoList[prefIndex],
                                                     hosterIdx,
                                                     prefIndex,
+                                                    rememberSelection = false,
                                                 )
                                             if (!success) {
                                                 hasFoundPreferredVideo.set(false)
@@ -2278,7 +2493,7 @@ class PlayerViewModel @JvmOverloads constructor(
 
                         val video = (hosterState.value[hosterIdx] as HosterState.Ready).videoList[videoIdx]
 
-                        loadVideo(source, video, hosterIdx, videoIdx)
+                        loadVideo(source, video, hosterIdx, videoIdx, rememberSelection = false)
                     }
                 }
             } catch (e: CancellationException) {
@@ -2291,7 +2506,13 @@ class PlayerViewModel @JvmOverloads constructor(
         }
     }
 
-    private suspend fun loadVideo(source: AnimeSource?, video: Video, hosterIndex: Int, videoIndex: Int): Boolean {
+    private suspend fun loadVideo(
+        source: AnimeSource?,
+        video: Video,
+        hosterIndex: Int,
+        videoIndex: Int,
+        rememberSelection: Boolean = false,
+    ): Boolean {
         val selectedHosterState = (_hosterState.value[hosterIndex] as? HosterState.Ready) ?: return false
         updateIsLoadingEpisode(true)
 
@@ -2332,7 +2553,7 @@ class PlayerViewModel @JvmOverloads constructor(
 
                 val newVideo = (hosterState.value[newHosterIdx] as HosterState.Ready).videoList[newVideoIdx]
 
-                return loadVideo(source, newVideo, newHosterIdx, newVideoIdx)
+                return loadVideo(source, newVideo, newHosterIdx, newVideoIdx, rememberSelection = false)
             } else {
                 _selectedHosterVideoIndex.update { _ -> oldSelectedIndex }
                 _hosterState.updateAt(
@@ -2351,6 +2572,9 @@ class PlayerViewModel @JvmOverloads constructor(
         _currentVideo.update { _ -> resolvedVideo }
 
         qualityIndex = Pair(hosterIndex, videoIndex)
+        if (rememberSelection) {
+            rememberPreferredVideoSelection(hosterIndex, videoIndex)
+        }
 
         activity.setVideo(resolvedVideo)
         return true
@@ -2371,7 +2595,13 @@ class PlayerViewModel @JvmOverloads constructor(
         }
 
         viewModelScope.launchIO {
-            val success = loadVideo(currentSource.value, video, hosterIndex, videoIndex)
+            val success = loadVideo(
+                currentSource.value,
+                video,
+                hosterIndex,
+                videoIndex,
+                rememberSelection = true,
+            )
             if (success) {
                 if (sheetShown.value == Sheets.QualityTracks) {
                     dismissSheet()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -80,6 +80,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -161,6 +162,8 @@ fun PlayerControls(
     val subtitleCues by viewModel.subtitleHistory.collectAsState()
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
     val primarySubtitleDelaySeconds by viewModel.primarySubtitleDelaySeconds.collectAsState()
+    val panel by viewModel.panelShown.collectAsState()
+    val isSubtitleOverlayListShown = panel == Panels.SubtitleOverlayList
     val activeSubtitleCue = remember(subtitleCues, activeSubtitleCueIndex) {
         subtitleCues.firstOrNull { it.index == activeSubtitleCueIndex }
     }
@@ -194,9 +197,10 @@ fun PlayerControls(
         label = "controls_transparent_overlay",
     )
     val openSubtitleLookup: (SubtitleLookupSelection) -> Unit = openSubtitleLookup@{ subtitleLookup ->
+        val currentPanel = viewModel.panelShown.value
         if (
             viewModel.sheetShown.value != Sheets.None ||
-            viewModel.panelShown.value != Panels.None ||
+            (currentPanel != Panels.None && currentPanel != Panels.SubtitleOverlayList) ||
             viewModel.dialogShown.value != Dialogs.None
         ) {
             return@openSubtitleLookup
@@ -260,13 +264,29 @@ fun PlayerControls(
                 viewModel.unpause()
             })
         }
-        PlayerSubtitleTextLayer(
-            text = currentSubtitleText,
-            cue = activeSubtitleCue,
-            subtitleDelaySeconds = primarySubtitleDelaySeconds,
-            request = subtitleLookupRequest,
-            onLookup = openSubtitleLookup,
-        )
+        if (isSubtitleOverlayListShown) {
+            PlayerSubtitleTextLayer(
+                text = activeSubtitleCue?.text ?: currentSubtitleText,
+                cue = activeSubtitleCue,
+                subtitleDelaySeconds = primarySubtitleDelaySeconds,
+                request = subtitleLookupRequest,
+                onLookup = openSubtitleLookup,
+                bottomPadding = 84.dp,
+                widthFraction = 0.56f,
+                maxWidth = 520.dp,
+                fontSizeFactor = 0.42f,
+                minFontSize = 14f,
+                maxFontSize = 30f,
+            )
+        } else {
+            PlayerSubtitleTextLayer(
+                text = currentSubtitleText,
+                cue = activeSubtitleCue,
+                subtitleDelaySeconds = primarySubtitleDelaySeconds,
+                request = subtitleLookupRequest,
+                onLookup = openSubtitleLookup,
+            )
+        }
     }
     DoubleTapToSeekOvals(doubleTapSeekAmount, seekText, interactionSource)
     CompositionLocalProvider(
@@ -719,7 +739,8 @@ fun PlayerControls(
         val subtitles by viewModel.subtitleTracks.collectAsState()
         val selectedSubtitles by viewModel.selectedSubtitles.collectAsState()
         val jimakuState by viewModel.jimakuState.collectAsState()
-        val jimakuTitle by subtitlePreferences.jimakuTitle().collectAsState()
+        val anime by viewModel.currentAnime.collectAsState()
+        val jimakuTitle by subtitlePreferences.jimakuTitleForAnime(anime?.id).collectAsState()
         val audioTracks by viewModel.audioTracks.collectAsState()
         val selectedAudio by viewModel.selectedAudio.collectAsState()
         val isLoadingHosters by viewModel.isLoadingHosters.collectAsState()
@@ -732,7 +753,6 @@ fun PlayerControls(
         val showSubtitles by subtitlePreferences.screenshotSubtitles().collectAsState()
         val showFailedHosters by playerPreferences.showFailedHosters().collectAsState()
         val emptyHosters by playerPreferences.showEmptyHosters().collectAsState()
-        val anime by viewModel.currentAnime.collectAsState()
 
         PlayerSheets(
             sheetShown = sheetShown,
@@ -792,7 +812,6 @@ fun PlayerControls(
             onDismissRequest = { viewModel.showSheet(Sheets.None) },
             dismissSheet = dismissSheet,
         )
-        val panel by viewModel.panelShown.collectAsState()
         PlayerPanels(
             panelShown = panel,
             subtitleCues = subtitleCues.toImmutableList(),
@@ -866,6 +885,12 @@ private fun PlayerSubtitleTextLayer(
     request: SubtitleLookupRequest?,
     onLookup: (SubtitleLookupSelection) -> Unit,
     modifier: Modifier = Modifier,
+    bottomPadding: Dp? = null,
+    widthFraction: Float = 0.92f,
+    maxWidth: Dp = 980.dp,
+    fontSizeFactor: Float = 0.52f,
+    minFontSize: Float = 18f,
+    maxFontSize: Float = 42f,
 ) {
     val subtitleText = remember(text) {
         text.lines()
@@ -887,8 +912,8 @@ private fun PlayerSubtitleTextLayer(
 
     var textLayout by remember(subtitleText) { mutableStateOf<TextLayoutResult?>(null) }
     var textLayerOrigin by remember(subtitleText) { mutableStateOf(Offset.Zero) }
-    val fontSizeSp = (subtitleFontSize * subtitleScale * 0.52f).coerceIn(18f, 42f)
-    val bottomPadding = (28f + (100 - subtitlePos).coerceIn(0, 100) * 2.2f).dp
+    val fontSizeSp = (subtitleFontSize * subtitleScale * fontSizeFactor).coerceIn(minFontSize, maxFontSize)
+    val resolvedBottomPadding = bottomPadding ?: (28f + (100 - subtitlePos).coerceIn(0, 100) * 2.2f).dp
     val outlineWidth = borderSize.coerceAtLeast(1) * 1.8f
     val baseStyle = TextStyle(
         color = Color(textColor),
@@ -903,13 +928,13 @@ private fun PlayerSubtitleTextLayer(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 24.dp)
-            .padding(bottom = bottomPadding),
+            .padding(bottom = resolvedBottomPadding),
         contentAlignment = Alignment.BottomCenter,
     ) {
         Box(
             modifier = Modifier
-                .fillMaxWidth(0.92f)
-                .widthIn(max = 980.dp)
+                .fillMaxWidth(widthFraction)
+                .widthIn(max = maxWidth)
                 .onGloballyPositioned { coordinates ->
                     textLayerOrigin = coordinates.positionInRoot()
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -103,6 +103,7 @@ import eu.kanade.tachiyomi.ui.player.controls.components.ControlsButton
 import eu.kanade.tachiyomi.ui.player.controls.components.SeekbarWithTimers
 import eu.kanade.tachiyomi.ui.player.controls.components.TextPlayerUpdate
 import eu.kanade.tachiyomi.ui.player.controls.components.VolumeSlider
+import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitlesBorderStyle
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.toFixed
 import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
 import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
@@ -906,6 +907,8 @@ private fun PlayerSubtitleTextLayer(
     val subtitlePos by subtitlePreferences.subtitlePos().collectAsState()
     val textColor by subtitlePreferences.textColorSubtitles().collectAsState()
     val borderColor by subtitlePreferences.borderColorSubtitles().collectAsState()
+    val backgroundColor by subtitlePreferences.backgroundColorSubtitles().collectAsState()
+    val borderStyle by subtitlePreferences.borderStyleSubtitles().collectAsState()
     val borderSize by subtitlePreferences.subtitleBorderSize().collectAsState()
     val bold by subtitlePreferences.boldSubtitles().collectAsState()
     val italic by subtitlePreferences.italicSubtitles().collectAsState()
@@ -915,6 +918,13 @@ private fun PlayerSubtitleTextLayer(
     val fontSizeSp = (subtitleFontSize * subtitleScale * fontSizeFactor).coerceIn(minFontSize, maxFontSize)
     val resolvedBottomPadding = bottomPadding ?: (28f + (100 - subtitlePos).coerceIn(0, 100) * 2.2f).dp
     val outlineWidth = borderSize.coerceAtLeast(1) * 1.8f
+    val boxBackgroundColor = Color(backgroundColor).let {
+        if (it.alpha == 0f && borderStyle != SubtitlesBorderStyle.OutlineAndShadow) {
+            Color.Black.copy(alpha = 0.78f)
+        } else {
+            it
+        }
+    }
     val baseStyle = TextStyle(
         color = Color(textColor),
         fontSize = fontSizeSp.sp,
@@ -940,6 +950,28 @@ private fun PlayerSubtitleTextLayer(
                 }
                 .drawBehind {
                     val layout = textLayout ?: return@drawBehind
+                    if (borderStyle != SubtitlesBorderStyle.OutlineAndShadow) {
+                        val backgroundRects = when (borderStyle) {
+                            SubtitlesBorderStyle.OpaqueBox -> layout.subtitleLineBackgroundRects(
+                                subtitleText,
+                                fullLineWidth = true,
+                            )
+                            SubtitlesBorderStyle.BackgroundBox -> layout.subtitleLineBackgroundRects(
+                                subtitleText,
+                                fullLineWidth = false,
+                            )
+                            SubtitlesBorderStyle.OutlineAndShadow -> emptyList()
+                        }
+                        backgroundRects.forEach { rect ->
+                            drawRoundRect(
+                                color = boxBackgroundColor,
+                                topLeft = Offset(rect.left, rect.top),
+                                size = Size(rect.width, rect.height),
+                                cornerRadius = CornerRadius(4f, 4f),
+                            )
+                        }
+                    }
+
                     val activeRequest = request?.takeIf { it.fullText == subtitleText } ?: return@drawBehind
                     val start = (activeRequest.charOffset + activeRequest.matchOffset)
                         .coerceIn(0, subtitleText.length)
@@ -973,15 +1005,17 @@ private fun PlayerSubtitleTextLayer(
                     )
                 },
         ) {
-            Text(
-                text = subtitleText,
-                modifier = Modifier.fillMaxWidth(),
-                color = Color(borderColor),
-                style = baseStyle.copy(
+            if (borderStyle == SubtitlesBorderStyle.OutlineAndShadow) {
+                Text(
+                    text = subtitleText,
+                    modifier = Modifier.fillMaxWidth(),
                     color = Color(borderColor),
-                    drawStyle = Stroke(width = outlineWidth),
-                ),
-            )
+                    style = baseStyle.copy(
+                        color = Color(borderColor),
+                        drawStyle = Stroke(width = outlineWidth),
+                    ),
+                )
+            }
 
             Text(
                 text = subtitleText,
@@ -1156,12 +1190,38 @@ private fun TextLayoutResult.highlightRects(text: String, start: Int, end: Int):
     return merged
 }
 
+private fun TextLayoutResult.subtitleLineBackgroundRects(text: String, fullLineWidth: Boolean): List<Rect> {
+    return (0 until lineCount).mapNotNull { lineIndex ->
+        val lineStart = getLineStart(lineIndex).coerceIn(0, text.length)
+        val lineEnd = getLineEnd(lineIndex, visibleEnd = true).coerceIn(lineStart, text.length)
+        if (text.substring(lineStart, lineEnd).isBlank()) return@mapNotNull null
+
+        val rect = if (fullLineWidth) {
+            lineBounds(lineIndex)
+        } else {
+            highlightRects(text, lineStart, lineEnd).reduceOrNull { acc, item -> acc.unionWith(item) }
+                ?: return@mapNotNull null
+        }
+
+        rect.inflate(horizontal = 10f, vertical = 4f)
+    }
+}
+
 private fun TextLayoutResult.lineBounds(lineIndex: Int): Rect {
     return Rect(
         left = getLineLeft(lineIndex),
         top = getLineTop(lineIndex),
         right = getLineRight(lineIndex),
         bottom = getLineBottom(lineIndex),
+    )
+}
+
+private fun Rect.inflate(horizontal: Float, vertical: Float): Rect {
+    return Rect(
+        left = left - horizontal,
+        top = top - vertical,
+        right = right + horizontal,
+        bottom = bottom + vertical,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
@@ -114,7 +114,7 @@ private fun SubtitleOverlayList(
 
     Column(
         modifier = modifier
-            .padding(start = 24.dp, end = 24.dp, bottom = 84.dp)
+            .padding(start = 24.dp, end = 24.dp, bottom = 132.dp)
             .widthIn(max = 520.dp)
             .fillMaxWidth(0.56f),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -123,13 +123,15 @@ private fun SubtitleOverlayList(
         if (visibleCues.isEmpty()) {
             EmptySubtitleListMessage()
         } else {
-            visibleCues.forEach { cue ->
-                SubtitleCueOverlayRow(
-                    cue = cue,
-                    selected = cue.index == activeCueIndex,
-                    onClick = { onSelectCue(cue.index) },
-                )
-            }
+            visibleCues
+                .filterNot { it.index == activeCueIndex }
+                .forEach { cue ->
+                    SubtitleCueOverlayRow(
+                        cue = cue,
+                        selected = false,
+                        onClick = { onSelectCue(cue.index) },
+                    )
+                }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
@@ -20,6 +20,10 @@ class SubtitlePreferences(
     fun subtitleBlacklist() = preferenceStore.getString("pref_subtitle_blacklist", "")
     fun jimakuApiKey() = preferenceStore.getString("pref_jimaku_api_key", "")
     fun jimakuTitle() = preferenceStore.getString("pref_jimaku_title", "")
+    fun jimakuTitleForAnime(animeId: Long?) = animeId
+        ?.takeIf { it > 0 }
+        ?.let { preferenceStore.getString("pref_jimaku_title_anime_$it", "") }
+        ?: jimakuTitle()
 
     // Non-preferences
 


### PR DESCRIPTION
## Summary

This PR fixes several player state regressions around stream selection and subtitles:

- Remembers the user-selected streaming server and quality when moving between episodes.
- Reattaches manually added and Jimaku subtitles after switching server/quality on the same episode.
- Restores the selected subtitle track after a video reload instead of falling back to the default track.
- Makes the mini subtitle overlay a replacement for the normal subtitle line, not an extra duplicate above it.
- Allows lookup/mining from the mini subtitle overlay by rendering its active line through the same interactive subtitle text layer used by normal subtitles.
- Restores support for subtitle `Opaque box` and `Background box` border styles in the Compose-rendered subtitle layer.
- Avoids reopening completed/stale episodes at the end of the video, which could leave the player on a black screen with the slider at the end.
- Scopes Jimaku title overrides per anime entry so an override for one show is not reused for unrelated entries.

## Details

### Server and quality persistence

The player previously kept only the selected hoster/video indices. Those indices were reset or became meaningless when the next episode loaded a fresh hoster/video list, so skipping episodes often returned to the source/default quality.

This PR stores stable selection keys for the selected hoster and video title/resolution/bitrate, then tries that remembered choice before falling back to source-preferred videos or the generic best-video fallback.

### Subtitle preservation on server changes

External subtitles added during playback lived only in MPV's current track list. When the same episode was reloaded with a different streaming server, MPV rebuilt the file and those added tracks disappeared.

This PR keeps per-episode records of added subtitle tracks and re-adds them during track setup after a video reload. It also remembers the selected primary/secondary subtitle tracks so the selected subtitle survives the reload.

### Mini subtitle overlay lookup/mining

The compact subtitle overlay was rendering passive `Text` rows as an extra list above the normal subtitles. This made it duplicate the normal subtitle line and prevented dictionary lookup/mining from that compact UI.

This PR changes overlay mode so the active mini subtitle replaces the normal subtitle layer and uses the existing `PlayerSubtitleTextLayer`. That keeps the small-screen layout while preserving tap/long-press lookup, term matching, and subtitle audio capture for mining.

### Subtitle box border styles

The player now renders subtitle text through Compose so lookup/highlight/mining can work on subtitles. MPV's own subtitle layer is intentionally transparent, but that meant MPV-only styles such as `Opaque box` and `Background box` were not visible even when selected.

This PR makes the Compose subtitle layer honor `SubtitlesBorderStyle` directly:

- `Outline and shadow` keeps the existing outlined subtitle text rendering.
- `Opaque box` draws line-sized background boxes behind subtitle lines.
- `Background box` draws tighter text-sized boxes behind subtitle text.

Both box styles use the configured subtitle background color. If that color is fully transparent, the renderer falls back to an opaque dark box so selecting a box style visibly works.

### Resume position guard

If an episode had a saved position near the end, especially with missing/stale duration metadata, reopening could start at the end and show a black screen. The resume logic now resets completed/stale seen progress back to the start instead of seeking to an unusable end position.

### Per-entry Jimaku titles

The Jimaku title override used a single global preference key. This caused a title entered for one anime to be reused for other entries after leaving the player. The player now reads/writes Jimaku title overrides using a per-anime preference key.

## Verification

Passed:

```powershell
.\gradlew.bat :app:compileDebugKotlin --no-daemon --console=plain --stacktrace
```

Also checked:

```powershell
.\gradlew.bat :app:spotlessCheck --no-daemon --console=plain
```

`spotlessCheck` currently fails on pre-existing unrelated formatting violations across many files, so no repo-wide formatter was applied in this PR.