### PR TITLE
fix(player): implement persistence and reload for manually added external audio tracks

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1505,10 +1505,11 @@ class PlayerActivity : BaseActivity() {
         val audioTracks = viewModel.currentVideo.value?.audioTracks?.takeIf { it.isNotEmpty() }
         val subtitleTracks = viewModel.currentVideo.value?.subtitleTracks?.takeIf { it.isNotEmpty() }
         val restoredSubtitleCount = viewModel.restoreAddedSubtitlesForCurrentEpisode()
+        val restoredAudioCount = viewModel.restoreAddedAudioForCurrentEpisode()
 
         // If no external audio or subtitle tracks are present, loadTracks() won't be
         // called and we need to call onFinishLoadingTracks() manually
-        if (audioTracks == null && subtitleTracks == null && restoredSubtitleCount == 0) {
+        if (audioTracks == null && subtitleTracks == null && restoredSubtitleCount == 0 && restoredAudioCount == 0) {
             viewModel.onFinishLoadingTracks()
             return
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -594,11 +594,21 @@ class PlayerViewModel @JvmOverloads constructor(
         val path = (if (isContentUri) uri.openContentFd(activity) else url)
             ?: return
         val name = if (isContentUri) uri.getFileName(activity) else null
+        val title = name ?: url.substringAfterLast('/')
+        rememberAddedAudioForCurrentEpisode(
+            AddedAudioTrack(
+                uriString = url,
+                path = path,
+                title = title,
+                isContentUri = isContentUri,
+            ),
+        )
         if (name == null) {
             MPVLib.command(arrayOf("audio-add", path, "cached"))
         } else {
             MPVLib.command(arrayOf("audio-add", path, "cached", name))
         }
+        loadTracks()
     }
 
     fun selectAudio(id: Int) {
@@ -1967,12 +1977,20 @@ class PlayerViewModel @JvmOverloads constructor(
         val isContentUri: Boolean,
     )
 
+    private data class AddedAudioTrack(
+        val uriString: String,
+        val path: String,
+        val title: String?,
+        val isContentUri: Boolean,
+    )
+
     private data class SubtitleTrackSelection(
         val primaryKey: String?,
         val secondaryKey: String?,
     )
 
     private val addedSubtitleTracksByEpisodeId = mutableMapOf<Long, MutableList<AddedSubtitleTrack>>()
+    private val addedAudioTracksByEpisodeId = mutableMapOf<Long, MutableList<AddedAudioTrack>>()
     private val subtitleTrackSelectionsByEpisodeId = mutableMapOf<Long, SubtitleTrackSelection>()
     private var pendingSubtitleSelectionKey: String? = null
 
@@ -2237,6 +2255,40 @@ class PlayerViewModel @JvmOverloads constructor(
                 MPVLib.command(arrayOf("sub-add", path, "cached"))
             } else {
                 MPVLib.command(arrayOf("sub-add", path, "cached", track.title))
+            }
+            restored += 1
+        }
+        return restored
+    }
+
+    private fun rememberAddedAudioForCurrentEpisode(track: AddedAudioTrack) {
+        val episodeId = currentEpisode.value?.id ?: return
+        val tracks = addedAudioTracksByEpisodeId.getOrPut(episodeId) { mutableListOf() }
+        val sourceKey = if (track.isContentUri) track.uriString else track.path
+        if (tracks.none { existing ->
+                existing.isContentUri == track.isContentUri &&
+                    (if (existing.isContentUri) existing.uriString else existing.path) == sourceKey
+            }
+        ) {
+            tracks += track
+        }
+    }
+
+    fun restoreAddedAudioForCurrentEpisode(): Int {
+        val episodeId = currentEpisode.value?.id ?: return 0
+        val tracks = addedAudioTracksByEpisodeId[episodeId].orEmpty()
+        var restored = 0
+        tracks.forEach { track ->
+            val path = if (track.isContentUri) {
+                Uri.parse(track.uriString).openContentFd(activity)
+            } else {
+                track.path
+            } ?: return@forEach
+
+            if (track.title == null) {
+                MPVLib.command(arrayOf("audio-add", path, "cached"))
+            } else {
+                MPVLib.command(arrayOf("audio-add", path, "cached", track.title))
             }
             restored += 1
         }


### PR DESCRIPTION
### Summary of Changes
1. Fixed manually added external audio tracks being lost upon episode switching or activity recreation.
2. Fixed the audio track selection UI not updating immediately after adding an external audio file.

### Details
- fix(player): implement persistence and reload for manually added external audio tracks