### PR TITLE
fix(player): swap incorrect values in AudioChannels enum mapping

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/AudioPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/AudioPreferences.kt
@@ -19,8 +19,8 @@ class AudioPreferences(
 }
 
 enum class AudioChannels(val titleRes: StringResource, val property: String, val value: String) {
-    Auto(MR.strings.pref_player_audio_channels_auto, "audio-channels", "auto-safe"),
-    AutoSafe(MR.strings.pref_player_audio_channels_auto_safe, "audio-channels", "auto"),
+    Auto(MR.strings.pref_player_audio_channels_auto, "audio-channels", "auto"),
+    AutoSafe(MR.strings.pref_player_audio_channels_auto_safe, "audio-channels", "auto-safe"),
     Mono(MR.strings.pref_player_audio_channels_mono, "audio-channels", "mono"),
     Stereo(MR.strings.pref_player_audio_channels_stereo, "audio-channels", "stereo"),
     ReverseStereo(MR.strings.pref_player_audio_channels_reverse_stereo, "af", "pan=[stereo|c0=c1|c1=c0]"),


### PR DESCRIPTION
### Summary of Changes
1. Swapped the incorrect internal property values of `Auto` (`auto-safe`) and `AutoSafe` (`auto`) inside the `AudioChannels` enum configuration to properly match user expectations and UI labels.

### Details
- fix(player): swap incorrect values in AudioChannels enum mapping