### PR TITLE
fix(settings): clean up manga/source/novel overrides when deleting profile

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -1136,7 +1136,7 @@ object SettingsDictionaryScreen : SearchableSettings {
                 confirmButton = {
                     TextButton(
                         onClick = {
-                            profileStore.deleteProfile(profile.id)
+                            dictionaryPreferences.deleteProfileWithOverrides(profile.id)
                             showDeleteDialog = null
                         }
                     ) { Text("Delete") }


### PR DESCRIPTION
### Summary of Changes
1. Cleanup dynamic manga, source, and novel profile override settings in SharedPreferences when deleting a profile.

### Details
- fix(settings): clean up manga/source/novel overrides when deleting profile