### PR TITLE
style(ui): unify anime and manga floating action buttons and fix scroll expand bug

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/entries/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/AnimeScreen.kt
@@ -104,7 +104,20 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.components.FastScrollLazyVerticalGrid
 import tachiyomi.presentation.core.components.TwoPanelBox
-import tachiyomi.presentation.core.components.material.ExtendedFloatingActionButton
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionOnScreen
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.roundToInt
 import tachiyomi.presentation.core.components.material.PullRefresh
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.padding
@@ -378,6 +391,16 @@ private fun AnimeScreenSmallImpl(
         }
     }
 
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    var layoutSize by remember { mutableStateOf(IntSize.Zero) }
+    var fabSize by remember { mutableStateOf(IntSize.Zero) }
+    var positionOnScreen by remember { mutableStateOf(Offset.Zero) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    val fabPosition by uiPreferences.readButtonPosition().collectAsState()
+    val readButtonPosition = uiPreferences.readButtonPosition()
+    // KMK <--
+
     BackHandler(onBack = {
         if (isAnySelected) {
             onAllEpisodeSelected(false)
@@ -457,32 +480,55 @@ private fun AnimeScreenSmallImpl(
                 val isFABVisible = remember(episodes) {
                     episodes.fastAny { !it.episode.seen } && !isAnySelected
                 }
-                AnimatedVisibility(
-                    visible = isFABVisible,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
-                    ExtendedFloatingActionButton(
-                        text = {
-                            val isWatching = remember(state.episodes) {
-                                state.episodes.fastAny { it.episode.seen }
-                            }
-                            Text(
-                                text = stringResource(
-                                    if (isWatching) MR.strings.action_resume else MR.strings.action_start,
-                                ),
-                            )
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Filled.PlayArrow,
-                                contentDescription = null,
-                            )
-                        },
-                        onClick = onContinueWatching,
-                        expanded = itemListState.shouldExpandFAB(),
+                SmallExtendedFloatingActionButton(
+                    text = {
+                        val isWatching = remember(state.episodes) {
+                            state.episodes.fastAny { it.episode.seen }
+                        }
+                        Text(
+                            text = stringResource(if (isWatching) MR.strings.action_resume else MR.strings.action_start),
+                        )
+                    },
+                    icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
+                    onClick = onContinueWatching,
+                    expanded = itemListState.shouldExpandFAB(),
+                    modifier = Modifier.animateFloatingActionButton(
+                        visible = isFABVisible,
+                        alignment = Alignment.BottomEnd,
                     )
-                }
+                        .offset { IntOffset(offsetX.roundToInt(), 0) }
+                        .onGloballyPositioned { coordinates ->
+                            fabSize = coordinates.size
+                            positionOnScreen = coordinates.positionOnScreen()
+                        }
+                        .pointerInput(Unit) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = {
+                                    if (positionOnScreen.x + fabSize.width / 2 >= layoutSize.width / 2) {
+                                        readButtonPosition.set(FabPosition.End.toString())
+                                    } else {
+                                        readButtonPosition.set(FabPosition.Start.toString())
+                                    }
+                                    offsetX = 0f
+                                },
+                            ) { change, dragAmount ->
+                                change.consume()
+                                val newOffsetX = offsetX + dragAmount
+                                if (!newOffsetX.isNaN()) {
+                                    offsetX = newOffsetX
+                                }
+                            }
+                        },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                )
+            },
+            floatingActionButtonPosition = if (fabPosition == FabPosition.End.toString()) {
+                FabPosition.End
+            } else {
+                FabPosition.Start
+            },
+            modifier = Modifier.onGloballyPositioned { coordinates ->
+                layoutSize = coordinates.size
             },
         ) { contentPadding ->
             val topPadding = contentPadding.calculateTopPadding()
@@ -761,6 +807,16 @@ fun AnimeScreenLargeImpl(
         }
     }
 
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    var layoutSize by remember { mutableStateOf(IntSize.Zero) }
+    var fabSize by remember { mutableStateOf(IntSize.Zero) }
+    var positionOnScreen by remember { mutableStateOf(Offset.Zero) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    val fabPosition by uiPreferences.readButtonPosition().collectAsState()
+    val readButtonPosition = uiPreferences.readButtonPosition()
+    // KMK <--
+
     val insetPadding = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal).asPaddingValues()
     val relatedMangasEnabled by remember { Injekt.get<SourcePreferences>().relatedMangas() }.collectAsState()
     val expandRelatedAnime by remember { Injekt.get<UiPreferences>().expandRelatedMangas() }.collectAsState()
@@ -848,27 +904,55 @@ fun AnimeScreenLargeImpl(
                 val isFABVisible = remember(episodes) {
                     episodes.fastAny { !it.episode.seen } && !isAnySelected
                 }
-                AnimatedVisibility(
-                    visible = isFABVisible,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
-                    ExtendedFloatingActionButton(
-                        text = {
-                            val isWatching = remember(state.episodes) {
-                                state.episodes.fastAny { it.episode.seen }
-                            }
-                            Text(
-                                text = stringResource(
-                                    if (isWatching) MR.strings.action_resume else MR.strings.action_start,
-                                ),
-                            )
-                        },
-                        icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
-                        onClick = onContinueWatching,
-                        expanded = itemListState.shouldExpandFAB(),
+                SmallExtendedFloatingActionButton(
+                    text = {
+                        val isWatching = remember(state.episodes) {
+                            state.episodes.fastAny { it.episode.seen }
+                        }
+                        Text(
+                            text = stringResource(if (isWatching) MR.strings.action_resume else MR.strings.action_start),
+                        )
+                    },
+                    icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
+                    onClick = onContinueWatching,
+                    expanded = itemListState.shouldExpandFAB(),
+                    modifier = Modifier.animateFloatingActionButton(
+                        visible = isFABVisible,
+                        alignment = Alignment.BottomEnd,
                     )
-                }
+                        .offset { IntOffset(offsetX.roundToInt(), 0) }
+                        .onGloballyPositioned { coordinates ->
+                            fabSize = coordinates.size
+                            positionOnScreen = coordinates.positionOnScreen()
+                        }
+                        .pointerInput(Unit) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = {
+                                    if (positionOnScreen.x + fabSize.width / 2 >= layoutSize.width / 2) {
+                                        readButtonPosition.set(FabPosition.End.toString())
+                                    } else {
+                                        readButtonPosition.set(FabPosition.Start.toString())
+                                    }
+                                    offsetX = 0f
+                                },
+                            ) { change, dragAmount ->
+                                change.consume()
+                                val newOffsetX = offsetX + dragAmount
+                                if (!newOffsetX.isNaN()) {
+                                    offsetX = newOffsetX
+                                }
+                            }
+                        },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                )
+            },
+            floatingActionButtonPosition = if (fabPosition == FabPosition.End.toString()) {
+                FabPosition.End
+            } else {
+                FabPosition.Start
+            },
+            modifier = Modifier.onGloballyPositioned { coordinates ->
+                layoutSize = coordinates.size
             },
         ) { contentPadding ->
             PullRefresh(

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/util/LazyListState.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/util/LazyListState.kt
@@ -107,23 +107,4 @@ fun LazyListState.isItemScrollingDown(initiallyVisible: Boolean = false): Boolea
 }
 // KMK <--
 
-@Composable
-fun LazyGridState.shouldExpandFAB(): Boolean {
-    var lastScrolledBackward by remember { mutableStateOf(true) }
-    LaunchedEffect(this) {
-        snapshotFlow { firstVisibleItemIndex }
-            .map { it }
-            .distinctUntilChanged()
-            .collect { currentIndex ->
-                lastScrolledBackward = currentIndex <= firstVisibleItemIndex
-            }
-    }
-    return remember {
-        derivedStateOf {
-            (firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0) ||
-                lastScrolledBackward ||
-                !canScrollForward
-        }
-    }
-        .value
-}
+fun LazyGridState.shouldExpandFAB(): Boolean = lastScrolledBackward || !canScrollForward || !canScrollBackward


### PR DESCRIPTION
### Summary of Changes
1. Unified the Anime details screen "Continue Watching" Floating Action Button (FAB) design, layout, size, and drag-to-position behavior to match the Manga details screen.
2. Resolved a bug in the LazyGrid scroll state where the Anime FAB did not collapse/shrink when scrolling down the episode list.

### Details
- style(ui): unify anime details screen continue watching button with manga details screen
- fix(ui): simplify grid scroll expanding state using compose built-in lastScrolledBackward

### How to Test
1. **FAB Dragging Behavior**: Open any Anime Details Screen and drag the "Continue Watching" button horizontally. It should snap to the left/right side and persist this position (aligned with the Manga FAB preference).
2. **Scroll Collapsing Behavior**: Scroll down the episode list; the FAB should collapse (showing only the icon). Scroll back up; it should expand (showing the text).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
