### PR TITLE
fix(player): make external file name resolution crash-safe

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerUtils.kt
@@ -47,9 +47,16 @@ internal fun Uri.resolveUri(context: Context): String? {
 }
 
 internal fun Uri.getFileName(context: Context): String? {
-    return context.contentResolver.query(this, null, null, null, null)?.use { cursor ->
-        val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        cursor.moveToFirst()
-        cursor.getString(nameIndex)
+    return try {
+        context.contentResolver.query(this, null, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex != -1 && cursor.moveToFirst()) {
+                cursor.getString(nameIndex)
+            } else {
+                null
+            }
+        }
+    } catch (e: Exception) {
+        null
     }
 }


### PR DESCRIPTION
### Summary of Changes
1. Added safety checks and exception handling to the `getFileName` helper function to prevent player crashes caused by empty cursors or missing metadata when retrieving file names from custom external file providers.

### Details
- fix(player): make external file name resolution crash-safe