### PR TITLE
fix(browse): catch LinkageError to prevent crashes from outdated extensions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/animesource/globalsearch/AnimeSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/animesource/globalsearch/AnimeSearchScreenModel.kt
@@ -171,6 +171,10 @@ abstract class AnimeSearchScreenModel(
                         if (isActive) {
                             updateItem(source, AnimeSearchItemResult.Error(e))
                         }
+                    } catch (e: LinkageError) {
+                        if (isActive) {
+                            updateItem(source, AnimeSearchItemResult.Error(e))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -298,6 +298,8 @@ open class FeedScreenModel(
                         }
                     } catch (e: Exception) {
                         emptyList()
+                    } catch (e: LinkageError) {
+                        emptyList()
                     }
 
                     val result = withIOContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -250,6 +250,8 @@ open class SourceFeedScreenModel(
                         }.mangas
                     } catch (e: Exception) {
                         emptyList()
+                    } catch (e: LinkageError) {
+                        emptyList()
                     }
 
                     val titles = withIOContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -200,6 +200,10 @@ abstract class SearchScreenModel(
                         if (isActive) {
                             updateItem(source, SearchItemResult.Error(e))
                         }
+                    } catch (e: LinkageError) {
+                        if (isActive) {
+                            updateItem(source, SearchItemResult.Error(e))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary of Changes
1. Prevent app crashes caused by NoSuchMethodError when searching or viewing feeds from outdated/incompatible extensions by explicitly catching LinkageError.

### Details
- fix(browse): catch LinkageError when fetching manga/anime from sources in SearchScreenModel, AnimeSearchScreenModel, SourceFeedScreenModel, and FeedScreenModel