### PR TITLE
fix(settings): invalidate reader profile cache on profile content changes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/novels/ChimaReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/novels/ChimaReaderActivity.kt
@@ -122,6 +122,15 @@ class ChimaReaderActivity : NovelReaderActivity() {
                 }
             }
         }
+
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                prefs.rawProfiles().changes().collect {
+                    cachedActiveProfile = null
+                    cachedTermPaths = null
+                }
+            }
+        }
     }
 
     override fun getSettingsNamespace(): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -372,6 +372,16 @@ class ReaderActivity : BaseActivity() {
                     }
                 }
             }
+
+            lifecycleScope.launch {
+                lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    prefs.rawProfiles().changes().collect {
+                        // Profile content changed — invalidate cache so next access re-resolves
+                        cachedActiveProfile = null
+                        cachedTermPaths = null
+                    }
+                }
+            }
         }
 
         binding = ReaderActivityBinding.inflate(layoutInflater)


### PR DESCRIPTION
### Summary of Changes
1. Listen to `rawProfiles().changes()` in ReaderActivity and ChimaReaderActivity to invalidate cached active profile and dictionary paths whenever the contents of any profile are updated.

### Details
- fix(settings): invalidate reader profile cache on profile content changes