### PR TITLE
Fix subtitle regex filters and resume position

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -85,6 +85,7 @@ import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import eu.kanade.tachiyomi.ui.player.utils.ChapterUtils
 import eu.kanade.tachiyomi.ui.player.utils.ChapterUtils.Companion.getStringRes
+import eu.kanade.tachiyomi.ui.player.utils.safeResumePositionMillis
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
@@ -115,8 +116,6 @@ import java.io.OutputStream
 import java.util.Calendar
 import kotlin.math.ceil
 import kotlin.math.floor
-
-private const val COMPLETED_RESUME_GRACE_MS = 1_500L
 
 class PlayerActivity : BaseActivity() {
     private val viewModel by viewModels<PlayerViewModel>(factoryProducer = { PlayerViewModelProviderFactory(this) })
@@ -1276,7 +1275,13 @@ class PlayerActivity : BaseActivity() {
                     arrayOf(
                         "set",
                         "start",
-                        "${resumePosition.resetIfCompleted(episode.total_seconds, episode.seen) / 1000F}",
+                        "${
+                            resumePosition.safeResumePositionMillis(
+                                totalMillis = episode.total_seconds,
+                                seen = episode.seen,
+                                resetWhenDurationUnknown = true,
+                            ) / 1000F
+                        }",
                     ),
                 )
             }
@@ -1288,7 +1293,7 @@ class PlayerActivity : BaseActivity() {
                     arrayOf(
                         "set",
                         "start",
-                        "${currentPosition.resetIfCompleted(currentDuration) / 1000F}",
+                        "${currentPosition.safeResumePositionMillis(currentDuration) / 1000F}",
                     ),
                 )
             }
@@ -1388,15 +1393,6 @@ class PlayerActivity : BaseActivity() {
         // MPVLib.setOptionString("cache-on-disk", "yes")
         // val cacheDir = File(applicationContext.filesDir, "media").path
         // MPVLib.setOptionString("cache-dir", cacheDir)
-    }
-
-    private fun Long.resetIfCompleted(total: Long, seen: Boolean = false): Long {
-        val position = coerceAtLeast(0L)
-        if (position == 0L) return position
-        if (total > 0L) {
-            return if (position >= total - COMPLETED_RESUME_GRACE_MS) 0L else position
-        }
-        return if (seen) 0L else position
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerEnums.kt
@@ -103,7 +103,6 @@ enum class Sheets {
 enum class Panels {
     None,
     SubtitleSideList,
-    SubtitleOverlayList,
     SubtitleSettings,
     SubtitleDelay,
     SubtitleRegex,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -44,7 +44,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FormatListBulleted
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Subtitles
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.MaterialTheme
@@ -160,7 +159,6 @@ fun PlayerControls(
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
     val primarySubtitleDelaySeconds by viewModel.primarySubtitleDelaySeconds.collectAsState()
     val panel by viewModel.panelShown.collectAsState()
-    val isSubtitleOverlayListShown = panel == Panels.SubtitleOverlayList
     val activeSubtitleCue = remember(subtitleCues, activeSubtitleCueIndex) {
         subtitleCues.firstOrNull { it.index == activeSubtitleCueIndex }
     }
@@ -194,7 +192,7 @@ fun PlayerControls(
         val currentPanel = viewModel.panelShown.value
         if (
             viewModel.sheetShown.value != Sheets.None ||
-            (currentPanel != Panels.None && currentPanel != Panels.SubtitleOverlayList) ||
+            currentPanel != Panels.None ||
             viewModel.dialogShown.value != Dialogs.None
         ) {
             return@openSubtitleLookup
@@ -246,29 +244,13 @@ fun PlayerControls(
                 viewModel.unpause()
             })
         }
-        if (isSubtitleOverlayListShown) {
-            PlayerSubtitleTextLayer(
-                text = activeSubtitleCue?.text ?: currentSubtitleText,
-                cue = activeSubtitleCue,
-                subtitleDelaySeconds = primarySubtitleDelaySeconds,
-                request = subtitleLookupRequest,
-                onLookup = openSubtitleLookup,
-                bottomPadding = 84.dp,
-                widthFraction = 0.56f,
-                maxWidth = 520.dp,
-                fontSizeFactor = 0.42f,
-                minFontSize = 14f,
-                maxFontSize = 30f,
-            )
-        } else {
-            PlayerSubtitleTextLayer(
-                text = currentSubtitleText,
-                cue = activeSubtitleCue,
-                subtitleDelaySeconds = primarySubtitleDelaySeconds,
-                request = subtitleLookupRequest,
-                onLookup = openSubtitleLookup,
-            )
-        }
+        PlayerSubtitleTextLayer(
+            text = currentSubtitleText,
+            cue = activeSubtitleCue,
+            subtitleDelaySeconds = primarySubtitleDelaySeconds,
+            request = subtitleLookupRequest,
+            onLookup = openSubtitleLookup,
+        )
     }
     DoubleTapToSeekOvals(doubleTapSeekAmount, seekText, interactionSource)
     CompositionLocalProvider(
@@ -510,23 +492,12 @@ fun PlayerControls(
                         bottom.linkTo(parent.bottom)
                     },
                 ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.medium),
-                    ) {
-                        ControlsButton(
-                            icon = Icons.Default.FormatListBulleted,
-                            onClick = { togglePanel(Panels.SubtitleSideList) },
-                            horizontalSpacing = MaterialTheme.padding.mediumSmall,
-                            iconSize = MaterialTheme.padding.large,
-                        )
-                        ControlsButton(
-                            icon = Icons.Default.Subtitles,
-                            onClick = { togglePanel(Panels.SubtitleOverlayList) },
-                            horizontalSpacing = MaterialTheme.padding.mediumSmall,
-                            iconSize = MaterialTheme.padding.large,
-                        )
-                    }
+                    ControlsButton(
+                        icon = Icons.Default.FormatListBulleted,
+                        onClick = { togglePanel(Panels.SubtitleSideList) },
+                        horizontalSpacing = MaterialTheme.padding.mediumSmall,
+                        iconSize = MaterialTheme.padding.large,
+                    )
                 }
                 AnimatedVisibility(
                     visible = (controlsShown || seekBarShown) && !areControlsLocked,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
@@ -38,7 +38,6 @@ import eu.kanade.tachiyomi.ui.player.PlayerViewModel.SubtitleCue
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.AudioDelayPanel
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitleDelayPanel
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitleListPanel
-import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitleListPanelMode
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitleRegexPanel
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitleSettingsPanel
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.VideoFiltersPanel
@@ -76,16 +75,6 @@ fun PlayerPanels(
             }
             Panels.SubtitleSideList -> {
                 SubtitleListPanel(
-                    mode = SubtitleListPanelMode.SideList,
-                    cues = subtitleCues,
-                    activeCueIndex = activeSubtitleCueIndex,
-                    onSelectCue = onSelectSubtitleCue,
-                    onDismissRequest = onDismissRequest,
-                )
-            }
-            Panels.SubtitleOverlayList -> {
-                SubtitleListPanel(
-                    mode = SubtitleListPanelMode.Overlay,
                     cues = subtitleCues,
                     activeCueIndex = activeSubtitleCueIndex,
                     onSelectCue = onSelectSubtitleCue,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
@@ -4,17 +4,14 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.animateScrollBy
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -39,14 +36,8 @@ import eu.kanade.tachiyomi.ui.player.PlayerViewModel.SubtitleCue
 import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.presentation.core.components.material.padding
 
-enum class SubtitleListPanelMode {
-    SideList,
-    Overlay,
-}
-
 @Composable
 fun SubtitleListPanel(
-    mode: SubtitleListPanelMode,
     cues: ImmutableList<SubtitleCue>,
     activeCueIndex: Int?,
     onSelectCue: (Int) -> Unit,
@@ -56,20 +47,12 @@ fun SubtitleListPanel(
     BackHandler(onBack = onDismissRequest)
 
     Box(modifier = modifier.fillMaxSize()) {
-        when (mode) {
-            SubtitleListPanelMode.SideList -> SubtitleSideList(
-                cues = cues,
-                activeCueIndex = activeCueIndex,
-                onSelectCue = onSelectCue,
-                modifier = Modifier.align(Alignment.CenterEnd),
-            )
-            SubtitleListPanelMode.Overlay -> SubtitleOverlayList(
-                cues = cues,
-                activeCueIndex = activeCueIndex,
-                onSelectCue = onSelectCue,
-                modifier = Modifier.align(Alignment.BottomCenter),
-            )
-        }
+        SubtitleSideList(
+            cues = cues,
+            activeCueIndex = activeCueIndex,
+            onSelectCue = onSelectCue,
+            modifier = Modifier.align(Alignment.CenterEnd),
+        )
     }
 }
 
@@ -88,7 +71,6 @@ private fun SubtitleSideList(
         cues = cues,
         activeCueIndex = activeCueIndex,
         onSelectCue = onSelectCue,
-        mode = SubtitleCueRowMode.Side,
         modifier = modifier
             .padding(end = 8.dp, top = 36.dp, bottom = 36.dp)
             .width(width)
@@ -97,55 +79,10 @@ private fun SubtitleSideList(
 }
 
 @Composable
-private fun SubtitleOverlayList(
-    cues: ImmutableList<SubtitleCue>,
-    activeCueIndex: Int?,
-    onSelectCue: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val activePosition = activePosition(cues, activeCueIndex)
-    val visibleCues = if (cues.isEmpty()) {
-        emptyList()
-    } else {
-        cues
-            .drop((activePosition - 3).coerceAtLeast(0))
-            .take(7)
-    }
-
-    Column(
-        modifier = modifier
-            .padding(start = 24.dp, end = 24.dp, bottom = 132.dp)
-            .widthIn(max = 520.dp)
-            .fillMaxWidth(0.56f),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        if (visibleCues.isEmpty()) {
-            EmptySubtitleListMessage()
-        } else {
-            visibleCues
-                .filterNot { it.index == activeCueIndex }
-                .forEach { cue ->
-                    SubtitleCueOverlayRow(
-                        cue = cue,
-                        selected = false,
-                        onClick = { onSelectCue(cue.index) },
-                    )
-                }
-        }
-    }
-}
-
-private enum class SubtitleCueRowMode {
-    Side,
-}
-
-@Composable
 private fun SubtitleCueLazyList(
     cues: ImmutableList<SubtitleCue>,
     activeCueIndex: Int?,
     onSelectCue: (Int) -> Unit,
-    mode: SubtitleCueRowMode,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -170,13 +107,11 @@ private fun SubtitleCueLazyList(
             contentPadding = PaddingValues(vertical = maxHeight * 0.5f),
         ) {
             items(cues, key = { it.index }) { cue ->
-                when (mode) {
-                    SubtitleCueRowMode.Side -> SubtitleCueSideRow(
-                        cue = cue,
-                        selected = cue.index == activeCueIndex,
-                        onClick = { onSelectCue(cue.index) },
-                    )
-                }
+                SubtitleCueSideRow(
+                    cue = cue,
+                    selected = cue.index == activeCueIndex,
+                    onClick = { onSelectCue(cue.index) },
+                )
             }
         }
     }
@@ -221,28 +156,6 @@ private fun SubtitleCueSideRow(
 }
 
 @Composable
-private fun SubtitleCueOverlayRow(
-    cue: SubtitleCue,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = cue.text,
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .background(activeLineColor(selected), RoundedCornerShape(2.dp))
-            .padding(horizontal = 10.dp, vertical = if (selected) 5.dp else 3.dp),
-        style = subtitleOverlayTextStyle(selected),
-        color = Color.White.copy(alpha = if (selected) 1f else 0.78f),
-        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
-        maxLines = if (selected) 2 else 1,
-        overflow = TextOverflow.Ellipsis,
-    )
-}
-
-@Composable
 private fun EmptySubtitleListMessage(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier.fillMaxWidth(),
@@ -260,17 +173,6 @@ private fun EmptySubtitleListMessage(modifier: Modifier = Modifier) {
 @Composable
 private fun subtitleLogTextStyle(): TextStyle {
     return MaterialTheme.typography.bodyLarge.copy(
-        shadow = Shadow(
-            color = Color.Black.copy(alpha = 0.95f),
-            blurRadius = 8f,
-        ),
-    )
-}
-
-@Composable
-private fun subtitleOverlayTextStyle(selected: Boolean): TextStyle {
-    return (if (selected) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium).copy(
-        textAlign = TextAlign.Center,
         shadow = Shadow(
             color = Color.Black.copy(alpha = 0.95f),
             blurRadius = 8f,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/PlayerResume.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/PlayerResume.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+private const val COMPLETED_RESUME_GRACE_MS = 1_500L
+
+internal fun Long.safeResumePositionMillis(
+    totalMillis: Long,
+    seen: Boolean = false,
+    resetWhenDurationUnknown: Boolean = seen,
+): Long {
+    val position = coerceAtLeast(0L)
+    if (position == 0L) return 0L
+
+    val total = totalMillis.coerceAtLeast(0L)
+    if (total == 0L) {
+        return if (resetWhenDurationUnknown) 0L else position
+    }
+
+    val completedThreshold = (total - COMPLETED_RESUME_GRACE_MS).coerceAtLeast(0L)
+    return if (position >= completedThreshold) {
+        0L
+    } else {
+        position
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFilters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFilters.kt
@@ -75,10 +75,11 @@ fun customSubtitleRegex(pattern: String): Regex? {
     }.getOrNull()
 }
 
-private val speakerNameInParenthesesRegex = Regex("""(?m)^\s*\([^()\n]{1,48}\)\s*:?\s*""")
+private val speakerNameInParenthesesRegex =
+    Regex("""(?m)^\s*[\u0028\uff08][^\u0028\u0029\uff08\uff09\r\n]{1,48}[\u0029\uff09]\s*:?\s*""")
 private val bracketedTextRegex = Regex("""\[[^\[\]\n]*]""")
 private val curlyBracedTextRegex = Regex("""\{[^{}\n]*\}""")
-private val musicSymbolsRegex = Regex("""[♪♫♬♩♭♯#~〜]+""")
+private val musicSymbolsRegex = Regex("""[\u266a\u266b\u266c\u2669\u266d\u266f#~\u301c\uff5e]+""")
 
 private fun String.cleanSubtitleRegexFilterResult(): String {
     return lines()

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/PlayerResumeTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/PlayerResumeTest.kt
@@ -1,0 +1,32 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PlayerResumeTest {
+    @Test
+    fun `keeps incomplete episode position`() {
+        assertEquals(120_000L, 120_000L.safeResumePositionMillis(totalMillis = 600_000L))
+    }
+
+    @Test
+    fun `resets positions at the end of an episode`() {
+        assertEquals(0L, 599_000L.safeResumePositionMillis(totalMillis = 600_000L))
+    }
+
+    @Test
+    fun `resets stored episode progress when duration is unknown`() {
+        assertEquals(
+            0L,
+            120_000L.safeResumePositionMillis(
+                totalMillis = 0L,
+                resetWhenDurationUnknown = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `keeps active playback position when duration is not ready`() {
+        assertEquals(120_000L, 120_000L.safeResumePositionMillis(totalMillis = 0L))
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFiltersTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFiltersTest.kt
@@ -1,0 +1,62 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SubtitleRegexFiltersTest {
+    @Test
+    fun `removes ascii parenthesized speaker prefix`() {
+        assertEquals(
+            "\u5834\u6240\u306f?",
+            "(\u30b8\u30e7\u30f3\u30fb\u30b8\u30e3\u30a4\u30a2\u30f3\u30c8) \u5834\u6240\u306f?"
+                .applySubtitleRegexFilters(options(removeSpeakerNames = true)),
+        )
+    }
+
+    @Test
+    fun `removes full width parenthesized speaker prefix`() {
+        assertEquals(
+            "\u5834\u6240\u306f?",
+            "\uff08\u30b8\u30e7\u30f3\u30fb\u30b8\u30e3\u30a4\u30a2\u30f3\u30c8\uff09\u5834\u6240\u306f?"
+                .applySubtitleRegexFilters(options(removeSpeakerNames = true)),
+        )
+    }
+
+    @Test
+    fun `speaker filter keeps parenthesized text outside the speaker prefix`() {
+        assertEquals(
+            "\u5834\u6240\u306f? (\u6771\u4eac)",
+            "\u5834\u6240\u306f? (\u6771\u4eac)".applySubtitleRegexFilters(options(removeSpeakerNames = true)),
+        )
+    }
+
+    @Test
+    fun `music symbol filter removes common subtitle music markers`() {
+        assertEquals(
+            "hello",
+            "\u266a hello \u266b".applySubtitleRegexFilters(options(removeMusicSymbols = true)),
+        )
+    }
+
+    private fun options(
+        removeSpeakerNames: Boolean = false,
+        mergeMultiline: Boolean = false,
+        removeBracketedText: Boolean = false,
+        removeUppercaseLines: Boolean = false,
+        removeMusicSymbols: Boolean = false,
+        removeCurlyBracedText: Boolean = false,
+        customRegexEnabled: Boolean = false,
+        customRegexPattern: String = "",
+    ): SubtitleRegexFilterOptions {
+        return SubtitleRegexFilterOptions(
+            removeSpeakerNames = removeSpeakerNames,
+            mergeMultiline = mergeMultiline,
+            removeBracketedText = removeBracketedText,
+            removeUppercaseLines = removeUppercaseLines,
+            removeMusicSymbols = removeMusicSymbols,
+            removeCurlyBracedText = removeCurlyBracedText,
+            customRegexEnabled = customRegexEnabled,
+            customRegexPattern = customRegexPattern,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fix subtitle regex presets so speaker-name and music-symbol filters actually compile/apply correctly
- Add safe resume-position handling so completed or stale episode progress does not reopen videos at the end
- Remove the second/mini subtitle list style and keep the side subtitle history list as the only list mode

## Verification
- `./gradlew.bat --no-build-cache :app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.player.utils.PlayerResumeTest --tests eu.kanade.tachiyomi.ui.player.utils.SubtitleRegexFiltersTest`
- `./gradlew.bat --no-build-cache :app:assembleDebug`
- Installed `app-arm64-v8a-debug.apk` to connected device `23106RN0DA`

## Manual Testing

### Screen recording
[View MP4: subtitle regex toggle](https://gist.githubusercontent.com/1Selxo/1d346303ff4f5f3955e23d75d76bcaba/raw/chimahon-pr38-subtitle-regex-toggle.mp4)

### Before: `None` selected
![Subtitle regex menu with None selected and speaker prefix visible](https://gist.githubusercontent.com/1Selxo/1d346303ff4f5f3955e23d75d76bcaba/raw/chimahon-pr38-regex-none-before.png)

### After: `Remove speaker names in parentheses` selected
![Subtitle regex menu with speaker-name filter selected and speaker prefix removed](https://gist.githubusercontent.com/1Selxo/1d346303ff4f5f3955e23d75d76bcaba/raw/chimahon-pr38-speaker-filter-after.png)