### PR TITLE
fix(dictionary): refresh active search results on profile changes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -331,6 +331,15 @@ data object DictionaryTab : Tab {
             }
         }
 
+        LaunchedEffect(activeProfile) {
+            val trimmed = query.trim()
+            if (trimmed.isNotEmpty() && hasSearched) {
+                lookupStack.clear()
+                activeTabIndex = 0
+                stackLookup(trimmed)
+            }
+        }
+
         // Simple callback for Anki lookup - index maps to results array, glossaryIndex is optional
         val onAnkiLookup: ((Int, Int?, String?, String?, Boolean) -> Unit)? = if (ankiEnabled) {
             { resultIndex, glossaryIndex, selectedDict, popupSelection, forceOpen ->


### PR DESCRIPTION
### Summary of Changes
1. Add `LaunchedEffect(activeProfile)` in `DictionaryTab` to automatically refresh and re-run search query lookup when the active profile or its dictionary configuration is changed.

### Details
- fix(dictionary): refresh active search results on profile changes