### PR TITLE
Fix Browse tab position reset

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -176,10 +176,6 @@ data object BrowseTab : Tab {
         }
         val pagerState = rememberPagerState { currentTabs.size }
 
-        LaunchedEffect(browseMode) {
-            pagerState.scrollToPage(0)
-        }
-
         val currentTabIndex = pagerState.currentPage.coerceAtMost(currentTabs.lastIndex)
         val currentTab = currentTabs.getOrNull(currentTabIndex)
         val searchEnabled = currentTab?.searchEnabled ?: false


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
### Summary
Removed LaunchedEffect call that resets the Browse tab back to the starting page.
This is really minor and just bothered me when checking out extensions

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
