### PR TITLE
fix(dictionary): implement missing cache check in getDictionaryPaths

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -90,6 +90,16 @@ fun getDictionaryPaths(context: android.content.Context, activeProfileOverride: 
     val dictionariesDir = File(context.getExternalFilesDir(null), "dictionaries")
     if (!dictionariesDir.exists()) return chimahon.DictionaryPaths()
 
+    val currentModified = dictionariesDir.lastModified()
+    if (cachedDictionaryPaths != null && lastDictDirModified == currentModified) {
+        val activeProfile = activeProfileOverride ?: run {
+            try { Injekt.get<DictionaryPreferences>().profileStore.getActiveProfile() } catch (_: Exception) { null }
+        }
+        if (activeProfile != null && lastProfileHash == activeProfile.hashCode()) {
+            return cachedDictionaryPaths!!
+        }
+    }
+
     val typeDirs = mapOf(
         "term" to File(dictionariesDir, "term"),
         "frequency" to File(dictionariesDir, "frequency"),


### PR DESCRIPTION
### Summary of Changes
1. Implement the missing caching check at the beginning of `getDictionaryPaths` to avoid redundant file system scanning if the dictionaries directory modification time and the active profile hash are unchanged.

### Details
- fix(dictionary): implement missing cache check in getDictionaryPaths