### PR TITLE
fix(settings): show delete button and clear paths properly for fallback word audio db

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -2601,16 +2601,24 @@ object SettingsDictionaryScreen : SearchableSettings {
                                         }
                                     }
 
-                                    if (localUri.isNotBlank()) {
+                                    if (localUri.isNotBlank() || localPath.isNotBlank()) {
                                         OutlinedButton(
                                             onClick = {
-                                                try {
-                                                    context.contentResolver.releasePersistableUriPermission(
-                                                        Uri.parse(localUri),
-                                                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                                                    )
-                                                } catch (_: Exception) { }
-                                                prefs.wordAudioLocalUri().set("")
+                                                if (localUri.isNotBlank()) {
+                                                    try {
+                                                        context.contentResolver.releasePersistableUriPermission(
+                                                            Uri.parse(localUri),
+                                                            Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                                                        )
+                                                    } catch (_: Exception) { }
+                                                    prefs.wordAudioLocalUri().set("")
+                                                }
+                                                if (localPath.isNotBlank()) {
+                                                    try {
+                                                        File(localPath).delete()
+                                                    } catch (_: Exception) { }
+                                                    prefs.wordAudioLocalPath().set("")
+                                                }
                                             },
                                             enabled = !isImportingDb
                                         ) {


### PR DESCRIPTION
### Summary of Changes
1. Show the "Delete Database" button for local audio database settings when using the fallback internal path.
2. Clear both `wordAudioLocalUri` and `wordAudioLocalPath` preferences when deleting a local database.

### Details
- fix(settings): show delete button and clear paths properly for fallback word audio db