### PR TITLE
fix(settings): preserve other dictionary types when reordering filtered list

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -1294,7 +1294,17 @@ object SettingsDictionaryScreen : SearchableSettings {
             if (fromIdx in dictNamesState.indices && toIdx in dictNamesState.indices) {
                 val item = dictNamesState.removeAt(fromIdx)
                 dictNamesState.add(toIdx, item)
-                profileStore.updateProfile(profileStore.getActiveProfile().copy(dictionaryOrder = dictNamesState.toList()))
+                val newOrder = if (typeFilter == null) {
+                    dictNamesState.toList()
+                } else {
+                    val fullList = orderedDicts.toMutableList()
+                    val visibleIndices = fullList.indices.filter { fullList[it] in filteredOrderedDicts }
+                    visibleIndices.forEachIndexed { i, originalIndex ->
+                        fullList[originalIndex] = dictNamesState[i]
+                    }
+                    fullList.toList()
+                }
+                profileStore.updateProfile(profileStore.getActiveProfile().copy(dictionaryOrder = newOrder))
             }
         }
 


### PR DESCRIPTION
### Summary of Changes
1. Preserve other dictionary types (frequency, pitch) when reordering dictionaries while a type filter is active.

### Details
- fix(settings): preserve other dictionary types when reordering filtered list