### PR TITLE
feat: Read .mokuro files from inside archives

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1890,12 +1890,11 @@ class ReaderViewModel @JvmOverloads constructor(
                 chapterName.endsWith(".epub", ignoreCase = true) ||
                     Archive.isSupported(chapterFile)
             )
-            val mokuroFile = findMokuroFile(chapterFile, chapterName, baseDir, isArchive)
+            val content = readMokuroContent(chapterFile, chapterName, baseDir, isArchive)
                 ?: return@withLock null
 
             val imageFiles = resolveChapterImageFiles(chapterFile, chapterName)
 
-            val content = mokuroFile.openInputStream().use { it.bufferedReader().readText() }
             val mokuro = chimahon.ocr.Mokuro.parseMokuro(content)
                 ?: return@withLock null
 
@@ -2128,12 +2127,12 @@ class ReaderViewModel @JvmOverloads constructor(
         return getMokuroBlocksForPage(chapterData, pageIndex)
     }
 
-    private fun findMokuroFile(
+    private fun readMokuroContent(
         chapterFile: com.hippo.unifile.UniFile,
         chapterName: String,
         parentDir: com.hippo.unifile.UniFile,
         isArchive: Boolean,
-    ): com.hippo.unifile.UniFile? {
+    ): String? {
         val mokuroBaseName = if (isArchive) {
             chapterName.substringBeforeLast('.')
         } else {
@@ -2146,7 +2145,7 @@ class ReaderViewModel @JvmOverloads constructor(
             }
             if (insideFile != null) {
                 logcat { "Mokuro: found inside chapter folder: ${insideFile.name}" }
-                return insideFile
+                return insideFile.openInputStream().use { it.bufferedReader().readText() }
             }
         }
 
@@ -2154,11 +2153,35 @@ class ReaderViewModel @JvmOverloads constructor(
             val siblingFile = parentDir.findFile("$baseName.mokuro")
             if (siblingFile != null && siblingFile.isFile == true) {
                 logcat { "Mokuro: found as sibling: $baseName.mokuro" }
-                return siblingFile
+                return siblingFile.openInputStream().use { it.bufferedReader().readText() }
             }
         }
 
-        logcat { "Mokuro: no .mokuro file found for $chapterName (tried inside folder and sibling)" }
+        if (isArchive) {
+            val archiveContent = runCatching {
+                chapterFile.archiveReader(application).use { reader ->
+                    val entry = reader.useEntries { entries ->
+                        entries.firstOrNull {
+                            it.isFile && it.name.endsWith(".mokuro", ignoreCase = true)
+                        }
+                    } ?: return@runCatching null
+
+                    reader.getInputStream(entry.name)!!.bufferedReader().use {
+                        val text = it.readText()
+                        logcat { "Mokuro: found inside archive file: ${chapterFile.name}/${entry.name}" }
+                        text
+                    }
+                }
+            }.getOrElse { e ->
+                logcat(LogPriority.ERROR, e) { "Mokuro: failed to read .mokuro file in archive for $chapterName" }
+                null
+            }
+
+            if (archiveContent != null)
+                return archiveContent
+        }
+
+        logcat { "Mokuro: no .mokuro file found for $chapterName (tried inside folder, inside archive and siblings)" }
         return null
     }
 


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

### Summary
Changed `findMokuroFile` into `readMokuroContent`, now the function returns the file content directly instead of finding it first and reading it later, returns null if no file/content was found
Added a check for if it is an archive, if so it will try to find a .mokuro file and read from it directly

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
