### PR TITLE
feat(dictionary): implement configurable parallel OCR processing for chapters

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -568,8 +568,8 @@ object SettingsDictionaryScreen : SearchableSettings {
 
         val parallelOcrSubtitle = when {
             parallelOcrLimit == 1 -> "1 chapter (Recommended - safe and stable)"
-            ocrEngine == "local" -> "$parallelOcrLimit chapters (⚠️ Warning: Running multiple OCR tasks on-device simultaneously will increase battery drain and cause the device to heat up)"
-            else -> "$parallelOcrLimit chapters (⚠️ Warning: Running multiple OCR tasks online simultaneously may cause temporary rate limits or IP blocks)"
+            ocrEngine == "local" -> "$parallelOcrLimit chapters (Running multiple OCR tasks on-device simultaneously will increase battery drain and cause the device to heat up)"
+            else -> "$parallelOcrLimit chapters (Running multiple OCR tasks online simultaneously may cause temporary rate limits or IP blocks)"
         }
 
         val navigator = LocalNavigator.currentOrThrow

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -560,6 +560,18 @@ object SettingsDictionaryScreen : SearchableSettings {
         val videoOcrAudioPaddingPref = dictionaryPreferences.videoOcrSentenceAudioPaddingSeconds()
         val videoOcrAudioPadding by videoOcrAudioPaddingPref.collectAsState()
 
+        val parallelOcrLimitPref = dictionaryPreferences.parallelOcrLimit()
+        val parallelOcrLimit by parallelOcrLimitPref.collectAsState()
+
+        val ocrEnginePref = dictionaryPreferences.ocrEngine()
+        val ocrEngine by ocrEnginePref.collectAsState()
+
+        val parallelOcrSubtitle = when {
+            parallelOcrLimit == 1 -> "1 chapter (Recommended - safe and stable)"
+            ocrEngine == "local" -> "$parallelOcrLimit chapters (⚠️ Warning: Running multiple OCR tasks on-device simultaneously will increase battery drain and cause the device to heat up)"
+            else -> "$parallelOcrLimit chapters (⚠️ Warning: Running multiple OCR tasks online simultaneously may cause temporary rate limits or IP blocks)"
+        }
+
         val navigator = LocalNavigator.currentOrThrow
         val customCssPref = dictionaryPreferences.customCss()
 
@@ -1042,6 +1054,14 @@ object SettingsDictionaryScreen : SearchableSettings {
                             }
                             true
                         },
+                    ),
+                    Preference.PreferenceItem.SliderPreference(
+                        value = parallelOcrLimit,
+                        title = "Concurrent OCR tasks",
+                        subtitle = parallelOcrSubtitle,
+                        valueRange = 1..5,
+                        steps = 3,
+                        onValueChanged = { parallelOcrLimitPref.set(it) },
                     ),
                     Preference.PreferenceItem.SliderPreference(
                         value = videoOcrAudioPadding,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrManager.kt
@@ -45,6 +45,7 @@ class OcrManager(
     private val chapterRepository: ChapterRepository = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val ocrStore: OcrStore = Injekt.get(),
+    private val ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = kotlinx.coroutines.Dispatchers.IO,
 ) {
     private val ocrCacheManager: OcrCacheManager = Injekt.get()
     private val lensClient: LensClient = Injekt.get()
@@ -78,6 +79,8 @@ class OcrManager(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val stateMutex = Mutex()
+    private val runningJobs = java.util.concurrent.ConcurrentHashMap<Long, kotlinx.coroutines.Job>()
+    private val triggerChannel = kotlinx.coroutines.channels.Channel<Unit>(kotlinx.coroutines.channels.Channel.CONFLATED)
 
     init {
         scope.launch {
@@ -134,6 +137,7 @@ class OcrManager(
         }
 
         if (changed || ocrStore.hasRunnableTasks()) {
+            triggerChannel.trySend(Unit)
             OcrJob.start(context)
         }
     }
@@ -155,6 +159,7 @@ class OcrManager(
         scope.launch {
             refreshQueueState()
         }
+        triggerChannel.trySend(Unit)
         OcrJob.start(context)
         return true
     }
@@ -180,6 +185,7 @@ class OcrManager(
 
     suspend fun cancelChapter(chapterId: Long) {
         ocrStore.remove(chapterId)
+        runningJobs[chapterId]?.cancel()
         stateMutex.withLock {
             _queueState.update { current ->
                 current.filterNot { it.chapter.id == chapterId }
@@ -246,40 +252,83 @@ class OcrManager(
         }
     }
 
-    suspend fun runPendingQueue(stopRequested: () -> Boolean) {
-        while (!stopRequested()) {
-            val task = ocrStore.getAll().firstOrNull { it.status.isRunnable() } ?: return
-            val manga = mangaRepository.getMangaById(task.mangaId)
-            val chapter = chapterRepository.getChapterById(task.chapterId)
-
-            if (manga == null || chapter == null) {
-                ocrStore.remove(task.chapterId)
-                refreshQueueState()
-                continue
+    suspend fun runPendingQueue(stopRequested: () -> Boolean) = kotlinx.coroutines.supervisorScope {
+        val dictPrefs = Injekt.get<eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences>()
+        
+        val prefJob = launch {
+            dictPrefs.parallelOcrLimit().changes().collect {
+                triggerChannel.trySend(Unit)
             }
+        }
 
-            val result = try {
-                processTask(task, manga, chapter, stopRequested)
-            } catch (e: CancellationException) {
-                if (ocrStore.get(task.chapterId) != null) {
-                    updateStoredTask(task.chapterId) { current ->
-                        current.copy(status = OcrQueueStatus.PENDING)
+        try {
+            while (!stopRequested()) {
+                val parallelLimit = dictPrefs.parallelOcrLimit().get()
+                
+                val runnableTasks = ocrStore.getAll().filter { it.status.isRunnable() }
+                val nextTask = runnableTasks.firstOrNull { !runningJobs.containsKey(it.chapterId) }
+
+                if (nextTask == null) {
+                    if (runningJobs.isEmpty()) {
+                        break
+                    }
+                    kotlinx.coroutines.withTimeoutOrNull(5000) {
+                        triggerChannel.receive()
+                    }
+                    continue
+                }
+
+                if (runningJobs.size >= parallelLimit) {
+                    kotlinx.coroutines.withTimeoutOrNull(5000) {
+                        triggerChannel.receive()
+                    }
+                    continue
+                }
+
+                val manga = mangaRepository.getMangaById(nextTask.mangaId)
+                val chapter = chapterRepository.getChapterById(nextTask.chapterId)
+
+                if (manga == null || chapter == null) {
+                    ocrStore.remove(nextTask.chapterId)
+                    refreshQueueState()
+                    continue
+                }
+
+                val job = launch(ioDispatcher, start = kotlinx.coroutines.CoroutineStart.LAZY) {
+                    try {
+                        val result = processTask(nextTask, manga, chapter, stopRequested)
+                        when (result) {
+                            OcrTaskResult.SUCCESS,
+                            OcrTaskResult.CANCELLED,
+                            -> {
+                                ocrStore.remove(nextTask.chapterId)
+                            }
+                            OcrTaskResult.ERROR -> Unit
+                            OcrTaskResult.STOPPED -> Unit
+                        }
+                    } catch (e: CancellationException) {
+                        if (ocrStore.get(nextTask.chapterId) != null) {
+                            updateStoredTask(nextTask.chapterId) { current ->
+                                current.copy(status = OcrQueueStatus.PENDING)
+                            }
+                        }
+                        throw e
+                    } catch (e: Exception) {
+                        logcat(LogPriority.ERROR, e) { "Error processing OCR task ${nextTask.chapterId}" }
+                        try {
+                            updateStoredTask(nextTask.chapterId) { it.copy(status = OcrQueueStatus.ERROR) }
+                        } catch (_: Exception) {}
+                    } finally {
+                        runningJobs.remove(nextTask.chapterId)
+                        refreshQueueState()
+                        triggerChannel.trySend(Unit)
                     }
                 }
-                refreshQueueState()
-                throw e
+                runningJobs[nextTask.chapterId] = job
+                job.start()
             }
-
-            when (result) {
-                OcrTaskResult.SUCCESS,
-                OcrTaskResult.CANCELLED,
-                -> {
-                    ocrStore.remove(task.chapterId)
-                }
-                OcrTaskResult.ERROR -> Unit
-                OcrTaskResult.STOPPED -> return
-            }
-            refreshQueueState()
+        } finally {
+            prefJob.cancel()
         }
     }
 
@@ -366,7 +415,7 @@ class OcrManager(
         }
     }
 
-    private suspend fun processTask(
+    internal suspend fun processTask(
         _task: OcrTask,
         manga: Manga,
         chapter: Chapter,
@@ -718,7 +767,7 @@ class CbzImageProvider(
     }
 }
 
-private enum class OcrTaskResult {
+internal enum class OcrTaskResult {
     SUCCESS,
     ERROR,
     CANCELLED,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryPreferences.kt
@@ -30,6 +30,8 @@ class DictionaryPreferences(
     /** "cloud" (default) or "local" */
     fun ocrEngine() = preferenceStore.getString("pref_ocr_engine", "cloud")
 
+    fun parallelOcrLimit() = preferenceStore.getInt("pref_parallel_ocr_limit", 1)
+
     fun videoOcrSentenceAudioPaddingSeconds() = preferenceStore.getInt("pref_video_ocr_sentence_audio_padding_seconds", 3)
 
     fun showFrequencyHarmonic() = preferenceStore.getBoolean("pref_dict_show_frequency_harmonic", false)

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/data/ocr/OcrManagerTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/data/ocr/OcrManagerTest.kt
@@ -1,0 +1,297 @@
+package eu.kanade.tachiyomi.data.ocr
+
+import android.content.Context
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.addSingletonFactory
+import chimahon.ocr.OcrCacheManager
+import chimahon.ocr.LensClient
+import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.chapter.repository.ChapterRepository
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.core.common.preference.Preference
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OcrManagerTest {
+    companion object {
+        private val dictionaryPreferences = mockk<DictionaryPreferences>(relaxed = true)
+        private val parallelOcrLimitPref = mockk<Preference<Int>>(relaxed = true)
+        private val changesFlow = MutableSharedFlow<Int>()
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            if (!logcat.LogcatLogger.isInstalled) {
+                logcat.LogcatLogger.install()
+                logcat.LogcatLogger.loggers += object : logcat.LogcatLogger {
+                    override fun log(priority: logcat.LogPriority, tag: String, message: String) {
+                        println("[$priority] $tag: $message")
+                    }
+                }
+            }
+            every { dictionaryPreferences.parallelOcrLimit() } returns parallelOcrLimitPref
+            every { parallelOcrLimitPref.changes() } returns changesFlow
+            
+            Injekt.addSingletonFactory<DictionaryPreferences> { dictionaryPreferences }
+            Injekt.addSingletonFactory<OcrCacheManager> { mockk(relaxed = true) }
+            Injekt.addSingletonFactory<LensClient> { mockk(relaxed = true) }
+            Injekt.addSingletonFactory<DownloadManager> { mockk(relaxed = true) }
+            Injekt.addSingletonFactory<DownloadProvider> { mockk(relaxed = true) }
+        }
+    }
+
+    @Test
+    fun testConcurrencyLimitRespected() = runTest {
+        val ocrStore = mockk<OcrStore>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>(relaxed = true)
+        val chapterRepository = mockk<ChapterRepository>(relaxed = true)
+        val sourceManager = mockk<SourceManager>(relaxed = true)
+
+        every { parallelOcrLimitPref.get() } returns 2
+
+        val task1 = OcrTask(1L, 101L, 1, false, OcrQueueStatus.PENDING)
+        val task2 = OcrTask(1L, 102L, 2, false, OcrQueueStatus.PENDING)
+        val task3 = OcrTask(1L, 103L, 3, false, OcrQueueStatus.PENDING)
+        val storeMap = mutableMapOf(101L to task1, 102L to task2, 103L to task3)
+        every { ocrStore.getAll() } answers { storeMap.values.toList() }
+        every { ocrStore.get(any()) } answers { storeMap[firstArg()] }
+
+        val mockManga = mockk<Manga>(relaxed = true)
+        val mockChapter = mockk<Chapter>(relaxed = true)
+        coEvery { mangaRepository.getMangaById(any()) } returns mockManga
+        coEvery { chapterRepository.getChapterById(any()) } returns mockChapter
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val manager = spyk(OcrManager(mockk(relaxed = true), null, null, mangaRepository, chapterRepository, sourceManager, ocrStore, testDispatcher))
+        
+        var maxActiveJobs = 0
+        var activeJobs = 0
+        coEvery { manager.processTask(any(), any(), any(), any()) } coAnswers {
+            activeJobs++
+            if (activeJobs > maxActiveJobs) {
+                maxActiveJobs = activeJobs
+            }
+            delay(1000)
+            activeJobs--
+            OcrTaskResult.SUCCESS
+        }
+
+        val queueJob = launch {
+            manager.runPendingQueue { false }
+        }
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertEquals(2, maxActiveJobs)
+        queueJob.cancel()
+    }
+
+    @Test
+    fun testDynamicLimitAdjustment() = runTest {
+        val ocrStore = mockk<OcrStore>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>(relaxed = true)
+        val chapterRepository = mockk<ChapterRepository>(relaxed = true)
+        val sourceManager = mockk<SourceManager>(relaxed = true)
+
+        every { parallelOcrLimitPref.get() } returns 1
+
+        val task1 = OcrTask(1L, 101L, 1, false, OcrQueueStatus.PENDING)
+        val task2 = OcrTask(1L, 102L, 2, false, OcrQueueStatus.PENDING)
+        val task3 = OcrTask(1L, 103L, 3, false, OcrQueueStatus.PENDING)
+        val storeMap = mutableMapOf(101L to task1, 102L to task2, 103L to task3)
+        every { ocrStore.getAll() } answers { storeMap.values.toList() }
+        every { ocrStore.get(any()) } answers { storeMap[firstArg()] }
+
+        val mockManga = mockk<Manga>(relaxed = true)
+        val mockChapter = mockk<Chapter>(relaxed = true)
+        coEvery { mangaRepository.getMangaById(any()) } returns mockManga
+        coEvery { chapterRepository.getChapterById(any()) } returns mockChapter
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val manager = spyk(OcrManager(mockk(relaxed = true), null, null, mangaRepository, chapterRepository, sourceManager, ocrStore, testDispatcher))
+        
+        var activeJobs = 0
+        coEvery { manager.processTask(any(), any(), any(), any()) } coAnswers {
+            activeJobs++
+            delay(5000)
+            activeJobs--
+            OcrTaskResult.SUCCESS
+        }
+
+        val queueJob = launch {
+            manager.runPendingQueue { false }
+        }
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertEquals(1, activeJobs)
+
+        every { parallelOcrLimitPref.get() } returns 3
+        changesFlow.emit(3)
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertEquals(3, activeJobs)
+        queueJob.cancel()
+    }
+
+    @Test
+    fun testOcrJobCancellation() = runTest {
+        val ocrStore = mockk<OcrStore>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>(relaxed = true)
+        val chapterRepository = mockk<ChapterRepository>(relaxed = true)
+        val sourceManager = mockk<SourceManager>(relaxed = true)
+
+        every { parallelOcrLimitPref.get() } returns 1
+
+        val task1 = OcrTask(1L, 101L, 1, false, OcrQueueStatus.PENDING)
+        val storeMap = mutableMapOf(101L to task1)
+        every { ocrStore.getAll() } answers { storeMap.values.toList() }
+        every { ocrStore.get(101L) } answers { storeMap[101L] }
+        every { ocrStore.remove(101L) } answers { storeMap.remove(101L) }
+        every { ocrStore.update(any(), any()) } answers {
+            val chapterId = firstArg<Long>()
+            val transform = secondArg<(OcrTask) -> OcrTask>()
+            val current = storeMap[chapterId]
+            if (current != null) {
+                val updated = transform(current)
+                storeMap[chapterId] = updated
+                updated
+            } else {
+                null
+            }
+        }
+
+        val mockManga = mockk<Manga>(relaxed = true)
+        val mockChapter = mockk<Chapter>(relaxed = true)
+        coEvery { mangaRepository.getMangaById(any()) } returns mockManga
+        coEvery { chapterRepository.getChapterById(any()) } returns mockChapter
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val manager = spyk(OcrManager(mockk(relaxed = true), null, null, mangaRepository, chapterRepository, sourceManager, ocrStore, testDispatcher))
+        
+        var isCancelled = false
+        coEvery { manager.processTask(any(), any(), any(), any()) } coAnswers {
+            try {
+                delay(10000)
+                OcrTaskResult.SUCCESS
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                isCancelled = true
+                throw e
+            }
+        }
+
+        val queueJob = launch {
+            manager.runPendingQueue { false }
+        }
+
+        runCurrent()
+        advanceTimeBy(500)
+        manager.cancelChapter(101L)
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertTrue(isCancelled)
+        
+        // Verify no resurrection: Task is permanently removed from the map
+        assertNull(storeMap[101L])
+        
+        queueJob.cancel()
+    }
+
+    @Test
+    fun testOcrJobSuccessCleanup() = runTest {
+        val ocrStore = mockk<OcrStore>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>(relaxed = true)
+        val chapterRepository = mockk<ChapterRepository>(relaxed = true)
+        val sourceManager = mockk<SourceManager>(relaxed = true)
+
+        every { parallelOcrLimitPref.get() } returns 1
+
+        val task1 = OcrTask(1L, 101L, 1, false, OcrQueueStatus.PENDING)
+        val storeMap = mutableMapOf(101L to task1)
+        every { ocrStore.getAll() } answers { storeMap.values.toList() }
+        every { ocrStore.get(101L) } answers { storeMap[101L] }
+        every { ocrStore.remove(101L) } answers { storeMap.remove(101L) }
+
+        val mockManga = mockk<Manga>(relaxed = true)
+        val mockChapter = mockk<Chapter>(relaxed = true)
+        coEvery { mangaRepository.getMangaById(any()) } returns mockManga
+        coEvery { chapterRepository.getChapterById(any()) } returns mockChapter
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val manager = spyk(OcrManager(mockk(relaxed = true), null, null, mangaRepository, chapterRepository, sourceManager, ocrStore, testDispatcher))
+        coEvery { manager.processTask(any(), any(), any(), any()) } returns OcrTaskResult.SUCCESS
+
+        val queueJob = launch {
+            manager.runPendingQueue { false }
+        }
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertTrue(storeMap.isEmpty())
+        queueJob.cancel()
+    }
+
+    @Test
+    fun testOcrJobFailureState() = runTest {
+        val ocrStore = mockk<OcrStore>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>(relaxed = true)
+        val chapterRepository = mockk<ChapterRepository>(relaxed = true)
+        val sourceManager = mockk<SourceManager>(relaxed = true)
+
+        every { parallelOcrLimitPref.get() } returns 1
+
+        val task1 = OcrTask(1L, 101L, 1, false, OcrQueueStatus.PENDING)
+        val storeMap = mutableMapOf(101L to task1)
+        every { ocrStore.getAll() } answers { storeMap.values.toList() }
+        every { ocrStore.get(101L) } answers { storeMap[101L] }
+        every { ocrStore.remove(101L) } answers { storeMap.remove(101L) }
+        every { ocrStore.update(any(), any()) } answers {
+            val chapterId = firstArg<Long>()
+            val transform = secondArg<(OcrTask) -> OcrTask>()
+            val current = storeMap[chapterId]
+            if (current != null) {
+                val updated = transform(current)
+                storeMap[chapterId] = updated
+                updated
+            } else {
+                null
+            }
+        }
+
+        val mockManga = mockk<Manga>(relaxed = true)
+        val mockChapter = mockk<Chapter>(relaxed = true)
+        coEvery { mangaRepository.getMangaById(any()) } returns mockManga
+        coEvery { chapterRepository.getChapterById(any()) } returns mockChapter
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val manager = spyk(OcrManager(mockk(relaxed = true), null, null, mangaRepository, chapterRepository, sourceManager, ocrStore, testDispatcher))
+        coEvery { manager.processTask(any(), any(), any(), any()) } throws RuntimeException("Severe OCR failure")
+
+        val queueJob = launch {
+            manager.runPendingQueue { false }
+        }
+
+        runCurrent()
+        advanceTimeBy(500)
+        assertEquals(OcrQueueStatus.ERROR, storeMap[101L]?.status)
+        queueJob.cancel()
+    }
+}


### PR DESCRIPTION
### Summary of Changes
1. Added a user-configurable slider preference under Settings > Dictionaries to limit concurrent OCR tasks between 1 and 5 (default 1).
2. Refactored the OCR queue processor to execute tasks concurrently using structured concurrency with event-driven conflated channel triggers.

### Details
- feat(dictionary): add parallel OCR limit preference and settings slider UI with battery and rate limit warning descriptions
- feat(dictionary): implement parallel OCR processing queue in OcrManager using Dispatchers.IO to prevent dispatcher thread starvation
- test(dictionary): add comprehensive OcrManagerTest covering parallel queue limits, dynamic scaling, cancellation, and error states

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
