### PR TITLE
fix(settings): resolve transient URI permission revocation and file picker crash on custom ROMs

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -413,7 +413,7 @@ object SettingsDictionaryScreen : SearchableSettings {
         }
 
         if (errorDialogText != null) {
-            val showPermissionButton = errorDialogText!!.contains("Manager: false")
+            val showPermissionButton = errorDialogText!!.contains("Storage permission is not granted")
             AlertDialog(
                 onDismissRequest = { errorDialogText = null },
                 title = { Text("Import Diagnostics") },
@@ -2897,17 +2897,22 @@ private fun openStreamWithFallback(context: Context, uri: Uri): java.io.InputStr
         Log.w("DictionaryImport", "Standard openInputStream failed for $uri, trying fallback", e)
     }
 
-    var resolvedPath: String? = null
-    var exists = false
-    var canRead = false
+    val isManager = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+        android.os.Environment.isExternalStorageManager()
+    } else {
+        true
+    }
+
+    if (!isManager) {
+        throw java.io.FileNotFoundException("Storage permission is not granted. Please allow 'All files access' in settings.")
+    }
+
     try {
-        resolvedPath = getPathFromUri(context, uri)
-        if (resolvedPath != null) {
-            val file = java.io.File(resolvedPath)
-            exists = file.exists()
-            canRead = file.canRead()
-            if (exists && canRead) {
-                Log.d("DictionaryImport", "Fallback succeeded using file path: $resolvedPath")
+        val path = getPathFromUri(context, uri)
+        if (path != null) {
+            val file = java.io.File(path)
+            if (file.exists() && file.canRead()) {
+                Log.d("DictionaryImport", "Fallback succeeded using file path: $path")
                 return java.io.FileInputStream(file)
             }
         }
@@ -2915,13 +2920,7 @@ private fun openStreamWithFallback(context: Context, uri: Uri): java.io.InputStr
         Log.e("DictionaryImport", "Fallback file path open failed for $uri", e)
     }
 
-    val isManager = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-        android.os.Environment.isExternalStorageManager()
-    } else {
-        true
-    }
-
-    throw java.io.FileNotFoundException("URI: $uri\nPath: $resolvedPath\nManager: $isManager | Exists: $exists | CanRead: $canRead")
+    throw java.io.FileNotFoundException("File is inaccessible or corrupted.")
 }
 
 private fun getPathFromUri(context: Context, uri: Uri): String? {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -294,6 +294,7 @@ object SettingsDictionaryScreen : SearchableSettings {
         val context = LocalContext.current
         val scope = rememberCoroutineScope()
         val dictionaryPreferences = remember { Injekt.get<DictionaryPreferences>() }
+        var errorDialogText by remember { mutableStateOf<String?>(null) }
 
         // Trigger recomposition when profile state changes
         val rawProfiles by dictionaryPreferences.rawProfiles().collectAsState()
@@ -308,15 +309,59 @@ object SettingsDictionaryScreen : SearchableSettings {
         ) { uris ->
             Log.d(TAG, "importLauncher: uris=${uris.size}")
             if (uris.isEmpty()) return@rememberLauncherForActivityResult
+            val successNames = mutableListOf<String>()
+            val failedImports = mutableListOf<Pair<String, String>>()
+            
+            val pending = uris.map { uri ->
+                val name = getFileNameFromUri(context, uri)
+                try {
+                    val stream = openStreamWithFallback(context, uri)
+                    if (stream != null) {
+                        Triple(name, stream, null)
+                    } else {
+                        Triple(name, null, "Could not open file stream")
+                    }
+                } catch (e: Exception) {
+                    Triple(name, null, e.message ?: "Failed to open file")
+                }
+            }
+            
             scope.launch {
                 _isImporting.value = true
-                uris.forEach { uri ->
-                    val activeProfile = dictionaryPreferences.profileStore.getActiveProfile()
-                    val result = importDictionaryFromUri(context, uri, activeProfile)
-                    context.toast(result.first)
+                pending.forEach { (name, stream, err) ->
+                    if (err != null) {
+                        failedImports.add(name to err)
+                        return@forEach
+                    }
+                    if (stream != null) {
+                        val activeProfile = dictionaryPreferences.profileStore.getActiveProfile()
+                        val result = importDictionaryFromStream(context, stream, activeProfile)
+                        if (result.second) {
+                            successNames.add(name)
+                        } else {
+                            failedImports.add(name to result.first)
+                        }
+                    }
                 }
+                
                 loadDictionaryList(context)
                 _isImporting.value = false
+                
+                // Construct and display the result report dialog
+                val report = StringBuilder()
+                if (successNames.isNotEmpty()) {
+                    report.append("Imported successfully:\n")
+                    successNames.forEach { report.append("✓ $it\n") }
+                    report.append("\n")
+                }
+                if (failedImports.isNotEmpty()) {
+                    report.append("Failed to import:\n")
+                    failedImports.forEach { (name, errorMsg) ->
+                        val indentedErr = errorMsg.replace("\n", "\n  ")
+                        report.append("✗ $name\n  Reason: $indentedErr\n\n")
+                    }
+                }
+                errorDialogText = report.toString().trim()
             }
         }
 
@@ -365,6 +410,44 @@ object SettingsDictionaryScreen : SearchableSettings {
                     _isImportingDb.value = false
                 }
             }
+        }
+
+        if (errorDialogText != null) {
+            val showPermissionButton = errorDialogText!!.contains("Manager: false")
+            AlertDialog(
+                onDismissRequest = { errorDialogText = null },
+                title = { Text("Import Diagnostics") },
+                text = { Text(errorDialogText!!) },
+                confirmButton = {
+                    TextButton(onClick = { errorDialogText = null }) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = if (showPermissionButton) {
+                    {
+                        TextButton(
+                            onClick = {
+                                errorDialogText = null
+                                try {
+                                    val intent = Intent(android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                                        data = Uri.parse("package:${context.packageName}")
+                                    }
+                                    context.startActivity(intent)
+                                } catch (e: Exception) {
+                                    try {
+                                        val intent = Intent(android.provider.Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+                                        context.startActivity(intent)
+                                    } catch (ex: Exception) {
+                                        context.toast("Could not open settings")
+                                    }
+                                }
+                            }
+                        ) {
+                            Text("Grant Permission")
+                        }
+                    }
+                } else null
+            )
         }
 
         return listOf(
@@ -2695,57 +2778,54 @@ object SettingsDictionaryScreen : SearchableSettings {
     }
 }
 
-private suspend fun importDictionaryFromUri(
+private suspend fun importDictionaryFromStream(
     context: Context,
-    uri: Uri,
+    inputStream: java.io.InputStream,
     activeProfile: chimahon.anki.AnkiProfile,
 ): Pair<String, Boolean> {
     return withContext(Dispatchers.IO) {
         val dictionariesDir = File(context.getExternalFilesDir(null), "dictionaries")
-        Log.d(TAG, "importDictionaryFromUri: dictionariesDir=${dictionariesDir.absolutePath}")
+        Log.d(TAG, "importDictionaryFromStream: dictionariesDir=${dictionariesDir.absolutePath}")
 
         val tempZip = File(context.cacheDir, "chimahon_import_${System.currentTimeMillis()}.zip")
         val tempImportDir = File(context.cacheDir, "dict_import_tmp_${System.currentTimeMillis()}")
 
         try {
             if (!dictionariesDir.exists() && !dictionariesDir.mkdirs()) {
-                Log.e(TAG, "importDictionaryFromUri: failed to create dictionariesDir")
+                Log.e(TAG, "importDictionaryFromStream: failed to create dictionariesDir")
                 return@withContext Pair(
                     context.stringResource(MR.strings.storage_failed_to_create_directory, dictionariesDir.absolutePath),
                     false,
                 )
             }
 
-            val source = UniFile.fromUri(context, uri)
-                ?: return@withContext Pair(context.stringResource(MR.strings.file_null_uri_error), false)
-
-            source.openInputStream().use { input ->
+            inputStream.use { input ->
                 tempZip.outputStream().use { output ->
                     input.copyTo(output)
                 }
             }
 
-            Log.d(TAG, "importDictionaryFromUri: calling HoshiDicts.importDictionary...")
+            Log.d(TAG, "importDictionaryFromStream: calling HoshiDicts.importDictionary...")
             tempImportDir.mkdirs()
             val result = HoshiDicts.importDictionary(
                 zipPath = tempZip.absolutePath,
                 outputDir = tempImportDir.absolutePath,
             )
-            Log.d(TAG, "importDictionaryFromUri: HoshiDicts result: success=${result.success} terms=${result.termCount} freq=${result.freqCount} pitch=${result.pitchCount} media=${result.mediaCount}")
+            Log.d(TAG, "importDictionaryFromStream: HoshiDicts result: success=${result.success} terms=${result.termCount} freq=${result.freqCount} pitch=${result.pitchCount} media=${result.mediaCount}")
 
             if (!result.success) {
-                Log.e(TAG, "importDictionaryFromUri: import failed")
-                return@withContext Pair(context.stringResource(MR.strings.pref_import_dictionary_failed), false)
+                Log.e(TAG, "importDictionaryFromStream: import failed")
+                return@withContext Pair(result.title.takeIf { it.isNotBlank() } ?: context.stringResource(MR.strings.pref_import_dictionary_failed), false)
             }
 
             val importedDir = tempImportDir.listFiles()?.firstOrNull { it.isDirectory }
             if (importedDir == null) {
-                Log.e(TAG, "importDictionaryFromUri: no imported dir found")
+                Log.e(TAG, "importDictionaryFromStream: no imported dir found")
                 return@withContext Pair("Import succeeded but no dictionary directory found", false)
             }
 
             val title = if (result.title.isNotBlank()) result.title else importedDir.name
-            Log.d(TAG, "importDictionaryFromUri: imported dict title=$title")
+            Log.d(TAG, "importDictionaryFromStream: imported dict title=$title")
 
             data class CopyTarget(val type: String, val count: Long)
             val targets = buildList {
@@ -2755,7 +2835,7 @@ private suspend fun importDictionaryFromUri(
             }
 
             if (targets.isEmpty()) {
-                Log.e(TAG, "importDictionaryFromUri: no term/freq/pitch entries found")
+                Log.e(TAG, "importDictionaryFromStream: no term/freq/pitch entries found")
                 return@withContext Pair("Dictionary has no recognizable entries", false)
             }
 
@@ -2765,7 +2845,7 @@ private suspend fun importDictionaryFromUri(
                 val destDir = File(typeDir, title)
                 if (destDir.exists()) destDir.deleteRecursively()
                 importedDir.copyRecursively(destDir, overwrite = true)
-                Log.d(TAG, "importDictionaryFromUri: copied to ${target.type}/$title")
+                Log.d(TAG, "importDictionaryFromStream: copied to ${target.type}/$title")
             }
 
             // Add to profile order once (dict name, no type prefix)
@@ -2797,14 +2877,106 @@ private suspend fun importDictionaryFromUri(
                 true,
             )
         } catch (e: UnsatisfiedLinkError) {
-            Log.e(TAG, "importDictionaryFromUri: UnsatisfiedLinkError", e)
+            Log.e(TAG, "importDictionaryFromStream: UnsatisfiedLinkError", e)
             Pair("Native library not loaded. Check build configuration.", false)
         } catch (e: Throwable) {
-            Log.e(TAG, "importDictionaryFromUri: exception", e)
+            Log.e(TAG, "importDictionaryFromStream: exception", e)
             Pair(e.message ?: context.stringResource(MR.strings.unknown_error), false)
         } finally {
             if (tempZip.exists()) tempZip.delete()
             if (tempImportDir.exists()) tempImportDir.deleteRecursively()
         }
     }
+}
+
+private fun openStreamWithFallback(context: Context, uri: Uri): java.io.InputStream? {
+    try {
+        val stream = context.contentResolver.openInputStream(uri)
+        if (stream != null) return stream
+    } catch (e: Exception) {
+        Log.w("DictionaryImport", "Standard openInputStream failed for $uri, trying fallback", e)
+    }
+
+    var resolvedPath: String? = null
+    var exists = false
+    var canRead = false
+    try {
+        resolvedPath = getPathFromUri(context, uri)
+        if (resolvedPath != null) {
+            val file = java.io.File(resolvedPath)
+            exists = file.exists()
+            canRead = file.canRead()
+            if (exists && canRead) {
+                Log.d("DictionaryImport", "Fallback succeeded using file path: $resolvedPath")
+                return java.io.FileInputStream(file)
+            }
+        }
+    } catch (e: Exception) {
+        Log.e("DictionaryImport", "Fallback file path open failed for $uri", e)
+    }
+
+    val isManager = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+        android.os.Environment.isExternalStorageManager()
+    } else {
+        true
+    }
+
+    throw java.io.FileNotFoundException("URI: $uri\nPath: $resolvedPath\nManager: $isManager | Exists: $exists | CanRead: $canRead")
+}
+
+private fun getPathFromUri(context: Context, uri: Uri): String? {
+    val scheme = uri.scheme
+    if ("file".equals(scheme, ignoreCase = true)) {
+        return uri.path
+    }
+    if ("content".equals(scheme, ignoreCase = true)) {
+        val authority = uri.authority
+        if ("com.android.externalstorage.documents" == authority) {
+            val docId = android.provider.DocumentsContract.getDocumentId(uri)
+            val split = docId.split(":")
+            if (split.size >= 2) {
+                val type = split[0]
+                if ("primary".equals(type, ignoreCase = true)) {
+                    return android.os.Environment.getExternalStorageDirectory().toString() + "/" + split[1]
+                }
+            }
+        } else if ("com.android.providers.downloads.documents" == authority) {
+            val id = android.provider.DocumentsContract.getDocumentId(uri)
+            if (id.startsWith("raw:")) {
+                return id.substring(4)
+            }
+        }
+        
+        try {
+            context.contentResolver.query(uri, arrayOf("_data"), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex("_data")
+                    if (idx != -1) {
+                        return cursor.getString(idx)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Ignore
+        }
+    }
+    return null
+}
+
+private fun getFileNameFromUri(context: Context, uri: Uri): String {
+    if ("content".equals(uri.scheme, ignoreCase = true)) {
+        try {
+            context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (idx != -1) {
+                        return cursor.getString(idx)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Ignore
+        }
+    }
+    return uri.lastPathSegment ?: "Unknown File"
 }

--- a/chimahon/src/main/cpp/hoshidicts_jni.cpp
+++ b/chimahon/src/main/cpp/hoshidicts_jni.cpp
@@ -316,7 +316,11 @@ Java_chimahon_HoshiDicts_importDictionary(JNIEnv *env, jobject, jstring zip_path
         args.result = dictionary_importer::import(args.zip_path, args.output_dir, true);
     }
 
-    return new_import_result(env, args.result.success, args.result.title,
+    std::string title_or_error = args.result.title;
+    if (!args.result.success && !args.result.errors.empty()) {
+        title_or_error = args.result.errors[0];
+    }
+    return new_import_result(env, args.result.success, title_or_error,
                              static_cast<jlong>(args.result.term_count),
                              static_cast<jlong>(args.result.meta_count),
                              static_cast<jlong>(args.result.freq_count),


### PR DESCRIPTION
## Overview
This PR fixes a bug where users could not import Yomichan/Yomitan dictionaries on certain devices (specifically custom Android ROMs like Xiaomi HyperOS/MIUI devices) due to transient URI permission revocations and system-level `SecurityException` crashes.

## Problem Description
1. **Transient URI Permission Revocation:** When using `rememberLauncherForActivityResult` with `OpenMultipleDocuments`, the returned URIs are granted transient read permissions. Deferring the stream opening (`openInputStream`) entirely inside a background thread coroutine (`scope.launch`) causes the callback thread to exit immediately, prompting Android to revoke the read permission before the background thread can open the file.
2. **System Provider Permission Denial:** On some customized ROMs, opening streams from picked files throws `SecurityException: Permission Denial: com.android.externalstorage has no access to content://media/` because of system-level provider bugs, rendering standard `ContentResolver.openInputStream` unusable.

## Solution Implemented
1. **Synchronous Stream Open:** In `importLauncher`, we now synchronously call `openStreamWithFallback` on the main thread during the activity result callback to grab and secure the file descriptor immediately before Android can revoke the transient permissions.
2. **Direct File Path Fallback:** Added a path resolver (`getPathFromUri`) that parses `com.android.externalstorage.documents` and `com.android.providers.downloads.documents` URIs to their absolute storage paths (e.g., `/storage/emulated/0/...`). When the system `openInputStream` fails, it falls back to direct file reading using `FileInputStream` under the existing `MANAGE_EXTERNAL_STORAGE` permission.
3. **Aggregated Results UI & Clean Error Reporting:** Replaced the truncated Toast error notification with a styled Compose `AlertDialog`. The new dialog compiles a clean, user-friendly import report for single/multiple file selections, mapping success states with checkmarks (`✓`) and failure states with cross marks (`✗`). It filters out raw developer diagnostics (such as long URIs, absolute file paths, and internal variables) to prevent UI clutter. Furthermore, it dynamically displays a "Grant Permission" button if a storage permission failure is detected, allowing users to navigate directly to settings to grant the required access.
4. **Native Error Propagation:** Modified the JNI bridge (`hoshidicts_jni.cpp`) to pass raw C++ exception messages (such as `empty dictionary` or JSON parsing failures) in the `title` field of the `ImportResult` on failure, allowing the UI to display the exact root cause.

## Screenshots
<img width="250" height="500" alt="Screenshot_2026-07-02-01-55-11-479_app chimahon dev" src="https://github.com/user-attachments/assets/76795189-58c9-4214-855a-95e024f5fecf" />
<img width="250" height="500" alt="Screenshot_2026-07-02-01-55-50-809_app chimahon dev" src="https://github.com/user-attachments/assets/e996b4b4-9946-4fc9-b5f2-8ecf5bbd5d3d" />
