### PR TITLE
Add subtitle swipe controls and playback fixes

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsGesturesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsGesturesScreen.kt
@@ -53,6 +53,7 @@ object PlayerSettingsGesturesScreen : SearchableSettings {
     private fun getSlidersGroup(gesturePreferences: GesturePreferences): Preference.PreferenceGroup {
         val enableVolumeBrightnessGestures = gesturePreferences.gestureVolumeBrightness()
         val swapVol = gesturePreferences.swapVolumeBrightness()
+        val subtitleSwipeControls by gesturePreferences.subtitleSwipeControls().collectAsState()
 
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_player_sliders),
@@ -60,10 +61,12 @@ object PlayerSettingsGesturesScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     preference = enableVolumeBrightnessGestures,
                     title = stringResource(MR.strings.enable_volume_brightness_gestures),
+                    enabled = !subtitleSwipeControls,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = swapVol,
                     title = stringResource(MR.strings.pref_controls_swap_vol_brightness),
+                    enabled = !subtitleSwipeControls,
                 ),
             ),
         )
@@ -72,6 +75,8 @@ object PlayerSettingsGesturesScreen : SearchableSettings {
     @Composable
     private fun getSeekingGroup(gesturePreferences: GesturePreferences): Preference.PreferenceGroup {
         val scope = rememberCoroutineScope()
+        val subtitleSwipeControls = gesturePreferences.subtitleSwipeControls()
+        val subtitleSwipeControlsEnabled by subtitleSwipeControls.collectAsState()
         val enableHorizontalSeekGesture = gesturePreferences.gestureHorizontalSeek()
         val showSeekbar = gesturePreferences.showSeekBar()
         val defaultSkipIntroLength by gesturePreferences.defaultIntroLength().stateIn(scope).collectAsState()
@@ -94,8 +99,14 @@ object PlayerSettingsGesturesScreen : SearchableSettings {
             title = stringResource(MR.strings.pref_category_player_seeking),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.SwitchPreference(
+                    preference = subtitleSwipeControls,
+                    title = stringResource(MR.strings.pref_player_gesture_subtitle_swipe),
+                    subtitle = stringResource(MR.strings.pref_player_gesture_subtitle_swipe_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
                     preference = enableHorizontalSeekGesture,
                     title = stringResource(MR.strings.enable_horizontal_seek_gesture),
+                    enabled = !subtitleSwipeControlsEnabled,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = showSeekbar,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/animedownload/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/animedownload/AnimeDownloader.kt
@@ -352,10 +352,20 @@ class AnimeDownloader(
 
             val resolvedVideo = resolveExternalTracks(video)
 
-            if (resolvedVideo.videoUrl.startsWith("http")) {
-                ffmpegDownloadVideo(resolvedVideo, tmpDir, download)
-            } else {
-                downloadVideoFile(resolvedVideo, tmpDir, download)
+            when {
+                resolvedVideo.canUseDirectHttpDownload() -> {
+                    try {
+                        downloadVideoFile(resolvedVideo, tmpDir, download)
+                    } catch (_: HlsStreamRequiresFFmpegException) {
+                        ffmpegDownloadVideo(resolvedVideo, tmpDir, download)
+                    }
+                }
+                resolvedVideo.videoUrl.startsWith("http") -> {
+                    ffmpegDownloadVideo(resolvedVideo, tmpDir, download)
+                }
+                else -> {
+                    downloadVideoFile(resolvedVideo, tmpDir, download)
+                }
             }
 
             writeMetadata(video, tmpDir)
@@ -478,18 +488,11 @@ class AnimeDownloader(
                             if (ReturnCode.isSuccess(returnedSession.returnCode)) {
                                 cont.resume(Unit)
                             } else {
-                                val detail = buildString {
-                                    append("FFmpeg exit code: ${returnedSession.returnCode}")
-                                    val trace = returnedSession.failStackTrace
-                                    if (!trace.isNullOrBlank()) {
-                                        append("\n$trace")
-                                    } else {
-                                        val logs = returnedSession.allLogsAsString?.trim()
-                                        if (!logs.isNullOrBlank()) {
-                                            append("\n$logs")
-                                        }
-                                    }
-                                }
+                                val detail = buildFFmpegFailureMessage(
+                                    exitCode = returnedSession.returnCode.toString(),
+                                    failStackTrace = returnedSession.failStackTrace,
+                                    logs = returnedSession.allLogsAsString,
+                                )
                                 cont.resumeWithException(Exception(detail))
                             }
                         },
@@ -669,6 +672,10 @@ class AnimeDownloader(
 
                 downloadClient.newCall(request).execute().use { response ->
                     if (response.isSuccessful || response.code == 206) {
+                        val contentType = response.body.contentType()?.toString().orEmpty()
+                        if (contentType.isHlsContentType()) {
+                            throw HlsStreamRequiresFFmpegException()
+                        }
                         if (response.code == 200 && downloadedBytes > 0) {
                             outputFile.delete()
                         }
@@ -707,6 +714,8 @@ class AnimeDownloader(
                     }
                 }
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: HlsStreamRequiresFFmpegException) {
                 throw e
             } catch (e: Exception) {
                 logcat(LogPriority.WARN, e) { "Download attempt $attempt failed" }
@@ -805,6 +814,55 @@ class AnimeDownloader(
 }
 
 // Video files are much larger than manga pages — require 500 MB free
+private fun Video.canUseDirectHttpDownload(): Boolean {
+    return videoUrl.startsWith("http") &&
+        !videoUrl.contains("m3u8", ignoreCase = true) &&
+        subtitleTracks.isEmpty() &&
+        audioTracks.isEmpty() &&
+        ffmpegStreamArgs.isEmpty() &&
+        ffmpegVideoArgs.isEmpty()
+}
+
+private fun String.isHlsContentType(): Boolean {
+    return contains("mpegurl", ignoreCase = true) ||
+        contains("vnd.apple", ignoreCase = true)
+}
+
+private class HlsStreamRequiresFFmpegException : Exception()
+
+internal fun buildFFmpegFailureMessage(
+    exitCode: String,
+    failStackTrace: String?,
+    logs: String?,
+): String {
+    val details = sequenceOf(failStackTrace, logs)
+        .filterNotNull()
+        .flatMap { it.lineSequence() }
+        .map(String::trim)
+        .filter(String::isNotBlank)
+        .filterNot(String::isFFmpegBannerLine)
+        .toList()
+        .takeLast(8)
+
+    return buildString {
+        append("FFmpeg exit code: $exitCode")
+        if (details.isNotEmpty()) {
+            append('\n')
+            append(details.joinToString("\n"))
+        }
+    }
+}
+
+private fun String.isFFmpegBannerLine(): Boolean {
+    val normalized = lowercase()
+    return normalized.startsWith("ffmpeg version") ||
+        normalized.startsWith("built with") ||
+        normalized.startsWith("configuration:") ||
+        normalized.startsWith("libav") ||
+        normalized.startsWith("libsw") ||
+        normalized.startsWith("libpostproc")
+}
+
 private const val MIN_DISK_SPACE = 500L * 1024 * 1024
 
 private val VIDEO_EXTENSIONS = setOf("mp4", "mkv", "webm", "avi", "m4v", "ts")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -239,6 +239,8 @@ class PlayerViewModel @JvmOverloads constructor(
     val jimakuState = _jimakuState.asStateFlow()
     private val _currentSubtitleText = MutableStateFlow("")
     val currentSubtitleText = _currentSubtitleText.asStateFlow()
+    private val _subtitlesVisible = MutableStateFlow(true)
+    val subtitlesVisible = _subtitlesVisible.asStateFlow()
     private val _subtitleHistory = MutableStateFlow<List<SubtitleCue>>(emptyList())
     val subtitleHistory = _subtitleHistory.asStateFlow()
     private val _activeSubtitleCueIndex = MutableStateFlow<Int?>(null)
@@ -1330,6 +1332,41 @@ class PlayerViewModel @JvmOverloads constructor(
         val cue = subtitleHistory.value.firstOrNull { it.index == index } ?: return
         seekTo(cue.effectiveStartSeconds().coerceAtLeast(0.0))
         _activeSubtitleCueIndex.update { cue.index }
+    }
+
+    fun seekToAdjacentSubtitle(forward: Boolean) {
+        val delaySeconds = currentPrimarySubtitleDelaySeconds()
+        val speed = currentSubtitleSpeed()
+        val positionSeconds = pos.value.toDouble()
+        val target = if (forward) {
+            subtitleHistory.value
+                .filter { it.effectiveStartSeconds(delaySeconds, speed) > positionSeconds }
+                .minByOrNull { it.effectiveStartSeconds(delaySeconds, speed) }
+        } else {
+            subtitleHistory.value
+                .filter { it.effectiveEndSeconds(delaySeconds, speed) < positionSeconds }
+                .maxByOrNull { it.effectiveEndSeconds(delaySeconds, speed) }
+        }
+
+        if (target == null) {
+            MPVLib.command(arrayOf("sub-seek", if (forward) "1" else "-1", "primary"))
+            return
+        }
+
+        seekTo(target.effectiveStartSeconds(delaySeconds, speed).coerceAtLeast(0.0))
+        _activeSubtitleCueIndex.update { target.index }
+    }
+
+    fun setSubtitlesVisible(visible: Boolean) {
+        MPVLib.setPropertyBoolean("sub-visibility", visible)
+        _subtitlesVisible.update { visible }
+        playerUpdate.update {
+            PlayerUpdates.ShowText(
+                activity.stringResource(
+                    if (visible) MR.strings.player_subtitles_shown else MR.strings.player_subtitles_hidden,
+                ),
+            )
+        }
     }
 
     fun updatePlayBackPos(pos: Float) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
@@ -20,6 +20,7 @@ package eu.kanade.tachiyomi.ui.player.controls
 import android.os.SystemClock
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -51,8 +52,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import eu.kanade.presentation.player.components.LeftSideOvalShape
 import eu.kanade.presentation.player.components.RightSideOvalShape
@@ -76,6 +79,10 @@ import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.math.abs
+
+private const val SUBTITLE_SWIPE_TIME_LIMIT_MILLIS = 500L
+private const val SUBTITLE_SWIPE_DOMINANCE_RATIO = 1.5f
 
 @Composable
 fun GestureHandler(
@@ -109,6 +116,7 @@ fun GestureHandler(
     }
 
     val gestureVolumeBrightness = gesturePreferences.gestureVolumeBrightness().get()
+    val subtitleSwipeControls by gesturePreferences.subtitleSwipeControls().collectAsState()
     val swapVolumeBrightness by gesturePreferences.swapVolumeBrightness().collectAsState()
     val seekGesture by gesturePreferences.gestureHorizontalSeek().collectAsState()
     val preciseSeeking by gesturePreferences.playerSmoothSeek().collectAsState()
@@ -119,6 +127,7 @@ fun GestureHandler(
     val currentBrightness by viewModel.currentBrightness.collectAsState()
     val volumeBoostingCap = audioPreferences.volumeBoostCap().get()
     val haptics = LocalHapticFeedback.current
+    val subtitleSwipeDistance = with(LocalDensity.current) { 50.dp.toPx() }
 
     Box(
         modifier = modifier
@@ -229,8 +238,47 @@ fun GestureHandler(
                     )
                 }
             }
-            .pointerInput(areControlsLocked) {
-                if (!seekGesture || areControlsLocked) return@pointerInput
+            .pointerInput(areControlsLocked, subtitleSwipeControls, subtitleSwipeDistance) {
+                if (!subtitleSwipeControls || areControlsLocked) return@pointerInput
+                var startedAt = 0L
+                var totalDragX = 0f
+                var totalDragY = 0f
+                detectDragGestures(
+                    onDragStart = {
+                        startedAt = SystemClock.uptimeMillis()
+                        totalDragX = 0f
+                        totalDragY = 0f
+                    },
+                    onDragEnd = {
+                        if (SystemClock.uptimeMillis() - startedAt > SUBTITLE_SWIPE_TIME_LIMIT_MILLIS) {
+                            return@detectDragGestures
+                        }
+
+                        val horizontalDistance = abs(totalDragX)
+                        val verticalDistance = abs(totalDragY)
+                        when {
+                            horizontalDistance >= subtitleSwipeDistance &&
+                                horizontalDistance > verticalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
+                                viewModel.seekToAdjacentSubtitle(forward = totalDragX > 0f)
+                            }
+                            verticalDistance >= subtitleSwipeDistance &&
+                                verticalDistance > horizontalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
+                                viewModel.setSubtitlesVisible(visible = totalDragY > 0f)
+                            }
+                        }
+                    },
+                    onDragCancel = {
+                        totalDragX = 0f
+                        totalDragY = 0f
+                    },
+                ) { change, dragAmount ->
+                    totalDragX += dragAmount.x
+                    totalDragY += dragAmount.y
+                    change.consume()
+                }
+            }
+            .pointerInput(areControlsLocked, subtitleSwipeControls) {
+                if (subtitleSwipeControls || !seekGesture || areControlsLocked) return@pointerInput
                 var startingPosition = position.toInt()
                 var startingX = 0f
                 var wasPlayerAlreadyPause = false
@@ -263,8 +311,8 @@ fun GestureHandler(
                     if (showSeekbar) viewModel.showSeekBar()
                 }
             }
-            .pointerInput(areControlsLocked) {
-                if (!gestureVolumeBrightness || areControlsLocked) return@pointerInput
+            .pointerInput(areControlsLocked, subtitleSwipeControls) {
+                if (subtitleSwipeControls || !gestureVolumeBrightness || areControlsLocked) return@pointerInput
                 var startingY = 0f
                 var mpvVolumeStartingY = 0f
                 var originalVolume = currentVolume

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -155,6 +155,7 @@ fun PlayerControls(
     val chapters by viewModel.chapters.collectAsState()
     val currentBrightness by viewModel.currentBrightness.collectAsState()
     val currentSubtitleText by viewModel.currentSubtitleText.collectAsState()
+    val subtitlesVisible by viewModel.subtitlesVisible.collectAsState()
     val subtitleCues by viewModel.subtitleHistory.collectAsState()
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
     val primarySubtitleDelaySeconds by viewModel.primarySubtitleDelaySeconds.collectAsState()
@@ -250,7 +251,7 @@ fun PlayerControls(
             })
         }
         PlayerSubtitleTextLayer(
-            text = currentSubtitleText,
+            text = if (subtitlesVisible) currentSubtitleText else "",
             cue = activeSubtitleCue,
             subtitleDelaySeconds = primarySubtitleDelaySeconds,
             request = subtitleLookupRequest,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/GesturePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/GesturePreferences.kt
@@ -14,6 +14,8 @@ class GesturePreferences(
     )
     fun swapVolumeBrightness() = preferenceStore.getBoolean("pref_swap_volume_and_brightness", false)
 
+    fun subtitleSwipeControls() = preferenceStore.getBoolean("pref_subtitle_swipe_controls", true)
+
     // Seeking
 
     fun gestureHorizontalSeek() = preferenceStore.getBoolean("pref_gesture_horizontal_seek", true)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFilters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFilters.kt
@@ -40,7 +40,7 @@ fun String.applySubtitleRegexFilters(options: SubtitleRegexFilterOptions): Strin
 
     var result = this
     if (options.removeSpeakerNames) {
-        result = speakerNameInParenthesesRegex.replace(result, "")
+        result = speakerNameInParenthesesRegex.replace(result, "$1")
     }
     if (options.removeBracketedText) {
         result = bracketedTextRegex.replace(result, "")
@@ -76,7 +76,10 @@ fun customSubtitleRegex(pattern: String): Regex? {
 }
 
 private val speakerNameInParenthesesRegex =
-    Regex("""(?m)^\s*[\u0028\uff08][^\u0028\u0029\uff08\uff09\r\n]{1,48}[\u0029\uff09]\s*:?\s*""")
+    Regex(
+        """(?m)^(\s*(?:[-\u2013\u2014\u2015\uff0d]\s*)?)[\u0028\uff08]""" +
+            """[^\u0028\u0029\uff08\uff09\r\n]{1,48}[\u0029\uff09]\s*:?\s*""",
+    )
 private val bracketedTextRegex = Regex("""\[[^\[\]\n]*]""")
 private val curlyBracedTextRegex = Regex("""\{[^{}\n]*\}""")
 private val musicSymbolsRegex = Regex("""[\u266a\u266b\u266c\u2669\u266d\u266f#~\u301c\uff5e]+""")

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/data/animedownload/AnimeDownloaderTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/data/animedownload/AnimeDownloaderTest.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.data.animedownload
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AnimeDownloaderTest {
+    @Test
+    fun `ffmpeg failure shows final error instead of build banner`() {
+        val message = buildFFmpegFailureMessage(
+            exitCode = "1",
+            failStackTrace = null,
+            logs = """
+                ffmpeg version n7.1 Copyright (c) 2000-2024 the FFmpeg developers
+                built with Android clang version 18.0.3
+                configuration: --target-os=android
+                libavutil      59. 39.100 / 59. 39.100
+                [https @ 0x123] HTTP error 403 Forbidden
+                video.mp4: Server returned 403 Forbidden
+            """.trimIndent(),
+        )
+
+        assertTrue(message.contains("HTTP error 403 Forbidden"))
+        assertTrue(message.contains("Server returned 403 Forbidden"))
+        assertFalse(message.contains("ffmpeg version"))
+        assertFalse(message.contains("configuration:"))
+    }
+
+    @Test
+    fun `ffmpeg failure falls back to exit code without logs`() {
+        assertEquals(
+            "FFmpeg exit code: 1",
+            buildFFmpegFailureMessage(exitCode = "1", failStackTrace = null, logs = null),
+        )
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFiltersTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/SubtitleRegexFiltersTest.kt
@@ -23,6 +23,26 @@ class SubtitleRegexFiltersTest {
     }
 
     @Test
+    fun `removes speaker names after dialogue dashes`() {
+        assertEquals(
+            "- \u308f\u30fc\u3044\uff01\n- \u5de8\u4eba\u65cf\u306e\u5b50\u4f9b\uff1f",
+            (
+                "- (\u5b50\u4f9b\u305f\u3061) \u308f\u30fc\u3044\uff01\n" +
+                    "- (\u30ca\u30df) \u5de8\u4eba\u65cf\u306e\u5b50\u4f9b\uff1f"
+            ).applySubtitleRegexFilters(options(removeSpeakerNames = true)),
+        )
+    }
+
+    @Test
+    fun `removes full width speaker names after unicode dialogue dashes`() {
+        assertEquals(
+            "\u2014 \u5834\u6240\u306f?",
+            "\u2014 \uff08\u30ca\u30df\uff09 \u5834\u6240\u306f?"
+                .applySubtitleRegexFilters(options(removeSpeakerNames = true)),
+        )
+    }
+
+    @Test
     fun `speaker filter keeps parenthesized text outside the speaker prefix`() {
         assertEquals(
             "\u5834\u6240\u306f? (\u6771\u4eac)",

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -307,6 +307,8 @@
     <string name="pref_player_swap_vol_bright_summary">Volume on left, brightness on right</string>
     <string name="pref_player_gesture_h_seek">Horizontal seek gesture</string>
     <string name="pref_player_gesture_h_seek_summary">Swipe horizontally to seek</string>
+    <string name="pref_player_gesture_subtitle_swipe">Subtitle swipe controls</string>
+    <string name="pref_player_gesture_subtitle_swipe_summary">Swipe left/right between subtitles, up to hide, and down to show. Replaces seek and volume/brightness swipes.</string>
     <string name="pref_player_skip_length">Seek skip length</string>
     <string name="pref_player_smooth_seek">Smooth seek</string>
     <string name="pref_player_smooth_seek_summary">Show video while seeking</string>
@@ -1713,6 +1715,8 @@
     <string name="enable_volume_brightness_gestures">Volume and brightness gestures</string>
     <string name="enable_horizontal_seek_gesture">Horizontal seek gesture</string>
     <string name="pref_show_seekbar">Seekbar</string>
+    <string name="player_subtitles_hidden">Subtitles hidden</string>
+    <string name="player_subtitles_shown">Subtitles shown</string>
 
     <!-- Anime library/detail UI -->
     <string name="action_bookmark_episode">Bookmark episode</string>


### PR DESCRIPTION
## Summary
- add configurable subtitle swipe controls modeled after asbplayer mobile navigation
- swipe right/left to seek to the next/previous subtitle and swipe up/down to hide/show subtitles
- prevent subtitle swipes from conflicting with horizontal seek and volume/brightness gestures
- remove parenthesized speaker names when they follow ASCII or Unicode dialogue dashes
- use the resumable HTTP downloader for direct video files while retaining FFmpeg for HLS and complex inputs
- show the actionable tail of FFmpeg failures instead of its build banner

## Testing
- `:app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.player.utils.SubtitleRegexFiltersTest`
- `:app:testDebugUnitTest --tests eu.kanade.tachiyomi.data.animedownload.AnimeDownloaderTest`
- 8 targeted tests passed
- `:app:assembleDebug` completed successfully
- installed and launched the arm64 debug APK on a physical Android device