### PR TITLE
Add animated AVIF scene mining for Anki

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -80,6 +80,7 @@ import chimahon.HoshiDicts
 import chimahon.anki.AnkiCardCreator
 import chimahon.anki.AnkiDroidBridge
 import chimahon.anki.AnkiProfile
+import chimahon.anki.AnkiScreenshotMode
 import chimahon.anki.LapisPreset
 import chimahon.anki.Marker
 import chimahon.dictionary.readDictionaryIndex
@@ -2008,6 +2009,8 @@ object SettingsDictionaryScreen : SearchableSettings {
         val cropModeEntries = persistentListOf(
             "full" to "Screenshot",
             "crop" to "Crop Overlay",
+            AnkiScreenshotMode.ANIMATED_SCENE.storageValue to
+                stringResource(KMR.strings.pref_anki_screenshot_animated_scene),
             "no_screenshot" to "No Screenshot",
         ).associate { it.first to it.second }.toPersistentMap()
         val cropPresetEntries = persistentListOf(
@@ -2292,7 +2295,10 @@ object SettingsDictionaryScreen : SearchableSettings {
                     ),
                 )
 
-                if (cropMode != "no_screenshot") {
+                if (
+                    cropMode != "no_screenshot" &&
+                    cropMode != AnkiScreenshotMode.ANIMATED_SCENE.storageValue
+                ) {
                     add(
                         Preference.PreferenceItem.BasicListPreference(
                             value = cropPreset.takeIf { it in cropPresetMap } ?: "full",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -507,6 +507,7 @@ class PlayerActivity : BaseActivity() {
 
     override fun onDestroy() {
         player.isExiting = true
+        viewModel.onPlayerActivityDestroyed()
 
         audioFocusRequest?.let {
             AudioManagerCompat.abandonAudioFocusRequest(audioManager, it)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -33,9 +33,6 @@ import android.provider.Settings
 import android.util.DisplayMetrics
 import android.view.inputmethod.InputMethodManager
 import androidx.compose.runtime.Immutable
-import com.arthenica.ffmpegkit.FFmpegKitConfig
-import com.arthenica.ffmpegkit.FFmpegSession
-import com.arthenica.ffmpegkit.ReturnCode
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -43,6 +40,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import chimahon.anki.AnkiMediaRequest
+import chimahon.anki.AnkiScreenshotMode
+import chimahon.anki.AnkiScreenshotPreparation
+import chimahon.anki.LazyAnkiMediaProvider
+import chimahon.anki.LazyAnkiScreenshotProvider
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.domain.entries.anime.interactor.SetAnimeViewerFlags
 import eu.kanade.domain.base.BasePreferences
@@ -78,6 +80,21 @@ import eu.kanade.tachiyomi.ui.player.controls.components.sheets.HosterState
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.getChangedAt
 import eu.kanade.tachiyomi.ui.player.loader.EpisodeLoader
 import eu.kanade.tachiyomi.ui.player.loader.HosterLoader
+import eu.kanade.tachiyomi.ui.player.scene.AndroidSceneCaptureService
+import eu.kanade.tachiyomi.ui.player.scene.CapturedOcrFrame
+import eu.kanade.tachiyomi.ui.player.scene.FrozenSceneSentenceAudioService
+import eu.kanade.tachiyomi.ui.player.scene.PlayerSceneMiningCoordinator
+import eu.kanade.tachiyomi.ui.player.scene.PlayerSceneMiningProgress
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureInputSnapshot
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureRequest
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureRequestFactory
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureService
+import eu.kanade.tachiyomi.ui.player.scene.SceneClockDomain
+import eu.kanade.tachiyomi.ui.player.scene.SceneMpvSnapshot
+import eu.kanade.tachiyomi.ui.player.scene.SceneRangeCandidate
+import eu.kanade.tachiyomi.ui.player.scene.SceneRangeProvenance
+import eu.kanade.tachiyomi.ui.player.scene.SceneSentenceAudioService
+import eu.kanade.tachiyomi.ui.player.scene.SceneVideoInputSnapshot
 import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
@@ -106,13 +123,14 @@ import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.lang.takeBytes
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
-import eu.kanade.tachiyomi.util.storage.toFFmpegString
 import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.Utils
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
@@ -155,10 +173,12 @@ import tachiyomi.i18n.MR
 import tachiyomi.source.local.entries.anime.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.Closeable
 import java.io.File
 import java.io.InputStream
-import java.util.Locale
+import java.util.Collections
 import java.util.Date
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.first
 import kotlin.coroutines.cancellation.CancellationException
@@ -173,7 +193,7 @@ class PlayerViewModelProviderFactory(
     }
 }
 
-class PlayerViewModel @JvmOverloads constructor(
+class PlayerViewModel @JvmOverloads internal constructor(
     private val activity: PlayerActivity,
     private val savedState: SavedStateHandle,
     private val sourceManager: AnimeSourceManager = Injekt.get(),
@@ -201,6 +221,9 @@ class PlayerViewModel @JvmOverloads constructor(
     private val getCustomButtons: GetCustomButtons = Injekt.get(),
     private val trackSelect: TrackSelect = Injekt.get(),
     private val jimakuApi: JimakuApi = JimakuApi(),
+    private val sceneCaptureRequestFactory: SceneCaptureRequestFactory = SceneCaptureRequestFactory(),
+    private val sceneCaptureService: () -> SceneCaptureService = { AndroidSceneCaptureService(activity) },
+    private val sceneSentenceAudioService: SceneSentenceAudioService = FrozenSceneSentenceAudioService(activity),
     uiPreferences: UiPreferences = Injekt.get(),
 ) : ViewModel() {
 
@@ -248,7 +271,7 @@ class PlayerViewModel @JvmOverloads constructor(
     private val _subtitlesVisible = MutableStateFlow(true)
     val subtitlesVisible = _subtitlesVisible.asStateFlow()
     private val _subtitleHistory = MutableStateFlow<List<SubtitleCue>>(emptyList())
-    val subtitleHistory = _subtitleHistory.asStateFlow()
+    internal val subtitleHistory = _subtitleHistory.asStateFlow()
     private val _activeSubtitleCueIndex = MutableStateFlow<Int?>(null)
     val activeSubtitleCueIndex = _activeSubtitleCueIndex.asStateFlow()
     private val _primarySubtitleDelaySeconds = MutableStateFlow(0.0)
@@ -357,13 +380,21 @@ class PlayerViewModel @JvmOverloads constructor(
 
     private val _customButtons = MutableStateFlow<CustomButtonFetchState>(CustomButtonFetchState.Loading)
 
-    private val _ocrScreenshot = MutableStateFlow<Bitmap?>(null)
-    val ocrScreenshot: StateFlow<Bitmap?> = _ocrScreenshot.asStateFlow()
+    private val ocrFrameLock = Any()
+    private val ocrFrameState = MutableStateFlow<CapturedOcrFrame?>(null)
+    internal val ocrFrame: StateFlow<CapturedOcrFrame?> = ocrFrameState.asStateFlow()
     private val _isCapturingOcr = MutableStateFlow(false)
     val isCapturingOcr: StateFlow<Boolean> = _isCapturingOcr.asStateFlow()
     private val _suppressTap = MutableStateFlow(false)
     val suppressTap: StateFlow<Boolean> = _suppressTap.asStateFlow()
     val customButtons = _customButtons.asStateFlow()
+
+    private val sceneRequests = Collections.synchronizedSet(mutableSetOf<SceneCaptureRequest>())
+    private val sceneMiningCoordinator = PlayerSceneMiningCoordinator(
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+        sceneCaptureService = sceneCaptureService,
+    )
+    internal val sceneMiningProgress: StateFlow<PlayerSceneMiningProgress> = sceneMiningCoordinator.progress
 
     private val _primaryButtonTitle = MutableStateFlow("")
     val primaryButtonTitle = _primaryButtonTitle.asStateFlow()
@@ -545,12 +576,13 @@ class PlayerViewModel @JvmOverloads constructor(
     )
 
     @Immutable
-    data class SubtitleCue(
+    internal data class SubtitleCue(
         val index: Int,
         val text: String,
         val positionSeconds: Double,
         val endPositionSeconds: Double = positionSeconds + 5.0,
         val rawText: String = text,
+        val sceneTimingCandidate: SceneRangeCandidate? = null,
     )
 
     sealed interface JimakuState {
@@ -1199,7 +1231,8 @@ class PlayerViewModel @JvmOverloads constructor(
 
                 val timeParts = lines[timeIndex].split("-->", limit = 2)
                 val start = timeParts.getOrNull(0)?.let { parseSubtitleTimestampSeconds(it) } ?: return@forEach
-                val end = timeParts.getOrNull(1)?.let { parseSubtitleTimestampSeconds(it) } ?: (start + 5.0)
+                val parsedEnd = timeParts.getOrNull(1)?.let { parseSubtitleTimestampSeconds(it) }
+                val end = parsedEnd ?: (start + 5.0)
                 val text = lines.drop(timeIndex + 1)
                     .joinToString("\n")
                     .cleanMpvSubtitleText()
@@ -1210,6 +1243,14 @@ class PlayerViewModel @JvmOverloads constructor(
                         text = text,
                         positionSeconds = start,
                         endPositionSeconds = end.coerceAtLeast(start + 1.0),
+                        sceneTimingCandidate = parsedEnd?.let {
+                            SceneRangeCandidate(
+                                startSeconds = start,
+                                endSeconds = it,
+                                clockDomain = SceneClockDomain.SUBTITLE,
+                                provenance = SceneRangeProvenance.PARSED_SUBTITLE_CUE,
+                            )
+                        },
                     )
                 }
             }
@@ -1253,7 +1294,8 @@ class PlayerViewModel @JvmOverloads constructor(
             if (values.size <= maxOf(startIndex, endIndex, textIndex)) return@forEach
 
             val start = parseSubtitleTimestampSeconds(values[startIndex]) ?: return@forEach
-            val end = parseSubtitleTimestampSeconds(values[endIndex]) ?: (start + 5.0)
+            val parsedEnd = parseSubtitleTimestampSeconds(values[endIndex])
+            val end = parsedEnd ?: (start + 5.0)
             val text = values[textIndex].cleanMpvSubtitleText()
             if (text.isBlank()) return@forEach
 
@@ -1262,6 +1304,14 @@ class PlayerViewModel @JvmOverloads constructor(
                 text = text,
                 positionSeconds = start,
                 endPositionSeconds = end.coerceAtLeast(start + 1.0),
+                sceneTimingCandidate = parsedEnd?.let {
+                    SceneRangeCandidate(
+                        startSeconds = start,
+                        endSeconds = it,
+                        clockDomain = SceneClockDomain.SUBTITLE,
+                        provenance = SceneRangeProvenance.PARSED_SUBTITLE_CUE,
+                    )
+                },
             )
         }
         return cues
@@ -1480,19 +1530,28 @@ class PlayerViewModel @JvmOverloads constructor(
         }
         pause()
         viewModelScope.launch {
-            val screenshot = captureVideoFrameForOcr()
-            _isCapturingOcr.value = false
-            _suppressTap.value = false
-            if (screenshot == null) {
-                eventChannel.send(Event.OcrFailed)
-            } else {
-                _ocrScreenshot.value = screenshot
+            try {
+                val paddingSeconds = dictionaryPreferences.videoOcrSentenceAudioPaddingSeconds().get().toDouble()
+                val frame = sceneCaptureRequestFactory.captureOcr(
+                    videoSnapshot = ::sceneVideoInputSnapshot,
+                    paddingSeconds = paddingSeconds,
+                    captureFallback = ::captureVideoFrameForOcr,
+                )
+                if (frame == null) {
+                    eventChannel.send(Event.OcrFailed)
+                } else {
+                    sceneRequests += frame.request
+                    replaceOcrFrame(frame)?.let { releaseSceneRequest(it.request) }
+                }
+            } finally {
+                _isCapturingOcr.value = false
+                _suppressTap.value = false
             }
         }
     }
 
     fun dismissOcrScreenshot() {
-        _ocrScreenshot.value = null
+        replaceOcrFrame(null)?.let { releaseSceneRequest(it.request) }
     }
 
     fun hideSeekBar() {
@@ -1932,12 +1991,19 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     override fun onCleared() {
+        sceneMiningCoordinator.shutdown()
+        replaceOcrFrame(null)?.let { releaseSceneRequest(it.request) }
+        synchronized(sceneRequests) {
+            sceneRequests.toList().forEach { it.close() }
+            sceneRequests.clear()
+        }
         if (currentEpisode.value != null) {
             saveWatchingProgress(currentEpisode.value!!)
             episodeToDownload?.let {
                 downloadManager.addDownloadsToStartOfQueue(listOf(it))
             }
         }
+        super.onCleared()
     }
 
     fun updateCastProgress(position: Float) {
@@ -3084,97 +3150,144 @@ class PlayerViewModel @JvmOverloads constructor(
     }
 
     suspend fun captureVideoFrameForOcr(): Bitmap? {
-        val file = File(cachePath, "${System.currentTimeMillis()}_mpv_ocr_frame.png")
-        return runCatching {
+        val file = File(cachePath, "${UUID.randomUUID()}_mpv_ocr_frame.png")
+        return try {
             withUIContext {
                 file.delete()
                 MPVLib.command(arrayOf("screenshot-to-file", file.absolutePath, "video"))
             }
             withIOContext {
                 repeat(20) {
-                    if (file.exists() && file.length() > 0L) {
-                        return@withIOContext BitmapFactory.decodeFile(file.absolutePath)
+                    if (file.isFile && file.length() > 0L) {
+                        BitmapFactory.decodeFile(file.absolutePath)?.let { return@withIOContext it }
                     }
-                    Thread.sleep(25L)
+                    delay(25L)
                 }
-                file.takeIf { it.exists() && it.length() > 0L }
+                file.takeIf { it.isFile && it.length() > 0L }
                     ?.let { BitmapFactory.decodeFile(it.absolutePath) }
             }
-        }.onFailure {
-            logcat(LogPriority.ERROR, it)
-        }.getOrNull().also {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            null
+        } finally {
             file.delete()
         }
     }
 
-    suspend fun captureSubtitleAudioForAnki(startSeconds: Double?, endSeconds: Double?): ByteArray? {
-        val start = startSeconds ?: return null
-        val end = endSeconds ?: return null
-        if (end <= start) return null
+    internal suspend fun captureSubtitleSceneRequest(
+        parsedSubtitleCandidate: SceneRangeCandidate?,
+    ): SceneCaptureRequest? {
+        val request = sceneCaptureRequestFactory.captureSubtitle(
+            videoSnapshot = ::sceneVideoInputSnapshot,
+            parsedSubtitleCandidates = listOfNotNull(parsedSubtitleCandidate),
+            captureFallback = ::captureVideoFrameForOcr,
+        ) ?: return null
+        sceneRequests += request
+        return request
+    }
 
-        val video = currentVideo.value ?: return null
-        val output = File(activity.cacheDir, "chimahon_sentence_audio_${System.currentTimeMillis()}.m4a")
-        return runCatching {
-            withIOContext {
-                output.delete()
-
-                // For video-only streams (e.g. YouTube DASH), use the separate audio track URL
-                val audioSource = video.audioTracks.firstOrNull()?.url
-                val rawInput = audioSource
-                    ?: MPVLib.getPropertyString("path")
-                        ?.takeIf { it.isNotBlank() }
-                        ?: video.videoUrl
-                val input = when {
-                    video.videoUrl.startsWith("content://") -> Uri.parse(video.videoUrl).toFFmpegString(activity)
-                    rawInput.startsWith("file://") -> Uri.parse(rawInput).path ?: rawInput
-                    else -> rawInput
-                }.replace("\"", "\\\"")
-
-                val source = currentSource.value as? AnimeHttpSource
-                val headers = video.headers ?: source?.headers
-                val headerOptions = if (rawInput.startsWith("http") && headers != null) {
-                    headers.joinToString("", "-headers '", "'") {
-                        "${it.first}: ${it.second.replace("'", "'\\''")}\r\n"
-                    }
-                } else {
-                    ""
+    internal fun createSceneMediaRequest(
+        request: SceneCaptureRequest?,
+        screenshotMode: String,
+    ): AnkiMediaRequest {
+        val mode = AnkiScreenshotMode.fromStorageValue(screenshotMode)
+        return AnkiMediaRequest(
+            screenshotProvider = request
+                ?.takeUnless { mode == AnkiScreenshotMode.NONE }
+                ?.let { frozenRequest ->
+                LazyAnkiScreenshotProvider {
+                    sceneMiningCoordinator.prepareScreenshot(frozenRequest, mode)
                 }
-                val duration = (end - start).coerceIn(0.25, 30.0)
-                val command = listOf(
-                    headerOptions,
-                    "-ss ${start.coerceAtLeast(0.0).formatSeconds()}",
-                    "-t ${duration.formatSeconds()}",
-                    "-i \"$input\"",
-                    "-vn",
-                    "-map 0:a:0",
-                    "-c:a copy",
-                    "\"${output.absolutePath.replace("\"", "\\\"")}\"",
-                    "-y",
-                )
-                    .filter { it.isNotBlank() }
-                    .joinToString(" ")
-                val session = FFmpegSession.create(FFmpegKitConfig.parseArguments(command))
-                FFmpegKitConfig.ffmpegExecute(session)
-                if (ReturnCode.isSuccess(session.returnCode) && output.exists() && output.length() > 0L) {
-                    output.readBytes()
-                } else {
-                    session.failStackTrace?.let { logcat(LogPriority.WARN) { it } }
-                    null
+            },
+            sentenceAudioProvider = request?.let { frozenRequest ->
+                LazyAnkiMediaProvider {
+                    sceneSentenceAudioService.prepare(frozenRequest)
                 }
-            }
-        }.onFailure {
-            logcat(LogPriority.WARN, it) { "Failed to capture subtitle sentence audio" }
-        }.getOrNull().also {
-            output.delete()
+            },
+            onCommitStarted = sceneMiningCoordinator::markCommitStarted,
+        )
+    }
+
+    internal fun launchSceneMining(
+        request: SceneCaptureRequest?,
+        block: suspend () -> Unit,
+    ): Boolean {
+        return if (request != null) {
+            sceneMiningCoordinator.launch(request, block)
+        } else {
+            sceneMiningCoordinator.launchWithLease(
+                acquireLease = { Closeable {} },
+                block = block,
+            )
         }
     }
 
-    suspend fun captureVideoOcrAudioForAnki(): ByteArray? {
-        val centerSeconds = activity.player.timePos?.toDouble() ?: pos.value.toDouble()
-        val paddingSeconds = dictionaryPreferences.videoOcrSentenceAudioPaddingSeconds().get().toDouble()
-        return captureSubtitleAudioForAnki(
-            startSeconds = centerSeconds - paddingSeconds,
-            endSeconds = centerSeconds + paddingSeconds,
+    internal fun cancelSceneMiningPreCommit() {
+        sceneMiningCoordinator.cancelPreCommit()
+    }
+
+    internal fun onPlayerActivityDestroyed() {
+        sceneMiningCoordinator.cancelPreCommit()
+        replaceOcrFrame(null)?.let { releaseSceneRequest(it.request) }
+    }
+
+    internal fun releaseSceneRequest(request: SceneCaptureRequest) {
+        sceneRequests -= request
+        request.close()
+    }
+
+    private fun replaceOcrFrame(frame: CapturedOcrFrame?): CapturedOcrFrame? {
+        return synchronized(ocrFrameLock) {
+            val previous = ocrFrameState.value
+            ocrFrameState.value = frame
+            previous
+        }
+    }
+
+    private fun sceneVideoInputSnapshot(mpv: SceneMpvSnapshot): SceneCaptureInputSnapshot? {
+        val video = currentVideo.value ?: return null
+        val headers = (
+            video.headers
+                ?: (currentSource.value as? AnimeHttpSource)?.headers
+            )?.toList().orEmpty()
+        val originalValue = video.videoUrl
+        val stableLocalFile = when {
+            originalValue.startsWith("/") -> File(originalValue).isFile
+            originalValue.startsWith("file://", ignoreCase = true) -> {
+                Uri.parse(originalValue).path?.let(::File)?.isFile == true
+            }
+            else -> false
+        }
+        val videoInput = SceneVideoInputSnapshot(
+            originalVideoValue = originalValue,
+            playableValue = mpv.playableValue,
+            headers = headers,
+            ffmpegStreamArgs = video.ffmpegStreamArgs.toList(),
+            ffmpegVideoArgs = video.ffmpegVideoArgs.toList(),
+            seekable = mpv.seekable ?: stableLocalFile,
+            videoStreamIndex = mpv.selectedVideoFfmpegIndex,
+            audioStreamIndex = mpv.selectedAudioFfmpegIndex
+                ?.takeUnless { mpv.selectedAudioIsExternal },
+        )
+        val sentenceAudioInput = if (mpv.selectedAudioIsExternal) {
+            val audioValue = mpv.selectedExternalAudioValue.orEmpty()
+            SceneVideoInputSnapshot(
+                originalVideoValue = audioValue,
+                playableValue = audioValue,
+                headers = headers,
+                ffmpegStreamArgs = emptyList(),
+                ffmpegVideoArgs = emptyList(),
+                seekable = mpv.seekable ?: stableLocalFile,
+                audioStreamIndex = null,
+            )
+        } else {
+            null
+        }
+        return SceneCaptureInputSnapshot(
+            video = videoInput,
+            sentenceAudio = sentenceAudioInput,
         )
     }
 
@@ -3518,8 +3631,4 @@ fun CustomButton.executeLongPress() {
 
 fun Float.normalize(inMin: Float, inMax: Float, outMin: Float, outMax: Float): Float {
     return (this - inMin) * (outMax - outMin) / (inMax - inMin) + outMin
-}
-
-private fun Double.formatSeconds(): String {
-    return String.format(Locale.US, "%.3f", this)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -50,11 +50,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
@@ -103,6 +105,7 @@ import eu.kanade.tachiyomi.ui.player.controls.components.VolumeSlider
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitlesBorderStyle
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.toColorHexString
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.toFixed
+import eu.kanade.tachiyomi.ui.player.scene.SceneRangeCandidate
 import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
 import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
@@ -112,8 +115,10 @@ import eu.kanade.tachiyomi.ui.reader.viewer.isLookupStartChar
 import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
@@ -159,7 +164,7 @@ fun PlayerControls(
     val subtitlesVisible by viewModel.subtitlesVisible.collectAsState()
     val subtitleCues by viewModel.subtitleHistory.collectAsState()
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
-    val primarySubtitleDelaySeconds by viewModel.primarySubtitleDelaySeconds.collectAsState()
+    val sceneMiningProgress by viewModel.sceneMiningProgress.collectAsState()
     val panel by viewModel.panelShown.collectAsState()
     val activeSubtitleCue = remember(subtitleCues, activeSubtitleCueIndex) {
         subtitleCues.firstOrNull { it.index == activeSubtitleCueIndex }
@@ -169,7 +174,9 @@ fun PlayerControls(
     var isSeeking by remember { mutableStateOf(false) }
     var resetControls by remember { mutableStateOf(true) }
     var subtitleLookupRequest by remember { mutableStateOf<SubtitleLookupRequest?>(null) }
+    var subtitleLookupCaptureJob by remember { mutableStateOf<Job?>(null) }
     var wasPlayerAlreadyPause by remember { mutableStateOf(false) }
+    val subtitleLookupScope = rememberCoroutineScope()
     val customButtons by viewModel.customButtons.collectAsState()
     val customButton by viewModel.primaryButton.collectAsState()
 
@@ -191,12 +198,33 @@ fun PlayerControls(
         animationSpec = if (overlayTarget > 0f) playerControlsEnterAnimationSpec() else playerControlsExitAnimationSpec(),
         label = "controls_transparent_overlay",
     )
+    fun releaseSubtitleLookupRequest() {
+        subtitleLookupRequest
+            ?.sceneCaptureRequest
+            ?.let(viewModel::releaseSceneRequest)
+        subtitleLookupRequest = null
+    }
+
+    fun dismissSubtitleLookup() {
+        subtitleLookupCaptureJob?.cancel()
+        subtitleLookupCaptureJob = null
+        releaseSubtitleLookupRequest()
+        if (!wasPlayerAlreadyPause) viewModel.unpause()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            subtitleLookupCaptureJob?.cancel()
+            releaseSubtitleLookupRequest()
+        }
+    }
+
     val openSubtitleLookup: (SubtitleLookupSelection) -> Unit = openSubtitleLookup@{ subtitleLookup ->
         if (subtitleLookupRequest?.matchesTap(subtitleLookup) == true) {
-            subtitleLookupRequest = null
-            if (!wasPlayerAlreadyPause) viewModel.unpause()
+            dismissSubtitleLookup()
             return@openSubtitleLookup
         }
+        if (subtitleLookupCaptureJob?.isActive == true) return@openSubtitleLookup
         val currentPanel = viewModel.panelShown.value
         if (
             viewModel.sheetShown.value != Sheets.None ||
@@ -207,7 +235,8 @@ fun PlayerControls(
         }
         wasPlayerAlreadyPause = viewModel.paused.value
         viewModel.pause()
-        subtitleLookupRequest = SubtitleLookupRequest(
+        releaseSubtitleLookupRequest()
+        val baseRequest = SubtitleLookupRequest(
             lookupString = subtitleLookup.lookupString,
             fullText = subtitleLookup.fullText,
             charOffset = subtitleLookup.charOffset,
@@ -223,9 +252,19 @@ fun PlayerControls(
             lineTop = subtitleLookup.lineTop,
             lineWidth = subtitleLookup.lineWidth,
             lineHeight = subtitleLookup.lineHeight,
-            cueStartSeconds = subtitleLookup.cueStartSeconds,
-            cueEndSeconds = subtitleLookup.cueEndSeconds,
         )
+        subtitleLookupCaptureJob = subtitleLookupScope.launch {
+            var sceneRequest = viewModel.captureSubtitleSceneRequest(
+                parsedSubtitleCandidate = subtitleLookup.parsedSubtitleCandidate,
+            )
+            if (!isActive) {
+                sceneRequest?.let(viewModel::releaseSceneRequest)
+                return@launch
+            }
+            subtitleLookupRequest = baseRequest.copy(sceneCaptureRequest = sceneRequest)
+            sceneRequest = null
+            subtitleLookupCaptureJob = null
+        }
     }
     val togglePanel: (Panels) -> Unit = { panel ->
         viewModel.showPanel(
@@ -248,15 +287,15 @@ fun PlayerControls(
     )
     Box(Modifier.fillMaxSize()) {
         if (subtitleLookupRequest != null) {
-            Box(Modifier.fillMaxSize().clickable {
-                subtitleLookupRequest = null
-                if (!wasPlayerAlreadyPause) viewModel.unpause()
-            })
+            Box(
+                Modifier.fillMaxSize().clickable {
+                    dismissSubtitleLookup()
+                },
+            )
         }
         PlayerSubtitleTextLayer(
             text = if (subtitlesVisible) currentSubtitleText else "",
             cue = activeSubtitleCue,
-            subtitleDelaySeconds = primarySubtitleDelaySeconds,
             request = subtitleLookupRequest,
             onLookup = openSubtitleLookup,
         )
@@ -807,10 +846,7 @@ fun PlayerControls(
         PlayerSubtitleLookupPopup(
             viewModel = viewModel,
             request = subtitleLookupRequest,
-            onDismiss = {
-                subtitleLookupRequest = null
-                if (!wasPlayerAlreadyPause) viewModel.unpause()
-            },
+            onDismiss = ::dismissSubtitleLookup,
             onTermMatched = { count, offset ->
                 subtitleLookupRequest = subtitleLookupRequest?.copy(
                     matchedCharCount = count,
@@ -823,11 +859,16 @@ fun PlayerControls(
             brightness = currentBrightness,
         )
 
-        val ocrScreenshot by viewModel.ocrScreenshot.collectAsState()
+        val ocrFrame by viewModel.ocrFrame.collectAsState()
         PlayerVideoOcrOverlay(
             viewModel = viewModel,
-            screenshot = ocrScreenshot,
+            frame = ocrFrame,
             onDismiss = dismissVideoOcr,
+        )
+
+        PlayerSceneMiningProgressDialog(
+            progress = sceneMiningProgress,
+            onCancel = viewModel::cancelSceneMiningPreCommit,
         )
     }
 
@@ -844,7 +885,6 @@ fun PlayerControls(
 private fun PlayerSubtitleTextLayer(
     text: String,
     cue: PlayerViewModel.SubtitleCue?,
-    subtitleDelaySeconds: Double,
     request: SubtitleLookupRequest?,
     onLookup: (SubtitleLookupSelection) -> Unit,
     modifier: Modifier = Modifier,
@@ -968,17 +1008,17 @@ private fun PlayerSubtitleTextLayer(
                         )
                     }
                 }
-                .pointerInput(subtitleText, textLayout, textLayerOrigin, subtitleDelaySeconds) {
+                .pointerInput(subtitleText, textLayout, textLayerOrigin, cue) {
                     detectTapGestures(
                         onTap = { position ->
                             val layout = textLayout ?: return@detectTapGestures
-                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue, subtitleDelaySeconds)
+                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue)
                                 ?.offsetBy(textLayerOrigin)
                                 ?.let(onLookup)
                         },
                         onLongPress = { position ->
                             val layout = textLayout ?: return@detectTapGestures
-                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue, subtitleDelaySeconds)
+                            layout.subtitleLookupSelectionForTap(subtitleText, position, cue)
                                 ?.offsetBy(textLayerOrigin)
                                 ?.let(onLookup)
                         },
@@ -1023,8 +1063,7 @@ private data class SubtitleLookupSelection(
     val lineTop: Float,
     val lineWidth: Float,
     val lineHeight: Float,
-    val cueStartSeconds: Double? = null,
-    val cueEndSeconds: Double? = null,
+    val parsedSubtitleCandidate: SceneRangeCandidate? = null,
 )
 
 private fun String.hasLookupCharacters(): Boolean = any { it.isSubtitleLookupChar() }
@@ -1033,7 +1072,6 @@ private fun TextLayoutResult.subtitleLookupSelectionForTap(
     text: String,
     position: Offset,
     cue: PlayerViewModel.SubtitleCue?,
-    subtitleDelaySeconds: Double,
 ): SubtitleLookupSelection? {
     if (text.isBlank()) return null
     val offset = lookupOffsetForPosition(text, position) ?: return null
@@ -1063,8 +1101,7 @@ private fun TextLayoutResult.subtitleLookupSelectionForTap(
         lineTop = lineBounds.top,
         lineWidth = lineBounds.width,
         lineHeight = lineBounds.height,
-        cueStartSeconds = cue?.positionSeconds?.plus(subtitleDelaySeconds),
-        cueEndSeconds = cue?.endPositionSeconds?.plus(subtitleDelaySeconds),
+        parsedSubtitleCandidate = cue?.sceneTimingCandidate,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerPanels.kt
@@ -47,7 +47,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 @Composable
-fun PlayerPanels(
+internal fun PlayerPanels(
     panelShown: Panels,
     subtitleCues: ImmutableList<SubtitleCue>,
     activeSubtitleCueIndex: Int?,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSceneMiningUi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSceneMiningUi.kt
@@ -1,0 +1,53 @@
+package eu.kanade.tachiyomi.ui.player.controls
+
+import android.content.Context
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.DialogProperties
+import chimahon.anki.AnkiMediaWarning
+import eu.kanade.tachiyomi.ui.player.scene.PlayerSceneMiningProgress
+import eu.kanade.tachiyomi.util.system.toast
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+internal fun PlayerSceneMiningProgressDialog(
+    progress: PlayerSceneMiningProgress,
+    onCancel: () -> Unit,
+) {
+    if (!progress.isBusy) return
+    val status = when (progress) {
+        PlayerSceneMiningProgress.Idle -> return
+        PlayerSceneMiningProgress.Preparing -> stringResource(KMR.strings.anki_scene_preparing)
+        PlayerSceneMiningProgress.Committing -> stringResource(KMR.strings.anki_scene_committing)
+    }
+    AlertDialog(
+        onDismissRequest = {},
+        confirmButton = {
+            if (progress.canCancel) {
+                TextButton(onClick = onCancel) {
+                    Text(stringResource(KMR.strings.anki_scene_cancel))
+                }
+            }
+        },
+        text = { Text(status) },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+        ),
+    )
+}
+
+internal fun Context.showPlayerAnkiMediaWarnings(warnings: List<AnkiMediaWarning>) {
+    warnings.distinct().forEach { warning ->
+        toast(
+            when (warning) {
+                AnkiMediaWarning.SceneGenerationFailed -> KMR.strings.anki_scene_fallback_generation
+                AnkiMediaWarning.AnimatedStorageFailed -> KMR.strings.anki_scene_fallback_storage
+                AnkiMediaWarning.StillStorageFailed -> KMR.strings.anki_scene_still_storage_failed
+            },
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSubtitleLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSubtitleLookupPopup.kt
@@ -12,13 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import chimahon.DictionaryRepository
 import chimahon.MediaInfo
+import chimahon.anki.AnkiScreenshotMode
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryPopupWebViewWarmup
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
 import eu.kanade.tachiyomi.ui.dictionary.getDictionaryPaths
 import eu.kanade.tachiyomi.ui.player.PlayerViewModel
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureRequest
 import eu.kanade.tachiyomi.ui.reader.viewer.OcrLookupPopup
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -41,8 +45,7 @@ internal data class SubtitleLookupRequest(
     val lineHeight: Float,
     val matchedCharCount: Int = 0,
     val matchOffset: Int = 0,
-    val cueStartSeconds: Double? = null,
-    val cueEndSeconds: Double? = null,
+    val sceneCaptureRequest: SceneCaptureRequest? = null,
 )
 
 @Composable
@@ -59,6 +62,7 @@ internal fun PlayerSubtitleLookupPopup(
     val anime by viewModel.currentAnime.collectAsState()
     val episode by viewModel.currentEpisode.collectAsState()
     val source by viewModel.currentSource.collectAsState()
+    val miningProgress by viewModel.sceneMiningProgress.collectAsState()
     val activeProfile = remember(anime?.id, source?.id, source?.lang) {
         dictionaryPreferences.profileResolver.resolve(
             sourceId = source?.id ?: 0L,
@@ -84,6 +88,17 @@ internal fun PlayerSubtitleLookupPopup(
     BackHandler(enabled = request != null, onBack = onDismiss)
 
     val visible = request != null
+    val sceneRequest = request?.sceneCaptureRequest
+    val screenshotMode = AnkiScreenshotMode.fromStorageValue(activeProfile.ankiCropMode)
+    val mediaRequest = remember(sceneRequest, screenshotMode) {
+        viewModel.createSceneMediaRequest(
+            request = sceneRequest,
+            screenshotMode = screenshotMode.storageValue,
+        )
+    }
+    val launchMiningJob: (suspend () -> Unit) -> Boolean = remember(sceneRequest) {
+        { block -> viewModel.launchSceneMining(sceneRequest, block) }
+    }
 
     OcrLookupPopup(
         visible = visible,
@@ -104,15 +119,13 @@ internal fun PlayerSubtitleLookupPopup(
             mangaTitle = anime?.title.orEmpty(),
             chapterName = episode?.name.orEmpty(),
         ),
-        onRequestScreenshot = {
-            viewModel.captureVideoFrameForOcr()
+        mediaRequest = mediaRequest,
+        miningBusy = miningProgress.isBusy,
+        launchMiningJob = launchMiningJob,
+        onMiningBusy = {
+            context.toast(KMR.strings.anki_scene_busy)
         },
-        onRequestSentenceAudio = {
-            viewModel.captureSubtitleAudioForAnki(
-                startSeconds = request?.cueStartSeconds,
-                endSeconds = request?.cueEndSeconds,
-            )
-        },
+        onAnkiMediaWarnings = context::showPlayerAnkiMediaWarnings,
         usePopup = false,
         onTermMatched = onTermMatched,
         modifier = modifier,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerVideoOcrOverlay.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerVideoOcrOverlay.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.player.controls
 
-import android.graphics.Bitmap
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -35,6 +34,7 @@ import eu.kanade.tachiyomi.ui.dictionary.getDictionaryPaths
 import eu.kanade.tachiyomi.ui.dictionary.screenLookupCharOffset
 import eu.kanade.tachiyomi.ui.dictionary.toScreenLookupBlocks
 import eu.kanade.tachiyomi.ui.player.PlayerViewModel
+import eu.kanade.tachiyomi.ui.player.scene.CapturedOcrFrame
 import eu.kanade.tachiyomi.ui.reader.viewer.OcrLineGeometry
 import eu.kanade.tachiyomi.ui.reader.viewer.OcrLookupPopup
 import eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock
@@ -42,10 +42,13 @@ import eu.kanade.tachiyomi.ui.reader.viewer.extractOcrLookupString
 import eu.kanade.tachiyomi.ui.reader.viewer.isLookupStartChar
 import eu.kanade.tachiyomi.ui.reader.viewer.orderedFullText
 import eu.kanade.tachiyomi.ui.reader.viewer.toOrderedOffset
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
@@ -58,10 +61,11 @@ private const val TAP_HINT_DURATION_MS = 1_200L
 @Composable
 internal fun PlayerVideoOcrOverlay(
     viewModel: PlayerViewModel,
-    screenshot: Bitmap?,
+    frame: CapturedOcrFrame?,
     onDismiss: () -> Unit,
 ) {
-    if (screenshot == null) return
+    val capturedFrame = frame ?: return
+    val screenshot = capturedFrame.bitmap ?: return
 
     val context = LocalContext.current
     val localDensity = LocalDensity.current
@@ -70,6 +74,7 @@ internal fun PlayerVideoOcrOverlay(
     val source by viewModel.currentSource.collectAsState()
     val anime by viewModel.currentAnime.collectAsState()
     val episode by viewModel.currentEpisode.collectAsState()
+    val miningProgress by viewModel.sceneMiningProgress.collectAsState()
     val activeProfile = remember(source?.id, source?.lang) {
         dictionaryPreferences.profileResolver.resolve(
             sourceId = source?.id ?: 0L,
@@ -81,6 +86,12 @@ internal fun PlayerVideoOcrOverlay(
     }
     val boxScaleX = dictionaryPreferences.ocrBoxScaleX().get()
     val boxScaleY = dictionaryPreferences.ocrBoxScaleY().get()
+    val mediaRequest = remember(capturedFrame.request, activeProfile.ankiCropMode) {
+        viewModel.createSceneMediaRequest(
+            request = capturedFrame.request,
+            screenshotMode = activeProfile.ankiCropMode,
+        )
+    }
 
     LaunchedEffect(activeProfile) {
         withContext(Dispatchers.IO) {
@@ -116,16 +127,21 @@ internal fun PlayerVideoOcrOverlay(
             error = null
             blocks = emptyList()
             showTapHint = false
+            val recognitionLease = capturedFrame.request.acquireMiningLease()
+            if (recognitionLease == null) {
+                isLoading = false
+                error = context.contextStringResource(MR.strings.screen_lookup_capture_failed)
+                return@LaunchedEffect
+            }
             val language = OcrLanguage.entries.find {
                 it.bcp47.equals(activeProfile.languageCode, ignoreCase = true)
             } ?: OcrLanguage.JAPANESE
 
-            runCatching {
-                withContext(Dispatchers.Default) {
+            try {
+                val ocrBlocks = withContext(Dispatchers.Default) {
                     recognizePage(screenshot, language)
                         .toScreenLookupBlocks(language.bcp47)
                 }
-            }.onSuccess { ocrBlocks ->
                 blocks = remapToScreenArea(
                     ocrBlocks,
                     imgWidth = screenshot.width,
@@ -138,8 +154,12 @@ internal fun PlayerVideoOcrOverlay(
                 } else {
                     showTapHint = true
                 }
-            }.onFailure {
-                error = it.message ?: context.contextStringResource(MR.strings.screen_lookup_capture_failed)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                error = e.message ?: context.contextStringResource(MR.strings.screen_lookup_capture_failed)
+            } finally {
+                recognitionLease.close()
             }
             isLoading = false
 
@@ -232,7 +252,15 @@ internal fun PlayerVideoOcrOverlay(
                         mangaTitle = anime?.title.orEmpty(),
                         chapterName = episode?.name.orEmpty(),
                     ),
-                    onRequestSentenceAudio = { viewModel.captureVideoOcrAudioForAnki() },
+                    mediaRequest = mediaRequest,
+                    miningBusy = miningProgress.isBusy,
+                    launchMiningJob = { block ->
+                        viewModel.launchSceneMining(capturedFrame.request, block)
+                    },
+                    onMiningBusy = {
+                        context.toast(KMR.strings.anki_scene_busy)
+                    },
+                    onAnkiMediaWarnings = context::showPlayerAnkiMediaWarnings,
                     usePopup = false,
                     titleId = anime?.id?.toString(),
                     onTermMatched = { count, off ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleListPanel.kt
@@ -37,7 +37,7 @@ import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.presentation.core.components.material.padding
 
 @Composable
-fun SubtitleListPanel(
+internal fun SubtitleListPanel(
     cues: ImmutableList<SubtitleCue>,
     activeCueIndex: Int?,
     onSelectCue: (Int) -> Unit,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
@@ -1,0 +1,176 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.content.Context
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.webkit.MimeTypeMap
+import chimahon.anki.AnkiMediaNaming
+import chimahon.anki.AnkiScreenshotPreparation
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.UUID
+
+internal fun interface SceneCaptureService {
+    suspend fun prepare(request: SceneCaptureRequest): AnkiScreenshotPreparation
+}
+
+internal class AndroidSceneCaptureService private constructor(
+    private val sceneDirectory: File,
+    private val inputAcquirer: SceneInputAcquirer,
+    private val commandExecutor: SceneCommandExecutor,
+    private val validate: (File) -> AnimatedAvifInfo?,
+    private val av1EncoderName: () -> String?,
+) : SceneCaptureService {
+    constructor(context: Context) : this(
+        sceneDirectory = File(context.cacheDir, SCENE_CACHE_DIRECTORY),
+        inputAcquirer = AndroidSceneInputAcquirer(context),
+        commandExecutor = FfmpegKitSceneCommandExecutor(),
+        validate = AnimatedAvifValidator::validate,
+        av1EncoderName = ::platformAv1EncoderName,
+    )
+
+    override suspend fun prepare(request: SceneCaptureRequest): AnkiScreenshotPreparation {
+        val input = request.videoInput ?: return AnkiScreenshotPreparation.Failed(stillFallback = null)
+        val range = request.resolvedTiming?.animationRange
+            ?: return AnkiScreenshotPreparation.Failed(stillFallback = null)
+        val encoderName = av1EncoderName()
+        if (encoderName.isNullOrBlank()) {
+            return AnkiScreenshotPreparation.Failed(stillFallback = null)
+        }
+
+        return withContext(Dispatchers.IO) {
+            if (!isSafe(input)) {
+                return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+            }
+            val lease = inputAcquirer.acquire(input)
+                ?: return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+            sceneDirectory.mkdirs()
+            val output = File(sceneDirectory, "${UUID.randomUUID()}.avif")
+            val inputCleanup = SceneNativeCleanup(lease::close)
+            val outputCleanup = SceneNativeCleanup(output::delete)
+            var transferred = false
+            try {
+                val result = commandExecutor.executeFfmpeg(
+                    SceneFfmpegArguments.animatedAvif(
+                        input = input,
+                        acquiredInputValue = lease.ffmpegValue,
+                        range = range,
+                        outputFile = output.absolutePath,
+                        encoderName = encoderName,
+                        tlsCaFile = lease.tlsCaFile,
+                    ),
+                ) {
+                    inputCleanup.nativeFinished()
+                    outputCleanup.nativeFinished()
+                }
+                when (result) {
+                    SceneCommandResult.Failed -> {
+                        return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+                    }
+                    is SceneCommandResult.Success -> Unit
+                }
+                val info = validate(output)
+                    ?.takeIf {
+                        it.width in 1..MAX_OUTPUT_DIMENSION &&
+                            it.height in 1..MAX_OUTPUT_DIMENSION &&
+                            it.frameCount in 2..SceneFfmpegArguments.MAX_FRAME_COUNT &&
+                            it.totalDurationMillis > 0L
+                    }
+                    ?: return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+                val animation = AnkiMediaNaming.sceneFileSource(output)
+                transferred = true
+                AnkiScreenshotPreparation.Animated(
+                    animation = animation,
+                    stillFallback = null,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                AnkiScreenshotPreparation.Failed(stillFallback = null)
+            } finally {
+                inputCleanup.release()
+                if (!transferred) outputCleanup.release()
+            }
+        }
+    }
+
+    private suspend fun isSafe(input: SceneVideoInputSpec): Boolean {
+        val lease = inputAcquirer.acquire(input) ?: return false
+        val cleanup = SceneNativeCleanup(lease::close)
+        return try {
+            val result = commandExecutor.executeFfprobe(
+                SceneFfmpegArguments.videoProbe(input, lease.ffmpegValue, lease.tlsCaFile),
+                cleanup::nativeFinished,
+            )
+            result is SceneCommandResult.Success && SceneMediaProbe.inspect(result.output)
+        } finally {
+            cleanup.release()
+        }
+    }
+
+    internal companion object {
+        private const val SCENE_CACHE_DIRECTORY = "chimahon_scene_capture"
+        private const val MAX_OUTPUT_DIMENSION = 640
+
+        fun forTests(
+            sceneDirectory: File,
+            inputAcquirer: SceneInputAcquirer,
+            commandExecutor: SceneCommandExecutor,
+            validate: (File) -> AnimatedAvifInfo?,
+            av1EncoderName: () -> String? = { TEST_AV1_ENCODER_NAME },
+        ): AndroidSceneCaptureService {
+            return AndroidSceneCaptureService(
+                sceneDirectory = sceneDirectory,
+                inputAcquirer = inputAcquirer,
+                commandExecutor = commandExecutor,
+                validate = validate,
+                av1EncoderName = av1EncoderName,
+            )
+        }
+
+        private fun platformAv1EncoderName(): String? {
+            val mimeTypes = MimeTypeMap.getSingleton()
+            val hasMimeMapping = mimeTypes.getMimeTypeFromExtension("avif")
+                ?.equals("image/avif", ignoreCase = true) == true &&
+                mimeTypes.getExtensionFromMimeType("image/avif")
+                    ?.equals("avif", ignoreCase = true) == true
+            if (!hasMimeMapping) return null
+
+            return runCatching {
+                MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+                    .asSequence()
+                    .filter(MediaCodecInfo::isEncoder)
+                    .filter { info ->
+                        info.supportedTypes.any { it.equals(AV1_MIME_TYPE, ignoreCase = true) }
+                    }
+                    .firstOrNull { info ->
+                        runCatching {
+                            val capabilities = info.getCapabilitiesForType(AV1_MIME_TYPE)
+                            val encoder = capabilities.encoderCapabilities ?: return@runCatching false
+                            val video = capabilities.videoCapabilities ?: return@runCatching false
+                            val supportsYuv420Planar = capabilities.colorFormats.contains(
+                                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
+                            )
+                            supportsYuv420Planar &&
+                                encoder.isBitrateModeSupported(
+                                    MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CQ,
+                                ) &&
+                                encoder.qualityRange.contains(MEDIACODEC_QUALITY) &&
+                                video.areSizeAndRateSupported(
+                                    MAX_OUTPUT_DIMENSION,
+                                    MAX_OUTPUT_DIMENSION,
+                                    SceneFfmpegArguments.FRAME_RATE,
+                                )
+                        }.getOrDefault(false)
+                    }
+                    ?.name
+            }.getOrNull()
+        }
+
+        internal const val TEST_AV1_ENCODER_NAME = "test.av1.encoder"
+        private const val AV1_MIME_TYPE = "video/av01"
+        private const val MEDIACODEC_QUALITY = 35
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
@@ -1,0 +1,70 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.content.Context
+import android.net.Uri
+import java.io.Closeable
+import java.io.File
+
+internal interface SceneInputLease : Closeable {
+    val ffmpegValue: String
+    val tlsCaFile: String?
+}
+
+internal fun interface SceneInputAcquirer {
+    suspend fun acquire(input: SceneVideoInputSpec): SceneInputLease?
+}
+
+internal class AndroidSceneInputAcquirer(
+    context: Context,
+) : SceneInputAcquirer {
+    private val applicationContext = context.applicationContext
+    private val caBundle = File(applicationContext.filesDir, "cacert.pem")
+
+    override suspend fun acquire(input: SceneVideoInputSpec): SceneInputLease? {
+        return when (input.kind) {
+            SceneVideoInputKind.CONTENT_URI -> acquireContentUri(input.value)
+            SceneVideoInputKind.REMOTE_HTTP -> {
+                val readableBundle = getCaBundle() ?: return null
+                acquired(input.value, readableBundle.absolutePath)
+            }
+            SceneVideoInputKind.LOCAL_FILE -> acquired(input.value)
+        }
+    }
+
+    private fun getCaBundle(): File? = synchronized(CA_BUNDLE_LOCK) {
+        caBundle.takeIf { it.isFile && it.canRead() && it.length() > 0L } ?: runCatching {
+            applicationContext.assets.open("cacert.pem").use { input ->
+                caBundle.outputStream().use(input::copyTo)
+            }
+            caBundle.takeIf { it.isFile && it.canRead() && it.length() > 0L }
+        }.getOrNull()
+    }
+
+    private fun acquireContentUri(value: String): SceneInputLease? {
+        val descriptor = runCatching {
+            applicationContext.contentResolver.openFileDescriptor(Uri.parse(value), "r")
+        }.getOrNull() ?: return null
+        return object : SceneInputLease {
+            override val ffmpegValue = "/proc/self/fd/${descriptor.fd}"
+            override val tlsCaFile: String? = null
+
+            override fun close() = descriptor.close()
+        }
+    }
+
+    private fun acquired(
+        value: String,
+        caFile: String? = null,
+    ): SceneInputLease {
+        return object : SceneInputLease {
+            override val ffmpegValue = value
+            override val tlsCaFile = caFile
+
+            override fun close() = Unit
+        }
+    }
+
+    private companion object {
+        val CA_BUNDLE_LOCK = Any()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidator.kt
@@ -1,0 +1,219 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import java.io.File
+import java.io.FileInputStream
+
+internal data class AnimatedAvifInfo(
+    val width: Int,
+    val height: Int,
+    val frameCount: Int,
+    val totalDurationMillis: Long,
+)
+
+internal object AnimatedAvifValidator {
+    fun validate(file: File): AnimatedAvifInfo? {
+        if (!file.isFile || file.length() !in 1..MAX_FILE_BYTES) return null
+        val bytes = ByteArray(file.length().toInt())
+        FileInputStream(file).use { input ->
+            var offset = 0
+            while (offset < bytes.size) {
+                val read = input.read(bytes, offset, bytes.size - offset)
+                if (read <= 0) return null
+                offset += read
+            }
+            if (input.read() != -1) return null
+        }
+        return runCatching { Parser(bytes).parse() }.getOrNull()
+    }
+
+    private class Parser(
+        private val bytes: ByteArray,
+    ) {
+        private var boxCount = 0
+
+        fun parse(): AnimatedAvifInfo? {
+            val top = boxes(0, bytes.size) ?: return null
+            if (top.firstOrNull()?.type != "ftyp") return null
+            val ftyp = top.only("ftyp") ?: return null
+            val meta = top.only("meta") ?: return null
+            val moov = top.only("moov") ?: return null
+            val mdat = top.only("mdat") ?: return null
+            if (!validFileType(ftyp) || meta.dataSize < 4 || u32(meta.start) != 0L || mdat.dataSize == 0) {
+                return null
+            }
+
+            val track = parseMovie(moov) ?: return null
+            if (track.frames !in FRAME_RANGE || track.frames != track.sizedFrames) return null
+            if (track.duration != track.declaredDuration || track.duration > track.timescale * MAX_SECONDS) {
+                return null
+            }
+            val doubledRate = track.frames.toLong() * track.timescale * 2
+            if (doubledRate !in 15L * track.duration..17L * track.duration) return null
+            if (track.sampleBytes > mdat.dataSize) return null
+
+            val millis = (track.duration * 1_000L + track.timescale / 2) / track.timescale
+            return AnimatedAvifInfo(track.width, track.height, track.frames, millis)
+        }
+
+        private fun validFileType(box: Box): Boolean {
+            if (box.dataSize < 16 || (box.dataSize - 8) % 4 != 0 || fourCc(box.start) != "avis") {
+                return false
+            }
+            val brands = (box.start + 8 until box.end step 4).map(::fourCc)
+            return "avif" in brands && "MA1B" in brands
+        }
+
+        private fun parseMovie(movie: Box): Track? {
+            val track = boxes(movie.start, movie.end)?.only("trak") ?: return null
+            val media = boxes(track.start, track.end)?.only("mdia") ?: return null
+            val mediaBoxes = boxes(media.start, media.end) ?: return null
+            val (timescale, declaredDuration) = parseMediaHeader(mediaBoxes.only("mdhd") ?: return null) ?: return null
+            val mediaInfo = mediaBoxes.only("minf") ?: return null
+            val sampleTable = boxes(mediaInfo.start, mediaInfo.end)?.only("stbl") ?: return null
+            val sampleBoxes = boxes(sampleTable.start, sampleTable.end) ?: return null
+            val (width, height) = parseSampleDescription(sampleBoxes.only("stsd") ?: return null) ?: return null
+            val timing = parseTiming(sampleBoxes.only("stts") ?: return null) ?: return null
+            val sizes = parseSizes(sampleBoxes.only("stsz") ?: return null) ?: return null
+            return Track(
+                width = width,
+                height = height,
+                frames = timing.frames,
+                duration = timing.duration,
+                timescale = timescale,
+                declaredDuration = declaredDuration,
+                sizedFrames = sizes.frames,
+                sampleBytes = sizes.bytes,
+            )
+        }
+
+        private fun parseMediaHeader(box: Box): Pair<Long, Long>? {
+            val version = u8(box.start)
+            val timescaleOffset = when (version) {
+                0 -> box.start + 12
+                1 -> box.start + 20
+                else -> return null
+            }
+            val durationOffset = timescaleOffset + 4
+            val required = durationOffset + if (version == 0) 4 else 8
+            if (required > box.end) return null
+            val timescale = u32(timescaleOffset)
+            val duration = if (version == 0) u32(durationOffset) else u64(durationOffset)
+            return if (timescale > 0 && duration > 0) timescale to duration else null
+        }
+
+        private fun parseSampleDescription(box: Box): Pair<Int, Int>? {
+            if (box.dataSize < 8 || u32(box.start) != 0L || u32(box.start + 4) != 1L) return null
+            val entry = boxes(box.start + 8, box.end)?.singleOrNull() ?: return null
+            if (entry.type != "av01" || entry.dataSize < VISUAL_SAMPLE_ENTRY_BYTES) return null
+            val width = u16(entry.start + 24)
+            val height = u16(entry.start + 26)
+            if (width !in DIMENSION_RANGE || height !in DIMENSION_RANGE) return null
+            val children = boxes(entry.start + VISUAL_SAMPLE_ENTRY_BYTES, entry.end) ?: return null
+            val av1Config = children.only("av1C") ?: return null
+            return if (av1Config.dataSize >= 4) width to height else null
+        }
+
+        private fun parseTiming(box: Box): Timing? {
+            if (box.dataSize < 16 || u32(box.start) != 0L) return null
+            val entries = u32(box.start + 4)
+            if (entries !in 1..MAX_TIMING_ENTRIES ||
+                box.dataSize.toLong() != 8L + entries * 8L
+            ) {
+                return null
+            }
+            var frames = 0L
+            var duration = 0L
+            var offset = box.start + 8
+            repeat(entries.toInt()) {
+                val count = u32(offset)
+                val delta = u32(offset + 4)
+                if (count == 0L || delta == 0L || frames + count > FRAME_RANGE.last) return null
+                frames += count
+                duration += count * delta
+                offset += 8
+            }
+            return Timing(frames.toInt(), duration)
+        }
+
+        private fun parseSizes(box: Box): Sizes? {
+            if (box.dataSize < 12 || u32(box.start) != 0L) return null
+            val commonSize = u32(box.start + 4)
+            val frames = u32(box.start + 8)
+            if (frames !in FRAME_RANGE.first.toLong()..FRAME_RANGE.last.toLong()) return null
+            if (commonSize != 0L) {
+                return if (box.dataSize == 12) Sizes(frames.toInt(), commonSize * frames) else null
+            }
+            if (box.dataSize.toLong() != 12L + frames * 4L) return null
+            var total = 0L
+            var offset = box.start + 12
+            repeat(frames.toInt()) {
+                val size = u32(offset)
+                if (size == 0L) return null
+                total += size
+                offset += 4
+            }
+            return Sizes(frames.toInt(), total)
+        }
+
+        private fun boxes(start: Int, end: Int): List<Box>? {
+            if (start !in 0..end || end > bytes.size) return null
+            val result = mutableListOf<Box>()
+            var offset = start
+            while (offset < end) {
+                if (end - offset < BOX_HEADER_BYTES || ++boxCount > MAX_BOXES) return null
+                val size = u32(offset)
+                if (size < BOX_HEADER_BYTES || size > Int.MAX_VALUE) return null
+                val boxEnd = offset.toLong() + size
+                if (boxEnd > end) return null
+                result += Box(fourCc(offset + 4), offset + BOX_HEADER_BYTES, boxEnd.toInt())
+                offset = boxEnd.toInt()
+            }
+            return result.takeIf { offset == end }
+        }
+
+        private fun List<Box>.only(type: String) = filter { it.type == type }.singleOrNull()
+
+        private fun u8(offset: Int) = bytes[offset].toInt() and 0xff
+        private fun u16(offset: Int) = (u8(offset) shl 8) or u8(offset + 1)
+        private fun u32(offset: Int) =
+            (u8(offset).toLong() shl 24) or
+                (u8(offset + 1).toLong() shl 16) or
+                (u8(offset + 2).toLong() shl 8) or
+                u8(offset + 3).toLong()
+
+        private fun u64(offset: Int): Long {
+            if (u8(offset) and 0x80 != 0) return -1
+            var value = 0L
+            repeat(8) { value = (value shl 8) or u8(offset + it).toLong() }
+            return value
+        }
+
+        private fun fourCc(offset: Int) = String(bytes, offset, 4, Charsets.US_ASCII)
+
+        private data class Box(val type: String, val start: Int, val end: Int) {
+            val dataSize get() = end - start
+        }
+
+        private data class Timing(val frames: Int, val duration: Long)
+        private data class Sizes(val frames: Int, val bytes: Long)
+        private data class Track(
+            val width: Int,
+            val height: Int,
+            val frames: Int,
+            val duration: Long,
+            val timescale: Long,
+            val declaredDuration: Long,
+            val sizedFrames: Int,
+            val sampleBytes: Long,
+        )
+    }
+
+    private val DIMENSION_RANGE = 1..640
+    private val FRAME_RANGE = 2..80
+    private const val MAX_FILE_BYTES = 10L * 1024L * 1024L
+    private const val MAX_SECONDS = 10L
+    private const val MAX_TIMING_ENTRIES = 80L
+    private const val MAX_BOXES = 64
+    private const val BOX_HEADER_BYTES = 8
+    private const val VISUAL_SAMPLE_ENTRY_BYTES = 78
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/FfmpegKitSceneCommandExecutor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/FfmpegKitSceneCommandExecutor.kt
@@ -1,0 +1,207 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import com.arthenica.ffmpegkit.FFmpegKitConfig
+import com.arthenica.ffmpegkit.FFmpegSession
+import com.arthenica.ffmpegkit.FFprobeSession
+import com.arthenica.ffmpegkit.LogCallback
+import com.arthenica.ffmpegkit.LogRedirectionStrategy
+import com.arthenica.ffmpegkit.ReturnCode
+import com.arthenica.ffmpegkit.StatisticsCallback
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+
+internal sealed interface SceneCommandResult {
+    data class Success(val output: String = "") : SceneCommandResult
+
+    data object Failed : SceneCommandResult
+}
+
+internal interface SceneCommandExecutor {
+    suspend fun executeFfmpeg(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit = {},
+    ): SceneCommandResult
+
+    suspend fun executeFfprobe(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit = {},
+    ): SceneCommandResult
+}
+
+/**
+ * Releases an input or output only after both its Kotlin owner and native FFmpeg are done with it.
+ */
+internal class SceneNativeCleanup(
+    private val cleanup: () -> Unit,
+) {
+    private val nativeFinished = AtomicBoolean(false)
+    private val released = AtomicBoolean(false)
+    private val cleaned = AtomicBoolean(false)
+
+    fun nativeFinished() {
+        nativeFinished.set(true)
+        cleanIfReady()
+    }
+
+    fun release() {
+        released.set(true)
+        cleanIfReady()
+    }
+
+    private fun cleanIfReady() {
+        if (nativeFinished.get() && released.get() && cleaned.compareAndSet(false, true)) {
+            runCatching(cleanup)
+        }
+    }
+}
+
+internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
+    override suspend fun executeFfmpeg(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return executeSession(
+            createSession = {
+                FFmpegSession.create(
+                    arguments,
+                    {},
+                    DISCARD_LOG_CALLBACK,
+                    DISCARD_STATISTICS_CALLBACK,
+                    LogRedirectionStrategy.NEVER_PRINT_LOGS,
+                )
+            },
+            runSession = FFmpegKitConfig::ffmpegExecute,
+            cancelSession = FFmpegSession::cancel,
+            resultFor = { session ->
+                if (ReturnCode.isSuccess(session.returnCode)) {
+                    SceneCommandResult.Success()
+                } else {
+                    SceneCommandResult.Failed
+                }
+            },
+            onNativeFinished = onNativeFinished,
+        )
+    }
+
+    override suspend fun executeFfprobe(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return executeSession(
+            createSession = {
+                FFprobeSession.create(
+                    arguments,
+                    {},
+                    DISCARD_LOG_CALLBACK,
+                    LogRedirectionStrategy.NEVER_PRINT_LOGS,
+                )
+            },
+            runSession = FFmpegKitConfig::ffprobeExecute,
+            cancelSession = FFprobeSession::cancel,
+            resultFor = { session ->
+                if (ReturnCode.isSuccess(session.returnCode)) {
+                    SceneCommandResult.Success(session.output.orEmpty())
+                } else {
+                    SceneCommandResult.Failed
+                }
+            },
+            onNativeFinished = onNativeFinished,
+        )
+    }
+
+    /**
+     * FFmpegKit's Future can report cancellation after its Runnable has started. Dispatch the
+     * synchronous API ourselves so QUEUED -> CANCELLED proves native code never ran, while a
+     * RUNNING cancellation calls the native cancel hook. Cleanup is notified only after the
+     * synchronous call actually returns.
+     */
+    private suspend fun <Session : Any> executeSession(
+        createSession: () -> Session,
+        runSession: (Session) -> Unit,
+        cancelSession: (Session) -> Unit,
+        resultFor: (Session) -> SceneCommandResult,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return suspendCancellableCoroutine { continuation ->
+            val state = AtomicReference(SessionExecutionState.QUEUED)
+            val finishCalled = AtomicBoolean(false)
+            fun finishNativeUse() {
+                if (finishCalled.compareAndSet(false, true)) {
+                    runCatching(onNativeFinished)
+                }
+            }
+
+            val session = try {
+                createSession()
+            } catch (_: Exception) {
+                state.set(SessionExecutionState.FINISHED)
+                finishNativeUse()
+                continuation.resume(SceneCommandResult.Failed)
+                return@suspendCancellableCoroutine
+            }
+
+            continuation.invokeOnCancellation {
+                if (!state.compareAndSet(SessionExecutionState.QUEUED, SessionExecutionState.CANCELLED) &&
+                    state.get() == SessionExecutionState.RUNNING
+                ) {
+                    runCatching { cancelSession(session) }
+                }
+            }
+
+            try {
+                Dispatchers.IO.dispatch(
+                    continuation.context,
+                    Runnable {
+                        if (!state.compareAndSet(SessionExecutionState.QUEUED, SessionExecutionState.RUNNING)) {
+                            if (state.compareAndSet(
+                                    SessionExecutionState.CANCELLED,
+                                    SessionExecutionState.FINISHED,
+                                )
+                            ) {
+                                finishNativeUse()
+                            }
+                            return@Runnable
+                        }
+
+                        val result = try {
+                            runSession(session)
+                            runCatching { resultFor(session) }
+                                .getOrDefault(SceneCommandResult.Failed)
+                        } catch (_: Exception) {
+                            SceneCommandResult.Failed
+                        } finally {
+                            state.set(SessionExecutionState.FINISHED)
+                            finishNativeUse()
+                        }
+                        if (continuation.isActive) {
+                            continuation.resume(result)
+                        }
+                    },
+                )
+            } catch (_: Exception) {
+                if (state.getAndSet(SessionExecutionState.FINISHED) == SessionExecutionState.RUNNING) {
+                    runCatching { cancelSession(session) }
+                }
+                finishNativeUse()
+                if (continuation.isActive) {
+                    continuation.resume(SceneCommandResult.Failed)
+                }
+            }
+        }
+    }
+
+    private enum class SessionExecutionState {
+        QUEUED,
+        RUNNING,
+        CANCELLED,
+        FINISHED,
+    }
+
+    private companion object {
+        val DISCARD_LOG_CALLBACK = LogCallback {}
+        val DISCARD_STATISTICS_CALLBACK = StatisticsCallback {}
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinator.kt
@@ -1,0 +1,236 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import chimahon.anki.AnkiMediaSource
+import chimahon.anki.AnkiScreenshotMode
+import chimahon.anki.AnkiScreenshotPreparation
+import chimahon.util.ImageEncoder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.io.Closeable
+import java.security.MessageDigest
+
+internal fun interface SceneStillFallbackEncoder {
+    suspend fun encode(request: SceneCaptureRequest): AnkiMediaSource.Bytes?
+}
+
+internal object AndroidSceneStillFallbackEncoder : SceneStillFallbackEncoder {
+    override suspend fun encode(request: SceneCaptureRequest): AnkiMediaSource.Bytes? {
+        val bitmap = request.fallbackBitmapOrNull() ?: return null
+        return withContext(Dispatchers.Default) {
+            try {
+                val bytes = ImageEncoder.encode(bitmap).bytes.takeIf(ByteArray::isNotEmpty) ?: return@withContext null
+                val digest = MessageDigest.getInstance("SHA-256")
+                    .digest(bytes)
+                    .joinToString("") { "%02x".format(it) }
+                AnkiMediaSource.Bytes(
+                    data = bytes,
+                    preferredBaseName = "chimahon_screenshot_$digest",
+                    extension = "webp",
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}
+
+internal sealed interface PlayerSceneMiningProgress {
+    val isBusy: Boolean
+    val canCancel: Boolean
+
+    data object Idle : PlayerSceneMiningProgress {
+        override val isBusy = false
+        override val canCancel = false
+    }
+
+    data object Preparing : PlayerSceneMiningProgress {
+        override val isBusy = true
+        override val canCancel = true
+    }
+
+    data object Committing : PlayerSceneMiningProgress {
+        override val isBusy = true
+        override val canCancel = false
+    }
+}
+
+/**
+ * Owns at most one accepted mining job. Cancellation is allowed only until the Anki commit starts.
+ */
+internal class PlayerSceneMiningCoordinator(
+    private val scope: CoroutineScope,
+    private val sceneCaptureService: () -> SceneCaptureService,
+    private val stillEncoder: SceneStillFallbackEncoder = AndroidSceneStillFallbackEncoder,
+    private val sceneTimeoutMillis: Long = DEFAULT_SCENE_TIMEOUT_MILLIS,
+) {
+    private val lock = Any()
+    private var lifecycleState = LifecycleState.IDLE
+    private var activeJob: Job? = null
+    private var shuttingDown = false
+    private val _progress = MutableStateFlow<PlayerSceneMiningProgress>(PlayerSceneMiningProgress.Idle)
+    val progress: StateFlow<PlayerSceneMiningProgress> = _progress.asStateFlow()
+
+    fun launch(
+        request: SceneCaptureRequest,
+        block: suspend () -> Unit,
+    ): Boolean = launchWithLease(request::acquireMiningLease, block)
+
+    internal fun launchWithLease(
+        acquireLease: () -> Closeable?,
+        block: suspend () -> Unit,
+    ): Boolean {
+        synchronized(lock) {
+            if (shuttingDown || activeJob?.isActive == true) return false
+            val lease = acquireLease() ?: return false
+            lifecycleState = LifecycleState.PRE_COMMIT
+            _progress.value = PlayerSceneMiningProgress.Preparing
+            val job = scope.launch(start = CoroutineStart.LAZY) { block() }
+            activeJob = job
+            job.invokeOnCompletion {
+                lease.close()
+                val closeScope = synchronized(lock) {
+                    if (activeJob === job) {
+                        activeJob = null
+                        lifecycleState = LifecycleState.IDLE
+                        _progress.value = PlayerSceneMiningProgress.Idle
+                    }
+                    shuttingDown
+                }
+                if (closeScope) scope.cancel()
+            }
+            job.start()
+            return true
+        }
+    }
+
+    suspend fun prepareScreenshot(
+        request: SceneCaptureRequest,
+        mode: AnkiScreenshotMode,
+    ): AnkiScreenshotPreparation {
+        return when (mode) {
+            AnkiScreenshotMode.NONE -> AnkiScreenshotPreparation.Still(null)
+            AnkiScreenshotMode.FULL,
+            AnkiScreenshotMode.CROP,
+            -> AnkiScreenshotPreparation.Still(stillEncoder.encode(request))
+            AnkiScreenshotMode.ANIMATED_SCENE -> prepareAnimated(request)
+        }
+    }
+
+    fun markCommitStarted() {
+        synchronized(lock) {
+            when (lifecycleState) {
+                LifecycleState.PRE_COMMIT -> {
+                    lifecycleState = LifecycleState.COMMITTING
+                    _progress.value = PlayerSceneMiningProgress.Committing
+                }
+                LifecycleState.CANCELLING -> throw CancellationException("Scene mining cancelled before commit")
+                LifecycleState.COMMITTING -> Unit
+                LifecycleState.IDLE -> throw CancellationException("Scene mining job is no longer active")
+            }
+        }
+    }
+
+    fun cancelPreCommit() {
+        val job = synchronized(lock) {
+            if (lifecycleState != LifecycleState.PRE_COMMIT) {
+                null
+            } else {
+                lifecycleState = LifecycleState.CANCELLING
+                activeJob
+            }
+        }
+        job?.cancel()
+    }
+
+    fun shutdown() {
+        val action = synchronized(lock) {
+            shuttingDown = true
+            when (lifecycleState) {
+                LifecycleState.PRE_COMMIT -> {
+                    lifecycleState = LifecycleState.CANCELLING
+                    ShutdownAction(activeJob, closeScopeNow = false)
+                }
+                LifecycleState.CANCELLING -> ShutdownAction(activeJob, closeScopeNow = false)
+                LifecycleState.COMMITTING -> ShutdownAction(jobToCancel = null, closeScopeNow = false)
+                LifecycleState.IDLE -> ShutdownAction(jobToCancel = null, closeScopeNow = true)
+            }
+        }
+        action.jobToCancel?.cancel()
+        if (action.closeScopeNow) scope.cancel()
+    }
+
+    private suspend fun prepareAnimated(request: SceneCaptureRequest): AnkiScreenshotPreparation {
+        if (
+            request.videoInput == null ||
+            request.resolvedTiming == null
+        ) {
+            return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
+        }
+        val prepared = try {
+            withTimeout(sceneTimeoutMillis) {
+                sceneCaptureService().prepare(request)
+            }
+        } catch (_: TimeoutCancellationException) {
+            return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
+        }
+        if (prepared !is AnkiScreenshotPreparation.Animated) {
+            return prepared.withStillFallback(request)
+        }
+
+        var transferred = false
+        return try {
+            prepared.withStillFallback(request).also { transferred = true }
+        } finally {
+            if (!transferred) prepared.animation.file.delete()
+        }
+    }
+
+    private suspend fun AnkiScreenshotPreparation.withStillFallback(
+        request: SceneCaptureRequest,
+    ): AnkiScreenshotPreparation {
+        return when (this) {
+            is AnkiScreenshotPreparation.Animated -> {
+                if (stillFallback != null) this else copy(stillFallback = stillEncoder.encode(request))
+            }
+            is AnkiScreenshotPreparation.Still -> {
+                if (still != null) this else copy(still = stillEncoder.encode(request))
+            }
+            is AnkiScreenshotPreparation.Failed -> {
+                if (stillFallback != null) this else copy(stillFallback = stillEncoder.encode(request))
+            }
+        }
+    }
+
+    private enum class LifecycleState {
+        IDLE,
+        PRE_COMMIT,
+        COMMITTING,
+        CANCELLING,
+    }
+
+    private data class ShutdownAction(
+        val jobToCancel: Job?,
+        val closeScopeNow: Boolean,
+    )
+
+    private companion object {
+        const val DEFAULT_SCENE_TIMEOUT_MILLIS = 60_000L
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequest.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequest.kt
@@ -1,0 +1,391 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.graphics.Bitmap
+import `is`.xyz.mpv.MPVLib
+import java.io.Closeable
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Keeps the captured still alive while either its popup owner or the accepted mining job uses it.
+ */
+internal class OwnedResource<T : Any>(
+    resource: T,
+    private val disposer: (T) -> Unit,
+) : Closeable {
+    private val lock = Any()
+    private var resource: T? = resource
+    private var ownerOpen = true
+    private var leases = 0
+
+    fun valueOrNull(): T? = synchronized(lock) { resource }
+
+    fun acquireLease(): Lease? = synchronized(lock) {
+        if (!ownerOpen || resource == null) return null
+        leases += 1
+        Lease(this)
+    }
+
+    override fun close() {
+        disposeIfReady(
+            synchronized(lock) {
+                if (!ownerOpen) return
+                ownerOpen = false
+                takeResourceForDisposal()
+            },
+        )
+    }
+
+    private fun releaseLease() {
+        disposeIfReady(
+            synchronized(lock) {
+                check(leases > 0) { "Owned resource lease released more than once" }
+                leases -= 1
+                takeResourceForDisposal()
+            },
+        )
+    }
+
+    private fun takeResourceForDisposal(): T? {
+        if (ownerOpen || leases != 0) return null
+        return resource.also { resource = null }
+    }
+
+    private fun disposeIfReady(value: T?) {
+        value?.let(disposer)
+    }
+
+    class Lease internal constructor(
+        private val owner: OwnedResource<*>,
+    ) : Closeable {
+        private val lock = Any()
+        private var open = true
+
+        override fun close() {
+            synchronized(lock) {
+                if (!open) return
+                open = false
+            }
+            owner.releaseLease()
+        }
+    }
+}
+
+internal class OwnedBitmap private constructor(
+    private val owner: OwnedResource<Bitmap>,
+) : Closeable {
+    constructor(bitmap: Bitmap) : this(
+        OwnedResource(bitmap) {
+            if (!it.isRecycled) it.recycle()
+        },
+    )
+
+    fun bitmapOrNull(): Bitmap? = owner.valueOrNull()
+
+    fun acquireLease(): OwnedResource.Lease? = owner.acquireLease()
+
+    override fun close() = owner.close()
+}
+
+internal class SceneCaptureRequest(
+    val videoInput: SceneVideoInputSpec?,
+    val sentenceAudioInput: SceneVideoInputSpec?,
+    val resolvedTiming: SceneResolvedTiming?,
+    private val stillFallback: OwnedBitmap,
+) : Closeable {
+    fun fallbackBitmapOrNull(): Bitmap? = stillFallback.bitmapOrNull()
+
+    fun acquireMiningLease(): OwnedResource.Lease? = stillFallback.acquireLease()
+
+    override fun close() = stillFallback.close()
+}
+
+internal class CapturedOcrFrame(
+    val request: SceneCaptureRequest,
+) : Closeable {
+    val bitmap: Bitmap?
+        get() = request.fallbackBitmapOrNull()
+
+    override fun close() = request.close()
+}
+
+internal interface SceneMpvPropertyReader {
+    fun double(name: String): Double?
+
+    fun string(name: String): String?
+
+    fun boolean(name: String): Boolean?
+
+    fun int(name: String): Int?
+}
+
+internal object DirectSceneMpvPropertyReader : SceneMpvPropertyReader {
+    override fun double(name: String): Double? = runCatching { MPVLib.getPropertyDouble(name) }.getOrNull()
+
+    override fun string(name: String): String? = runCatching { MPVLib.getPropertyString(name) }.getOrNull()
+
+    override fun boolean(name: String): Boolean? = runCatching { MPVLib.getPropertyBoolean(name) }.getOrNull()
+
+    override fun int(name: String): Int? = runCatching { MPVLib.getPropertyInt(name) }.getOrNull()
+}
+
+internal data class SceneMpvSnapshot(
+    val anchorMediaSeconds: Double,
+    val mediaDurationSeconds: Double?,
+    val subtitleStartSeconds: Double?,
+    val subtitleEndSeconds: Double?,
+    val subtitleSpeed: Double,
+    val subtitleDelaySeconds: Double,
+    val playableValue: String?,
+    val selectedVideoId: Int,
+    val selectedVideoFfmpegIndex: Int,
+    val selectedAudioId: Int?,
+    val selectedExternalAudioValue: String?,
+    val selectedAudioIsExternal: Boolean,
+    val seekable: Boolean?,
+    val selectedAudioFfmpegIndex: Int? = null,
+)
+
+/**
+ * mpv offers no multi-property transaction. The request factory therefore reads this immutable
+ * snapshot both before and after the still capture and accepts only unchanged player state.
+ */
+internal class SceneMpvSnapshotReader(
+    private val properties: SceneMpvPropertyReader = DirectSceneMpvPropertyReader,
+) {
+    fun read(): SceneMpvSnapshot? {
+        val anchor = properties.double("time-pos")
+            ?.takeIf { it.isFinite() && it >= 0.0 }
+            ?: return null
+        val duration = properties.double("duration")
+            ?.takeIf { it.isFinite() && it >= 0.0 }
+        val speed = properties.double("sub-speed")
+            ?.takeIf { it.isFinite() && it > 0.0 }
+            ?: return null
+        val delay = properties.double("sub-delay")
+            ?.takeIf(Double::isFinite)
+            ?: return null
+        val selectedVideo = selectedVideo() ?: return null
+        val selectedAudio = selectedAudio()
+
+        return SceneMpvSnapshot(
+            anchorMediaSeconds = anchor,
+            mediaDurationSeconds = duration,
+            subtitleStartSeconds = properties.double("sub-start/full"),
+            subtitleEndSeconds = properties.double("sub-end/full"),
+            subtitleSpeed = speed,
+            subtitleDelaySeconds = delay,
+            playableValue = properties.string("path")?.takeIf(String::isNotBlank),
+            selectedVideoId = selectedVideo.id,
+            selectedVideoFfmpegIndex = selectedVideo.ffmpegIndex,
+            selectedAudioId = selectedAudio.id,
+            selectedExternalAudioValue = selectedAudio.externalValue,
+            selectedAudioIsExternal = selectedAudio.isExternal,
+            seekable = properties.boolean("seekable"),
+            selectedAudioFfmpegIndex = selectedAudio.ffmpegIndex,
+        )
+    }
+
+    private fun selectedVideo(): SelectedVideoSnapshot? {
+        val trackCount = properties.int("track-list/count") ?: return null
+        val index = (0 until trackCount).firstOrNull { index ->
+            properties.string("track-list/$index/type") == "video" &&
+                properties.boolean("track-list/$index/selected") == true
+        } ?: return null
+        if (properties.boolean("track-list/$index/external") == true) return null
+        return SelectedVideoSnapshot(
+            id = properties.int("track-list/$index/id") ?: return null,
+            ffmpegIndex = properties.int("track-list/$index/ff-index")
+                ?.takeIf { it >= 0 }
+                ?: return null,
+        )
+    }
+
+    private fun selectedAudio(): SelectedAudioSnapshot {
+        val selectedAudioId = properties.string("aid")?.toIntOrNull()
+            ?: properties.int("aid")
+            ?: return SelectedAudioSnapshot()
+        val trackCount = properties.int("track-list/count")
+            ?: return SelectedAudioSnapshot(id = selectedAudioId)
+        val index = (0 until trackCount).firstOrNull { index ->
+            properties.string("track-list/$index/type") == "audio" &&
+                properties.int("track-list/$index/id") == selectedAudioId
+        } ?: return SelectedAudioSnapshot(id = selectedAudioId)
+        val externalValue = properties.string("track-list/$index/external-filename")
+            ?.takeIf(String::isNotBlank)
+        return SelectedAudioSnapshot(
+            id = selectedAudioId,
+            externalValue = externalValue,
+            isExternal = properties.boolean("track-list/$index/external") == true ||
+                externalValue != null,
+            ffmpegIndex = properties.int("track-list/$index/ff-index")
+                ?.takeIf { it >= 0 },
+        )
+    }
+
+    private data class SelectedAudioSnapshot(
+        val id: Int? = null,
+        val externalValue: String? = null,
+        val isExternal: Boolean = false,
+        val ffmpegIndex: Int? = null,
+    )
+
+    private data class SelectedVideoSnapshot(
+        val id: Int,
+        val ffmpegIndex: Int,
+    )
+}
+
+internal class SceneCaptureRequestFactory(
+    private val mpvSnapshotReader: SceneMpvSnapshotReader = SceneMpvSnapshotReader(),
+) {
+    suspend fun captureSubtitle(
+        videoSnapshot: (SceneMpvSnapshot) -> SceneCaptureInputSnapshot?,
+        parsedSubtitleCandidates: List<SceneRangeCandidate>,
+        captureFallback: suspend () -> Bitmap?,
+    ): SceneCaptureRequest? {
+        return capture(videoSnapshot, captureFallback) { mpv ->
+            val timingSnapshot = mpv.toTimingSnapshot()
+            val mpvRange = SceneRangeEndpointPair(
+                startSeconds = mpv.subtitleStartSeconds,
+                endSeconds = mpv.subtitleEndSeconds,
+                clockDomain = SceneClockDomain.SUBTITLE,
+                provenance = SceneRangeProvenance.MPV_SUBTITLE_PROPERTIES,
+            )
+            val parsed = parsedSubtitleCandidates.filter {
+                it.clockDomain == SceneClockDomain.SUBTITLE &&
+                    it.provenance == SceneRangeProvenance.PARSED_SUBTITLE_CUE
+            }
+            SceneTimingResolver.resolve(
+                snapshot = timingSnapshot,
+                mpvSubtitleRange = mpvRange,
+                parsedSubtitleRanges = parsed,
+                playbackFallback = playbackFallbackFor(mpv),
+            )
+        }
+    }
+
+    suspend fun captureOcr(
+        videoSnapshot: (SceneMpvSnapshot) -> SceneCaptureInputSnapshot?,
+        paddingSeconds: Double,
+        captureFallback: suspend () -> Bitmap?,
+    ): CapturedOcrFrame? {
+        val request = capture(videoSnapshot, captureFallback) { mpv ->
+            val timingSnapshot = mpv.toTimingSnapshot()
+            val range = SceneTimingResolver.ocrRange(
+                anchorSeconds = mpv.anchorMediaSeconds,
+                paddingSeconds = paddingSeconds,
+                mediaDurationSeconds = mpv.mediaDurationSeconds,
+            ) ?: return@capture null
+            SceneTimingResolver.resolve(
+                snapshot = timingSnapshot,
+                mpvSubtitleRange = null,
+                parsedSubtitleRanges = emptyList(),
+                playbackFallback = range,
+            )
+        } ?: return null
+        return CapturedOcrFrame(request)
+    }
+
+    private suspend fun capture(
+        videoSnapshot: (SceneMpvSnapshot) -> SceneCaptureInputSnapshot?,
+        captureFallback: suspend () -> Bitmap?,
+        resolveTiming: (SceneMpvSnapshot) -> SceneResolvedTiming?,
+    ): SceneCaptureRequest? {
+        val beforeMpv = mpvSnapshotReader.read() ?: return null
+        val beforeVideo = videoSnapshot(beforeMpv) ?: return null
+        val fallback = captureFallback() ?: return null
+        var transferred = false
+        try {
+            val afterMpv = mpvSnapshotReader.read() ?: return null
+            val afterVideo = videoSnapshot(afterMpv) ?: return null
+            if (!sameCaptureState(beforeMpv, afterMpv) || beforeVideo != afterVideo) return null
+
+            val videoInput = SceneVideoInputResolver.resolve(beforeVideo.video)
+            val sentenceAudioInput = when {
+                beforeVideo.sentenceAudio != null -> {
+                    SceneVideoInputResolver.resolve(beforeVideo.sentenceAudio)
+                }
+                beforeMpv.selectedAudioId != null &&
+                    beforeMpv.selectedAudioFfmpegIndex == null -> null
+                else -> videoInput
+            }
+            val request = SceneCaptureRequest(
+                videoInput = videoInput,
+                sentenceAudioInput = sentenceAudioInput,
+                resolvedTiming = resolveTiming(beforeMpv),
+                stillFallback = OwnedBitmap(fallback),
+            )
+            transferred = true
+            return request
+        } finally {
+            if (!transferred && !fallback.isRecycled) fallback.recycle()
+        }
+    }
+
+    private fun sameCaptureState(before: SceneMpvSnapshot, after: SceneMpvSnapshot): Boolean {
+        return closeEnough(before.anchorMediaSeconds, after.anchorMediaSeconds, SCENE_ANCHOR_TOLERANCE_SECONDS) &&
+            nullableDoubleEquals(before.mediaDurationSeconds, after.mediaDurationSeconds) &&
+            nullableDoubleEquals(before.subtitleStartSeconds, after.subtitleStartSeconds) &&
+            nullableDoubleEquals(before.subtitleEndSeconds, after.subtitleEndSeconds) &&
+            nullableDoubleEquals(before.subtitleSpeed, after.subtitleSpeed) &&
+            nullableDoubleEquals(before.subtitleDelaySeconds, after.subtitleDelaySeconds) &&
+            before.playableValue == after.playableValue &&
+            before.selectedVideoId == after.selectedVideoId &&
+            before.selectedVideoFfmpegIndex == after.selectedVideoFfmpegIndex &&
+            before.selectedAudioId == after.selectedAudioId &&
+            before.selectedExternalAudioValue == after.selectedExternalAudioValue &&
+            before.selectedAudioIsExternal == after.selectedAudioIsExternal &&
+            before.seekable == after.seekable &&
+            before.selectedAudioFfmpegIndex == after.selectedAudioFfmpegIndex
+    }
+
+    private fun nullableDoubleEquals(first: Double?, second: Double?): Boolean {
+        if (first == null || second == null) return first == second
+        return closeEnough(first, second, DOUBLE_SNAPSHOT_TOLERANCE_SECONDS)
+    }
+
+    private fun closeEnough(first: Double, second: Double, tolerance: Double): Boolean {
+        if (!first.isFinite() || !second.isFinite()) return first.toBits() == second.toBits()
+        return abs(first - second) <= tolerance
+    }
+
+    private fun SceneMpvSnapshot.toTimingSnapshot(): SceneTimingSnapshot {
+        return SceneTimingSnapshot(
+            anchorSeconds = anchorMediaSeconds,
+            subtitleSpeed = subtitleSpeed,
+            subtitleDelaySeconds = subtitleDelaySeconds,
+            mediaDurationSeconds = mediaDurationSeconds,
+        )
+    }
+
+    private fun playbackFallbackFor(snapshot: SceneMpvSnapshot): SceneRangeCandidate {
+        val duration = snapshot.mediaDurationSeconds
+        val range = if (duration == null) {
+            val start = max(0.0, snapshot.anchorMediaSeconds - DEFAULT_PLAYBACK_FALLBACK_SECONDS / 2.0)
+            start to max(snapshot.anchorMediaSeconds, start + DEFAULT_PLAYBACK_FALLBACK_SECONDS)
+        } else {
+            val targetDuration = min(DEFAULT_PLAYBACK_FALLBACK_SECONDS, duration)
+            val start = (snapshot.anchorMediaSeconds - targetDuration / 2.0)
+                .coerceIn(0.0, max(0.0, duration - targetDuration))
+            start to (start + targetDuration)
+        }
+        return SceneRangeCandidate(
+            startSeconds = range.first,
+            endSeconds = range.second,
+            clockDomain = SceneClockDomain.MEDIA,
+            provenance = SceneRangeProvenance.PLAYBACK_POSITION,
+        )
+    }
+
+    private companion object {
+        const val DEFAULT_PLAYBACK_FALLBACK_SECONDS = 1.0
+        const val DOUBLE_SNAPSHOT_TOLERANCE_SECONDS = 0.000_001
+    }
+}
+
+internal data class SceneCaptureInputSnapshot(
+    val video: SceneVideoInputSnapshot,
+    val sentenceAudio: SceneVideoInputSnapshot?,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbe.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbe.kt
@@ -1,0 +1,53 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import java.util.Locale
+
+internal object SceneMediaProbe {
+    fun inspect(output: String): Boolean {
+        val normalized = output.lowercase(Locale.ROOT)
+        if (PROTECTION_MARKERS.any(normalized::contains)) {
+            return false
+        }
+        val values = output.lineSequence()
+            .mapNotNull { line ->
+                val separator = line.indexOf('=')
+                if (separator <= 0) {
+                    null
+                } else {
+                    line.substring(0, separator).trim().lowercase(Locale.ROOT) to
+                        line.substring(separator + 1).trim().lowercase(Locale.ROOT)
+                }
+            }
+            .toList()
+        val pixelFormat = values.firstOrNull { it.first == "pix_fmt" }?.second
+            ?: return false
+        if (pixelFormat in setOf("none", "unknown")) {
+            return false
+        }
+        val rawBits = values.firstOrNull { it.first == "bits_per_raw_sample" }
+            ?.second
+            ?.toIntOrNull()
+        val transfer = values.firstOrNull { it.first == "color_transfer" }?.second.orEmpty()
+        val primaries = values.firstOrNull { it.first == "color_primaries" }?.second.orEmpty()
+        val profile = values.firstOrNull { it.first == "profile" }?.second.orEmpty()
+        if (
+            rawBits?.let { it > 8 } == true ||
+            TEN_BIT_PIXEL_FORMAT.containsMatchIn(pixelFormat) ||
+            transfer in HDR_TRANSFERS ||
+            primaries == "bt2020" ||
+            profile.contains("main 10")
+        ) {
+            return false
+        }
+        return true
+    }
+
+    fun inspectAudio(output: String): Boolean {
+        val normalized = output.lowercase(Locale.ROOT)
+        return PROTECTION_MARKERS.none(normalized::contains) && "codec_type=audio" in normalized
+    }
+
+    private val HDR_TRANSFERS = setOf("smpte2084", "arib-std-b67")
+    private val TEN_BIT_PIXEL_FORMAT = Regex("(p0(?:10|12|16)|p(?:9|10|12|14|16)(?:le|be)?)(?:$|[^0-9])")
+    private val PROTECTION_MARKERS = setOf("cenc", "cbcs", "crypto", "encrypted", "encryption", "drm")
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneSentenceAudioService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneSentenceAudioService.kt
@@ -1,0 +1,113 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.content.Context
+import chimahon.anki.AnkiMediaSource
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
+import java.security.MessageDigest
+import java.util.UUID
+
+internal fun interface SceneSentenceAudioService {
+    suspend fun prepare(request: SceneCaptureRequest): AnkiMediaSource?
+}
+
+internal class FrozenSceneSentenceAudioService private constructor(
+    private val cacheDirectory: File,
+    private val inputAcquirer: SceneInputAcquirer,
+    private val commandExecutor: SceneCommandExecutor,
+) : SceneSentenceAudioService {
+    constructor(context: Context) : this(
+        cacheDirectory = context.cacheDir,
+        inputAcquirer = AndroidSceneInputAcquirer(context),
+        commandExecutor = FfmpegKitSceneCommandExecutor(),
+    )
+
+    override suspend fun prepare(request: SceneCaptureRequest): AnkiMediaSource? {
+        val videoInput = request.videoInput ?: return null
+        val input = request.sentenceAudioInput ?: return null
+        val range = request.resolvedTiming?.audioRange ?: return null
+        return withTimeoutOrNull(AUDIO_TIMEOUT_MILLIS) {
+            withContext(Dispatchers.IO) {
+                if (!isVideoSafe(videoInput) || !isAudioSafe(input)) {
+                    return@withContext null
+                }
+                val lease = inputAcquirer.acquire(input) ?: return@withContext null
+                val output = File(cacheDirectory, "chimahon_sentence_audio_${UUID.randomUUID()}.m4a")
+                val inputCleanup = SceneNativeCleanup(lease::close)
+                val outputCleanup = SceneNativeCleanup(output::delete)
+                try {
+                    output.delete()
+                    val result = commandExecutor.executeFfmpeg(
+                        SceneFfmpegArguments.sentenceAudio(
+                            input = input,
+                            acquiredInputValue = lease.ffmpegValue,
+                            range = range,
+                            outputFile = output.absolutePath,
+                            tlsCaFile = lease.tlsCaFile,
+                        ),
+                    ) {
+                        inputCleanup.nativeFinished()
+                        outputCleanup.nativeFinished()
+                    }
+                    if (result !is SceneCommandResult.Success || !output.isFile || output.length() == 0L) {
+                        return@withContext null
+                    }
+                    val bytes = output.readBytes()
+                    AnkiMediaSource.Bytes(
+                        data = bytes,
+                        preferredBaseName = "chimahon_sentence_${bytes.sha256()}",
+                        extension = "m4a",
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    return@withContext null
+                } finally {
+                    inputCleanup.release()
+                    outputCleanup.release()
+                }
+            }
+        }
+    }
+
+    private suspend fun isVideoSafe(input: SceneVideoInputSpec): Boolean {
+        val lease = inputAcquirer.acquire(input) ?: return false
+        val cleanup = SceneNativeCleanup(lease::close)
+        return try {
+            val probe = commandExecutor.executeFfprobe(
+                SceneFfmpegArguments.videoProbe(input, lease.ffmpegValue, lease.tlsCaFile),
+                cleanup::nativeFinished,
+            )
+            probe is SceneCommandResult.Success && SceneMediaProbe.inspect(probe.output)
+        } finally {
+            cleanup.release()
+        }
+    }
+
+    private suspend fun isAudioSafe(input: SceneVideoInputSpec): Boolean {
+        val lease = inputAcquirer.acquire(input) ?: return false
+        val cleanup = SceneNativeCleanup(lease::close)
+        return try {
+            val probe = commandExecutor.executeFfprobe(
+                SceneFfmpegArguments.audioProbe(input, lease.ffmpegValue, lease.tlsCaFile),
+                cleanup::nativeFinished,
+            )
+            probe is SceneCommandResult.Success && SceneMediaProbe.inspectAudio(probe.output)
+        } finally {
+            cleanup.release()
+        }
+    }
+
+    private fun ByteArray.sha256(): String {
+        return MessageDigest.getInstance("SHA-256")
+            .digest(this)
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private companion object {
+        const val AUDIO_TIMEOUT_MILLIS = 60_000L
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneTiming.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneTiming.kt
@@ -1,0 +1,229 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import kotlin.math.max
+import kotlin.math.min
+
+internal const val SCENE_ANCHOR_TOLERANCE_SECONDS = 0.125
+internal const val SCENE_MIN_DURATION_SECONDS = 0.25
+internal const val SCENE_MAX_ANIMATION_DURATION_SECONDS = 10.0
+internal const val SCENE_MAX_AUDIO_DURATION_SECONDS = 30.0
+
+internal enum class SceneClockDomain {
+    SUBTITLE,
+    MEDIA,
+}
+
+internal enum class SceneRangeProvenance {
+    MPV_SUBTITLE_PROPERTIES,
+    PARSED_SUBTITLE_CUE,
+    PLAYBACK_POSITION,
+    OCR_CAPTURE,
+}
+
+private val SceneRangeProvenance.expectedClockDomain: SceneClockDomain
+    get() = when (this) {
+        SceneRangeProvenance.MPV_SUBTITLE_PROPERTIES,
+        SceneRangeProvenance.PARSED_SUBTITLE_CUE,
+        -> SceneClockDomain.SUBTITLE
+        SceneRangeProvenance.PLAYBACK_POSITION,
+        SceneRangeProvenance.OCR_CAPTURE,
+        -> SceneClockDomain.MEDIA
+    }
+
+internal data class SceneRangeCandidate(
+    val startSeconds: Double,
+    val endSeconds: Double,
+    val clockDomain: SceneClockDomain,
+    val provenance: SceneRangeProvenance,
+) {
+    init {
+        require(provenance.expectedClockDomain == clockDomain) {
+            "$provenance must use ${provenance.expectedClockDomain} clock"
+        }
+    }
+}
+
+internal data class SceneRangeEndpointPair(
+    val startSeconds: Double?,
+    val endSeconds: Double?,
+    val clockDomain: SceneClockDomain,
+    val provenance: SceneRangeProvenance,
+) {
+    init {
+        require(provenance.expectedClockDomain == clockDomain) {
+            "$provenance must use ${provenance.expectedClockDomain} clock"
+        }
+    }
+
+    fun completeCandidateOrNull(): SceneRangeCandidate? {
+        return SceneRangeCandidate(
+            startSeconds = startSeconds ?: return null,
+            endSeconds = endSeconds ?: return null,
+            clockDomain = clockDomain,
+            provenance = provenance,
+        )
+    }
+}
+
+internal data class SceneTimeRange(
+    val startSeconds: Double,
+    val endSeconds: Double,
+) {
+    val durationSeconds: Double
+        get() = endSeconds - startSeconds
+
+    fun contains(
+        positionSeconds: Double,
+        toleranceSeconds: Double = SCENE_ANCHOR_TOLERANCE_SECONDS,
+    ): Boolean {
+        return positionSeconds >= startSeconds - toleranceSeconds &&
+            positionSeconds <= endSeconds + toleranceSeconds
+    }
+}
+
+internal data class SceneTimingSnapshot(
+    val anchorSeconds: Double,
+    val subtitleSpeed: Double,
+    val subtitleDelaySeconds: Double,
+    val mediaDurationSeconds: Double?,
+)
+
+internal data class SceneResolvedTiming(
+    val animationRange: SceneTimeRange,
+    val audioRange: SceneTimeRange,
+)
+
+internal object SceneTimingResolver {
+    fun resolve(
+        snapshot: SceneTimingSnapshot,
+        mpvSubtitleRange: SceneRangeEndpointPair?,
+        parsedSubtitleRanges: List<SceneRangeCandidate>,
+        playbackFallback: SceneRangeCandidate,
+        animationCapSeconds: Double = SCENE_MAX_ANIMATION_DURATION_SECONDS,
+        audioCapSeconds: Double = SCENE_MAX_AUDIO_DURATION_SECONDS,
+    ): SceneResolvedTiming? {
+        if (!snapshot.isValid()) return null
+        if (!animationCapSeconds.isFinite() || animationCapSeconds < SCENE_MIN_DURATION_SECONDS) return null
+        if (!audioCapSeconds.isFinite() || audioCapSeconds < SCENE_MIN_DURATION_SECONDS) return null
+
+        val candidates = buildList {
+            mpvSubtitleRange?.completeCandidateOrNull()?.let(::add)
+            addAll(parsedSubtitleRanges)
+            add(playbackFallback)
+        }
+        val resolvedSource = candidates.firstNotNullOfOrNull { candidate ->
+            candidate.toMediaRange(snapshot)?.takeIf {
+                it.contains(snapshot.anchorSeconds) &&
+                    it.isInsideMedia(snapshot.mediaDurationSeconds)
+            }
+        } ?: return null
+
+        val animationRange = deriveCappedRange(
+            sourceRange = resolvedSource,
+            anchorSeconds = snapshot.anchorSeconds,
+            capSeconds = animationCapSeconds,
+            mediaDurationSeconds = snapshot.mediaDurationSeconds,
+        ) ?: return null
+        val audioRange = deriveCappedRange(
+            sourceRange = resolvedSource,
+            anchorSeconds = snapshot.anchorSeconds,
+            capSeconds = audioCapSeconds,
+            mediaDurationSeconds = snapshot.mediaDurationSeconds,
+        ) ?: return null
+
+        return SceneResolvedTiming(
+            animationRange = animationRange,
+            audioRange = audioRange,
+        )
+    }
+
+    fun deriveCappedRange(
+        sourceRange: SceneTimeRange,
+        anchorSeconds: Double,
+        capSeconds: Double,
+        mediaDurationSeconds: Double?,
+    ): SceneTimeRange? {
+        if (!sourceRange.isValid() || !anchorSeconds.isFinite()) return null
+        if (!capSeconds.isFinite() || capSeconds < SCENE_MIN_DURATION_SECONDS) return null
+        if (!sourceRange.contains(anchorSeconds)) return null
+        if (mediaDurationSeconds != null) {
+            if (!mediaDurationSeconds.isFinite() || mediaDurationSeconds < SCENE_MIN_DURATION_SECONDS) return null
+            if (anchorSeconds > mediaDurationSeconds + SCENE_ANCHOR_TOLERANCE_SECONDS) return null
+        }
+
+        val sourceDuration = sourceRange.durationSeconds
+        val targetDuration = sourceDuration.coerceIn(SCENE_MIN_DURATION_SECONDS, capSeconds)
+        val candidateStart = if (sourceDuration > capSeconds) {
+            anchorSeconds - capSeconds / 2.0
+        } else {
+            sourceRange.startSeconds - (targetDuration - sourceDuration) / 2.0
+        }
+
+        val start = if (mediaDurationSeconds != null) {
+            candidateStart.coerceIn(0.0, max(0.0, mediaDurationSeconds - targetDuration))
+        } else {
+            max(0.0, candidateStart)
+        }
+        val result = SceneTimeRange(start, start + targetDuration)
+        return result.takeIf { it.contains(anchorSeconds) }
+    }
+
+    fun ocrRange(
+        anchorSeconds: Double,
+        paddingSeconds: Double,
+        mediaDurationSeconds: Double?,
+    ): SceneRangeCandidate? {
+        if (!anchorSeconds.isFinite() || anchorSeconds < 0.0) return null
+        if (!paddingSeconds.isFinite() || paddingSeconds <= 0.0) return null
+        val start = max(0.0, anchorSeconds - paddingSeconds)
+        val end = mediaDurationSeconds
+            ?.takeIf { it.isFinite() && it >= 0.0 }
+            ?.let { min(it, anchorSeconds + paddingSeconds) }
+            ?: (anchorSeconds + paddingSeconds)
+        if (end <= start) return null
+        return SceneRangeCandidate(
+            startSeconds = start,
+            endSeconds = end,
+            clockDomain = SceneClockDomain.MEDIA,
+            provenance = SceneRangeProvenance.OCR_CAPTURE,
+        )
+    }
+
+    private fun SceneTimingSnapshot.isValid(): Boolean {
+        return anchorSeconds.isFinite() &&
+            anchorSeconds >= 0.0 &&
+            subtitleSpeed.isFinite() &&
+            subtitleSpeed > 0.0 &&
+            subtitleDelaySeconds.isFinite() &&
+            (
+                mediaDurationSeconds == null ||
+                    (mediaDurationSeconds.isFinite() && mediaDurationSeconds >= 0.0)
+                )
+    }
+
+    private fun SceneRangeCandidate.toMediaRange(snapshot: SceneTimingSnapshot): SceneTimeRange? {
+        if (!startSeconds.isFinite() || !endSeconds.isFinite() || endSeconds <= startSeconds) return null
+        val range = when (clockDomain) {
+            SceneClockDomain.SUBTITLE -> SceneTimeRange(
+                startSeconds = startSeconds * snapshot.subtitleSpeed + snapshot.subtitleDelaySeconds,
+                endSeconds = endSeconds * snapshot.subtitleSpeed + snapshot.subtitleDelaySeconds,
+            )
+            SceneClockDomain.MEDIA -> SceneTimeRange(startSeconds, endSeconds)
+        }
+        return range.takeIf { it.isValid() }
+    }
+
+    private fun SceneTimeRange.isValid(): Boolean {
+        return startSeconds.isFinite() &&
+            endSeconds.isFinite() &&
+            startSeconds >= 0.0 &&
+            endSeconds > startSeconds
+    }
+
+    private fun SceneTimeRange.isInsideMedia(mediaDurationSeconds: Double?): Boolean {
+        return mediaDurationSeconds == null ||
+            endSeconds <= mediaDurationSeconds + RANGE_BOUND_EPSILON_SECONDS
+    }
+
+    private const val RANGE_BOUND_EPSILON_SECONDS = 0.000_001
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInput.kt
@@ -1,0 +1,333 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+internal enum class SceneVideoInputKind {
+    LOCAL_FILE,
+    CONTENT_URI,
+    REMOTE_HTTP,
+}
+
+internal data class SceneVideoInputSpec(
+    val value: String,
+    val kind: SceneVideoInputKind,
+    val headers: List<Pair<String, String>>,
+    val videoStreamIndex: Int? = null,
+    val audioStreamIndex: Int? = null,
+)
+
+internal data class SceneVideoInputSnapshot(
+    val originalVideoValue: String,
+    val playableValue: String?,
+    val headers: List<Pair<String, String>>,
+    val ffmpegStreamArgs: List<Pair<String, String>>,
+    val ffmpegVideoArgs: List<Pair<String, String>>,
+    val seekable: Boolean?,
+    val videoStreamIndex: Int? = null,
+    val audioStreamIndex: Int? = null,
+)
+
+internal object SceneVideoInputResolver {
+    fun resolve(snapshot: SceneVideoInputSnapshot): SceneVideoInputSpec? {
+        if (snapshot.originalVideoValue.isBlank() && snapshot.playableValue.isNullOrBlank()) {
+            return null
+        }
+        if (isDash(snapshot.originalVideoValue) || isDash(snapshot.playableValue)) return null
+        if (snapshot.ffmpegStreamArgs.isNotEmpty() || snapshot.ffmpegVideoArgs.isNotEmpty()) {
+            return null
+        }
+        if (snapshot.seekable != true) return null
+
+        val original = snapshot.originalVideoValue.takeIf(String::isNotBlank)
+        if (original != null && isTransient(original)) return null
+        val normalized = original?.let(::normalizeInput)
+            ?: snapshot.playableValue?.takeIf(String::isNotBlank)?.let { playable ->
+                if (isTransient(playable)) return null
+                normalizeInput(playable)
+            }
+            ?: return null
+
+        val headers = when (normalized.second) {
+            SceneVideoInputKind.REMOTE_HTTP -> validateRemoteInput(normalized.first, snapshot.headers)
+                ?: return null
+            SceneVideoInputKind.LOCAL_FILE,
+            SceneVideoInputKind.CONTENT_URI,
+            -> emptyList()
+        }
+
+        return SceneVideoInputSpec(
+            value = normalized.first,
+            kind = normalized.second,
+            headers = headers,
+            videoStreamIndex = snapshot.videoStreamIndex?.takeIf { it >= 0 },
+            audioStreamIndex = snapshot.audioStreamIndex?.takeIf { it >= 0 },
+        )
+    }
+
+    private fun validateRemoteInput(
+        value: String,
+        headers: List<Pair<String, String>>,
+    ): List<Pair<String, String>>? {
+        val uri = runCatching { URI(value) }.getOrNull() ?: return null
+        if (!uri.userInfo.isNullOrBlank() || uri.host.isNullOrBlank()) return null
+        if (hasSensitiveQuery(uri.rawQuery.orEmpty())) return null
+        if (!headers.all(::isAllowedHeader)) return null
+        return headers
+    }
+
+    private fun normalizeInput(value: String): Pair<String, SceneVideoInputKind>? {
+        return when {
+            value.startsWith("content://", ignoreCase = true) -> {
+                value to SceneVideoInputKind.CONTENT_URI
+            }
+            value.startsWith("file://", ignoreCase = true) -> {
+                val path = runCatching { URI(value).path }.getOrNull()
+                    ?.takeIf(String::isNotBlank)
+                    ?: return null
+                path to SceneVideoInputKind.LOCAL_FILE
+            }
+            value.startsWith("/") -> value to SceneVideoInputKind.LOCAL_FILE
+            value.startsWith("http://", ignoreCase = true) ||
+                value.startsWith("https://", ignoreCase = true) -> {
+                value to SceneVideoInputKind.REMOTE_HTTP
+            }
+            else -> null
+        }
+    }
+
+    private fun isAllowedHeader(header: Pair<String, String>): Boolean {
+        val (name, value) = header
+        return name.lowercase(Locale.ROOT) in ALLOWED_HTTP_HEADERS &&
+            value.length <= MAX_HEADER_VALUE_LENGTH &&
+            value.none { it == '\u0000' || it == '\r' || it == '\n' || (it.code < 0x20 && it != '\t') }
+    }
+
+    private fun hasSensitiveQuery(query: String): Boolean {
+        query.split('&').forEach { parameter ->
+            val name = runCatching {
+                URLDecoder.decode(parameter.substringBefore('='), StandardCharsets.UTF_8.name())
+                    .lowercase(Locale.ROOT)
+            }.getOrNull() ?: return true
+            if (name in SENSITIVE_QUERY_NAMES || SENSITIVE_QUERY_PREFIXES.any(name::startsWith)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun isDash(value: String?): Boolean {
+        val path = value?.substringBefore('?')?.lowercase(Locale.ROOT).orEmpty()
+        return path.endsWith(".mpd") || value?.startsWith("dash://", ignoreCase = true) == true
+    }
+
+    private fun isTransient(value: String): Boolean {
+        val scheme = value.substringBefore("://", missingDelimiterValue = "").lowercase(Locale.ROOT)
+        return scheme in TRANSIENT_SCHEMES ||
+            value.startsWith("magnet:", ignoreCase = true) ||
+            value.substringBefore('?').endsWith(".torrent", ignoreCase = true)
+    }
+
+    private val ALLOWED_HTTP_HEADERS = setOf(
+        "user-agent",
+        "accept",
+        "accept-encoding",
+        "accept-language",
+        "cache-control",
+        "origin",
+        "pragma",
+        "referer",
+    )
+    private val SENSITIVE_QUERY_NAMES = setOf(
+        "access_token",
+        "api_key",
+        "auth",
+        "authorization",
+        "credential",
+        "credentials",
+        "key",
+        "policy",
+        "signature",
+        "signed",
+        "sig",
+        "token",
+    )
+    private val SENSITIVE_QUERY_PREFIXES = setOf(
+        "x-amz-",
+        "x-goog-",
+    )
+    private val TRANSIENT_SCHEMES = setOf("blob", "data", "fd", "fdclose", "edl", "memory", "lavf", "ytdl")
+    private const val MAX_HEADER_VALUE_LENGTH = 8_192
+}
+
+internal object SceneFfmpegArguments {
+    fun animatedAvif(
+        input: SceneVideoInputSpec,
+        acquiredInputValue: String,
+        range: SceneTimeRange,
+        outputFile: String,
+        encoderName: String,
+        tlsCaFile: String? = null,
+    ): Array<String> {
+        require(encoderName.isNotBlank()) { "AV1 encoder name must not be blank" }
+        return buildList {
+            addInputOptions(input, tlsCaFile)
+            add("-ss")
+            add(range.startSeconds.toFfmpegSeconds())
+            add("-i")
+            add(acquiredInputValue)
+            add("-map")
+            add(input.videoMapSelector())
+            add("-an")
+            add("-sn")
+            add("-dn")
+            add("-t")
+            add(range.durationSeconds.toFfmpegSeconds())
+            add("-vf")
+            add(FRAME_FILTER)
+            add("-frames:v")
+            add(MAX_FRAME_COUNT.toString())
+            add("-c:v")
+            add("av1_mediacodec")
+            add("-codec_name")
+            add(encoderName)
+            add("-bitrate_mode")
+            add("cq")
+            add("-global_quality")
+            add("35")
+            add("-ndk_codec")
+            add("1")
+            add("-pix_fmt")
+            add("yuv420p")
+            add("-loop")
+            add("0")
+            add("-f")
+            add("avif")
+            add("-y")
+            add(outputFile)
+        }.toTypedArray()
+    }
+
+    fun videoProbe(
+        input: SceneVideoInputSpec,
+        acquiredInputValue: String,
+        tlsCaFile: String? = null,
+    ): Array<String> {
+        return buildList {
+            addInputOptions(input, tlsCaFile)
+            add("-v")
+            add("error")
+            add("-select_streams")
+            add(input.videoProbeSelector())
+            add("-show_entries")
+            add("stream=pix_fmt,color_transfer,color_primaries,bits_per_raw_sample,profile:stream_side_data")
+            add("-of")
+            add("default=noprint_wrappers=1")
+            add(acquiredInputValue)
+        }.toTypedArray()
+    }
+
+    fun audioProbe(
+        input: SceneVideoInputSpec,
+        acquiredInputValue: String,
+        tlsCaFile: String? = null,
+    ): Array<String> {
+        return buildList {
+            addInputOptions(input, tlsCaFile)
+            add("-v")
+            add("error")
+            add("-select_streams")
+            add(input.audioProbeSelector())
+            add("-show_entries")
+            add("stream=codec_type,codec_name:stream_side_data")
+            add("-of")
+            add("default=noprint_wrappers=1")
+            add(acquiredInputValue)
+        }.toTypedArray()
+    }
+
+    fun sentenceAudio(
+        input: SceneVideoInputSpec,
+        acquiredInputValue: String,
+        range: SceneTimeRange,
+        outputFile: String,
+        tlsCaFile: String? = null,
+    ): Array<String> {
+        return buildList {
+            addInputOptions(input, tlsCaFile)
+            add("-ss")
+            add(range.startSeconds.toFfmpegSeconds())
+            add("-i")
+            add(acquiredInputValue)
+            add("-map")
+            add(input.audioSelector())
+            add("-vn")
+            add("-sn")
+            add("-dn")
+            add("-t")
+            add(range.durationSeconds.toFfmpegSeconds())
+            add("-c:a")
+            add("aac")
+            add("-b:a")
+            add("128k")
+            add("-y")
+            add(outputFile)
+        }.toTypedArray()
+    }
+
+    private fun MutableList<String>.addInputOptions(
+        input: SceneVideoInputSpec,
+        tlsCaFile: String?,
+    ) {
+        add("-codec_whitelist")
+        add(ALLOWED_INPUT_DECODERS)
+        if (input.kind == SceneVideoInputKind.REMOTE_HTTP) {
+            require(!tlsCaFile.isNullOrBlank()) { "Remote scene input requires a CA bundle" }
+            add("-tls_verify")
+            add("1")
+            add("-ca_file")
+            add(tlsCaFile)
+            add("-protocol_whitelist")
+            add(REMOTE_PROTOCOLS)
+            add("-rw_timeout")
+            add(REMOTE_IO_TIMEOUT_MICROSECONDS)
+        }
+        if (input.headers.isNotEmpty()) {
+            add("-headers")
+            add(input.headers.joinToString(separator = "") { (name, value) -> "$name: $value\r\n" })
+        }
+    }
+
+    private fun SceneVideoInputSpec.videoMapSelector(): String {
+        return videoStreamIndex?.let { "0:$it" } ?: "0:v:0"
+    }
+
+    private fun SceneVideoInputSpec.videoProbeSelector(): String {
+        return videoStreamIndex?.toString() ?: "v:0"
+    }
+
+    private fun SceneVideoInputSpec.audioSelector(): String {
+        return audioStreamIndex?.let { "0:$it" } ?: "0:a:0"
+    }
+
+    private fun SceneVideoInputSpec.audioProbeSelector(): String {
+        return audioStreamIndex?.toString() ?: "a:0"
+    }
+
+    private fun Double.toFfmpegSeconds(): String {
+        return String.format(Locale.ROOT, "%.6f", this).trimEnd('0').trimEnd('.')
+    }
+
+    internal const val FRAME_FILTER =
+        "fps=8,scale=w='min(640,iw)':h='min(640,ih)':force_original_aspect_ratio=decrease:force_divisible_by=16,setsar=1"
+    internal const val FRAME_RATE = 8.0
+    internal const val MAX_FRAME_COUNT = 80
+    private const val REMOTE_PROTOCOLS = "http,https,tls,tcp,crypto"
+    private const val REMOTE_IO_TIMEOUT_MICROSECONDS = "15000000"
+    internal const val ALLOWED_INPUT_DECODERS =
+        "aac,ac3,alac,av1,dca,eac3,ffv1,flac,h263,h264,hevc,libdav1d,mjpeg,mp3,mp3float,mpeg1video," +
+            "mpeg2video,mpeg4,opus,pcm_f32le,pcm_s16le,pcm_s24le,pcm_s32le,png,prores,theora,truehd," +
+            "vorbis,vp8,vp9"
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -60,6 +60,8 @@ import chimahon.KanjiResult
 import chimahon.LookupResult
 import chimahon.MediaInfo
 import chimahon.anki.AnkiCardCreator
+import chimahon.anki.AnkiMediaRequest
+import chimahon.anki.AnkiMediaWarning
 import chimahon.anki.AnkiResult
 import chimahon.util.ImageEncoder
 import eu.kanade.tachiyomi.ui.dictionary.buildKanjiEntryJson
@@ -142,6 +144,11 @@ fun OcrLookupPopup(
     screenshot: Bitmap? = null,
     onRequestScreenshot: (suspend () -> Bitmap?)? = null,
     onRequestSentenceAudio: (suspend () -> ByteArray?)? = null,
+    mediaRequest: AnkiMediaRequest? = null,
+    miningBusy: Boolean = false,
+    launchMiningJob: ((suspend () -> Unit) -> Boolean)? = null,
+    onMiningBusy: () -> Unit = {},
+    onAnkiMediaWarnings: (List<AnkiMediaWarning>) -> Unit = {},
     onCropTriggered: ((Long, Int?) -> Unit)? = null,
     initialLookupDeferred: kotlinx.coroutines.Deferred<chimahon.DictionaryRepository.LookupResult2>? = null,
     initialEntryJsons: List<String>? = null,
@@ -515,6 +522,19 @@ fun OcrLookupPopup(
         }
     }
 
+    fun submitMining(block: suspend () -> Unit) {
+        if (miningBusy) {
+            onMiningBusy()
+            return
+        }
+        val launcher = launchMiningJob
+        if (launcher == null) {
+            miningScope.launch { block() }
+        } else if (!launcher(block)) {
+            onMiningBusy()
+        }
+    }
+
     fun performAnkiLookup(
         index: Int,
         glossaryIndex: Int?,
@@ -546,8 +566,8 @@ fun OcrLookupPopup(
         val shouldUseCropMode = screenshotFieldMapped && cropMode == "crop" && onCropTriggered != null
 
         if (shouldUseCropMode) {
-            miningScope.launch {
-                val sentenceAudioBytes = if (sentenceAudioFieldMapped) {
+            submitMining {
+                val sentenceAudioBytes = if (mediaRequest == null && sentenceAudioFieldMapped) {
                     onRequestSentenceAudio?.invoke()
                 } else {
                     null
@@ -576,11 +596,13 @@ fun OcrLookupPopup(
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
                     titleId = titleId,
+                    mediaRequest = mediaRequest,
                 )
                 if (ankiResult is AnkiResult.Success || ankiResult is AnkiResult.CardExists || ankiResult is AnkiResult.OpenCard) {
                     withContext(kotlinx.coroutines.Dispatchers.Main) {
                         when (ankiResult) {
                             is AnkiResult.Success -> {
+                                onAnkiMediaWarnings(ankiResult.warnings)
                                 updateStatus(result.term.expression)
                                 dismissPopup()
                                 onCropTriggered.invoke(ankiResult.noteId, glossaryIndex)
@@ -610,13 +632,17 @@ fun OcrLookupPopup(
                 }
             }
         } else {
-            miningScope.launch {
-                val encoding = if (screenshotFieldMapped && cropMode != "no_screenshot") {
+            submitMining {
+                val encoding = if (
+                    mediaRequest == null &&
+                    screenshotFieldMapped &&
+                    cropMode != "no_screenshot"
+                ) {
                     onRequestScreenshot?.invoke()?.let { ImageEncoder.encode(it) }
                 } else {
                     null
                 }
-                val sentenceAudioBytes = if (sentenceAudioFieldMapped) {
+                val sentenceAudioBytes = if (mediaRequest == null && sentenceAudioFieldMapped) {
                     onRequestSentenceAudio?.invoke()
                 } else {
                     null
@@ -646,10 +672,12 @@ fun OcrLookupPopup(
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
                     titleId = titleId,
+                    mediaRequest = mediaRequest,
                 )
                 withContext(kotlinx.coroutines.Dispatchers.Main) {
                     when (ankiResult) {
                         is AnkiResult.Success -> {
+                            onAnkiMediaWarnings(ankiResult.warnings)
                             updateStatus(result.term.expression)
                             context.toast(MR.strings.anki_card_added)
                         }
@@ -1309,6 +1337,11 @@ fun OcrLookupPopup(
             screenshot = screenshot,
             onRequestScreenshot = onRequestScreenshot,
             onRequestSentenceAudio = onRequestSentenceAudio,
+            mediaRequest = mediaRequest,
+            miningBusy = miningBusy,
+            launchMiningJob = launchMiningJob,
+            onMiningBusy = onMiningBusy,
+            onAnkiMediaWarnings = onAnkiMediaWarnings,
             onCropTriggered = onCropTriggered,
             usePopup = usePopup,
             onTermMatched = null,

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureServiceTest.kt
@@ -1,0 +1,204 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.graphics.Bitmap
+import chimahon.anki.AnkiScreenshotPreparation
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class AndroidSceneCaptureServiceTest {
+    @TempDir
+    lateinit var tempDirectory: File
+
+    @Test
+    fun `successful capture uses exact bounded AVIF command`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        val service = service(
+            executor = executor,
+            validate = { AnimatedAvifInfo(320, 180, 24, 3_000) },
+        )
+
+        val result = service.prepare(request())
+
+        val animated = result as AnkiScreenshotPreparation.Animated
+        assertEquals("avif", animated.animation.extension)
+        assertTrue(animated.animation.preferredBaseName.startsWith("chimahon_scene_"))
+        assertArrayEquals(
+            expectedAvifArguments(animated.animation.file.absolutePath),
+            executor.ffmpegArguments,
+        )
+        animated.animation.file.delete()
+    }
+
+    @Test
+    fun `missing compatible AV1 encoder falls back before native work`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        val service = service(
+            executor = executor,
+            av1EncoderName = { null },
+        )
+
+        val result = service.prepare(request())
+
+        assertTrue(result is AnkiScreenshotPreparation.Failed)
+        assertEquals(0, executor.probeCalls)
+        assertEquals(0, executor.ffmpegCalls)
+        assertFalse(tempDirectory.resolve("scene").exists())
+    }
+
+    @Test
+    fun `failed validation deletes partial output`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        val sceneDirectory = tempDirectory.resolve("scene")
+        val service = service(
+            executor = executor,
+            validate = { null },
+        )
+
+        val result = service.prepare(request())
+
+        assertTrue(result is AnkiScreenshotPreparation.Failed)
+        assertTrue(sceneDirectory.listFiles().isNullOrEmpty())
+    }
+
+    private fun service(
+        executor: RecordingExecutor,
+        validate: (File) -> AnimatedAvifInfo? = {
+            AnimatedAvifInfo(320, 180, 24, 3_000)
+        },
+        av1EncoderName: () -> String? = { TEST_AV1_ENCODER_NAME },
+    ): AndroidSceneCaptureService {
+        return AndroidSceneCaptureService.forTests(
+            sceneDirectory = tempDirectory.resolve("scene"),
+            inputAcquirer = SceneInputAcquirer { input ->
+                object : SceneInputLease {
+                    override val ffmpegValue = input.value
+                    override val tlsCaFile = "/files/cacert.pem"
+
+                    override fun close() = Unit
+                }
+            },
+            commandExecutor = executor,
+            validate = validate,
+            av1EncoderName = av1EncoderName,
+        )
+    }
+
+    private fun request(): SceneCaptureRequest {
+        val input = SceneVideoInputSpec(
+            value = "https://media.example/video.mp4",
+            kind = SceneVideoInputKind.REMOTE_HTTP,
+            headers = listOf("User-Agent" to "Chimahon"),
+        )
+        val bitmap = mockk<Bitmap>(relaxed = true)
+        every { bitmap.isRecycled } returns false
+        return SceneCaptureRequest(
+            videoInput = input,
+            sentenceAudioInput = input,
+            resolvedTiming = SceneResolvedTiming(
+                animationRange = SceneTimeRange(1.25, 4.25),
+                audioRange = SceneTimeRange(1.25, 4.25),
+            ),
+            stillFallback = OwnedBitmap(bitmap),
+        )
+    }
+
+    private fun expectedAvifArguments(output: String): Array<String> {
+        return arrayOf(
+            "-codec_whitelist",
+            SceneFfmpegArguments.ALLOWED_INPUT_DECODERS,
+            "-tls_verify",
+            "1",
+            "-ca_file",
+            "/files/cacert.pem",
+            "-protocol_whitelist",
+            "http,https,tls,tcp,crypto",
+            "-rw_timeout",
+            "15000000",
+            "-headers",
+            "User-Agent: Chimahon\r\n",
+            "-ss",
+            "1.25",
+            "-i",
+            "https://media.example/video.mp4",
+            "-map",
+            "0:v:0",
+            "-an",
+            "-sn",
+            "-dn",
+            "-t",
+            "3",
+            "-vf",
+            SceneFfmpegArguments.FRAME_FILTER,
+            "-frames:v",
+            "80",
+            "-c:v",
+            "av1_mediacodec",
+            "-codec_name",
+            TEST_AV1_ENCODER_NAME,
+            "-bitrate_mode",
+            "cq",
+            "-global_quality",
+            "35",
+            "-ndk_codec",
+            "1",
+            "-pix_fmt",
+            "yuv420p",
+            "-loop",
+            "0",
+            "-f",
+            "avif",
+            "-y",
+            output,
+        )
+    }
+
+    private class RecordingExecutor(
+        private val writeOutput: Boolean,
+    ) : SceneCommandExecutor {
+        var probeCalls = 0
+        var ffmpegCalls = 0
+        var ffmpegArguments: Array<String> = emptyArray()
+
+        override suspend fun executeFfmpeg(
+            arguments: Array<String>,
+            onNativeFinished: () -> Unit,
+        ): SceneCommandResult {
+            return try {
+                ffmpegCalls++
+                ffmpegArguments = arguments
+                if (writeOutput) {
+                    File(arguments.last()).writeBytes(byteArrayOf(1, 2, 3))
+                }
+                SceneCommandResult.Success()
+            } finally {
+                onNativeFinished()
+            }
+        }
+
+        override suspend fun executeFfprobe(
+            arguments: Array<String>,
+            onNativeFinished: () -> Unit,
+        ): SceneCommandResult {
+            return try {
+                probeCalls++
+                SceneCommandResult.Success(
+                    "pix_fmt=yuv420p\ncolor_transfer=bt709\ncolor_primaries=bt709\nbits_per_raw_sample=8",
+                )
+            } finally {
+                onNativeFinished()
+            }
+        }
+    }
+
+    private companion object {
+        const val TEST_AV1_ENCODER_NAME = "c2.android.av1.encoder"
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidatorTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidatorTest.kt
@@ -1,0 +1,150 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.RandomAccessFile
+
+class AnimatedAvifValidatorTest {
+    @TempDir
+    lateinit var directory: File
+
+    @Test
+    fun `accepts a structurally valid bounded animated AVIF`() {
+        assertEquals(
+            AnimatedAvifInfo(width = 64, height = 48, frameCount = 4, totalDurationMillis = 500),
+            validate(avif()),
+        )
+    }
+
+    @Test
+    fun `requires bounded files and core AVIF boxes`() {
+        assertNull(AnimatedAvifValidator.validate(directory.resolve("missing.avif")))
+        assertNull(validate(byteArrayOf()))
+        assertNull(validate(avif(includeMeta = false)))
+        assertNull(validate(avif(mediaBytes = 0)))
+
+        val oversized = directory.resolve("oversized.avif")
+        RandomAccessFile(oversized, "rw").use { it.setLength(MAX_FILE_BYTES + 1) }
+        assertNull(AnimatedAvifValidator.validate(oversized))
+    }
+
+    @Test
+    fun `requires animated AVIF brands and an AV1 configuration`() {
+        assertNull(validate(avif(majorBrand = "avif")))
+        assertNull(validate(avif(brands = listOf("avif"))))
+        assertNull(validate(avif(includeAv1Config = false)))
+        assertNull(validate(avif(width = 641)))
+    }
+
+    @Test
+    fun `requires two to eighty positively timed frames near eight fps`() {
+        assertNull(validate(avif(frames = 1)))
+        assertNull(validate(avif(frames = 81)))
+        assertNull(validate(avif(frameDuration = 0)))
+        assertNull(validate(avif(frameDuration = 2_000)))
+    }
+
+    @Test
+    fun `requires matching nonzero sample sizes within media data`() {
+        assertNull(validate(avif(sampleSizes = listOf(1, 1, 0, 1))))
+        assertNull(validate(avif(sampleSizes = listOf(1, 1, 1))))
+        assertNull(validate(avif(mediaBytes = 3)))
+    }
+
+    private fun avif(
+        majorBrand: String = "avis",
+        brands: List<String> = listOf("avif", "MA1B"),
+        includeMeta: Boolean = true,
+        includeAv1Config: Boolean = true,
+        width: Int = 64,
+        frames: Int = 4,
+        frameDuration: Int = 1_000,
+        sampleSizes: List<Int> = List(frames) { 1 },
+        mediaBytes: Int = sampleSizes.sum(),
+    ): ByteArray {
+        val fileType = majorBrand.ascii() + ByteArray(4) + brands.fold(byteArrayOf()) { bytes, brand -> bytes + brand.ascii() }
+        val sampleEntry = box(
+            "av01",
+            ByteArray(78).apply {
+                writeUInt16(24, width)
+                writeUInt16(26, 48)
+            } + if (includeAv1Config) box("av1C", byteArrayOf(0x81.toByte(), 0, 0, 0)) else byteArrayOf(),
+        )
+        val sampleDescription = ByteArray(8).apply { writeUInt32(4, 1) } + sampleEntry
+        val sampleTiming = ByteArray(16).apply {
+            writeUInt32(4, 1)
+            writeUInt32(8, frames)
+            writeUInt32(12, frameDuration)
+        }
+        val sampleSizeTable = ByteArray(12 + sampleSizes.size * 4).apply {
+            writeUInt32(8, sampleSizes.size)
+            sampleSizes.forEachIndexed { index, size -> writeUInt32(12 + index * 4, size) }
+        }
+        val mediaHeader = ByteArray(24).apply {
+            writeUInt32(12, 8_000)
+            writeUInt32(16, frames * frameDuration)
+        }
+        val sampleTable =
+            box("stsd", sampleDescription) +
+                box("stts", sampleTiming) +
+                box("stsz", sampleSizeTable)
+        val movie = box(
+            "moov",
+            box(
+                "trak",
+                box(
+                    "mdia",
+                    box("mdhd", mediaHeader) +
+                        box("minf", box("stbl", sampleTable)),
+                ),
+            ),
+        )
+        return box("ftyp", fileType) +
+            (if (includeMeta) box("meta", ByteArray(4)) else byteArrayOf()) +
+            movie +
+            box("mdat", ByteArray(mediaBytes))
+    }
+
+    private fun validate(bytes: ByteArray): AnimatedAvifInfo? {
+        val file = directory.resolve("scene-${System.nanoTime()}.avif")
+        file.writeBytes(bytes)
+        return AnimatedAvifValidator.validate(file)
+    }
+
+    private fun String.ascii() = toByteArray(Charsets.US_ASCII)
+
+    private fun ByteArray.writeUInt16(offset: Int, value: Int) {
+        this[offset] = (value ushr 8).toByte()
+        this[offset + 1] = value.toByte()
+    }
+
+    private fun ByteArray.writeUInt32(offset: Int, value: Int) {
+        this[offset] = (value ushr 24).toByte()
+        this[offset + 1] = (value ushr 16).toByte()
+        this[offset + 2] = (value ushr 8).toByte()
+        this[offset + 3] = value.toByte()
+    }
+
+    private fun box(type: String, payload: ByteArray): ByteArray {
+        return ByteArrayOutputStream().apply {
+            writeUInt32(payload.size + 8)
+            write(type.ascii())
+            write(payload)
+        }.toByteArray()
+    }
+
+    private fun ByteArrayOutputStream.writeUInt32(value: Int) {
+        write(value ushr 24)
+        write(value ushr 16)
+        write(value ushr 8)
+        write(value)
+    }
+
+    private companion object {
+        const val MAX_FILE_BYTES = 10L * 1024L * 1024L
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinatorTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinatorTest.kt
@@ -1,0 +1,156 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.graphics.Bitmap
+import chimahon.anki.AnkiMediaSource
+import chimahon.anki.AnkiScreenshotMode
+import chimahon.anki.AnkiScreenshotPreparation
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.Closeable
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlayerSceneMiningCoordinatorTest {
+    @Test
+    fun `only one job is accepted and its lease closes`() = runTest {
+        val coordinator = coordinator()
+        val release = CompletableDeferred<Unit>()
+        var closedLeases = 0
+
+        assertTrue(
+            coordinator.launchWithLease(
+                acquireLease = { Closeable { closedLeases++ } },
+                block = { release.await() },
+            ),
+        )
+        assertFalse(
+            coordinator.launchWithLease(
+                acquireLease = { Closeable { closedLeases++ } },
+                block = {},
+            ),
+        )
+        assertEquals(PlayerSceneMiningProgress.Preparing, coordinator.progress.value)
+
+        release.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(1, closedLeases)
+        assertEquals(PlayerSceneMiningProgress.Idle, coordinator.progress.value)
+    }
+
+    @Test
+    fun `precommit cancellation stops work`() = runTest {
+        val coordinator = coordinator()
+        val neverCompletes = CompletableDeferred<Unit>()
+        var closedLeases = 0
+
+        coordinator.launchWithLease(
+            acquireLease = { Closeable { closedLeases++ } },
+            block = { neverCompletes.await() },
+        )
+        runCurrent()
+        coordinator.cancelPreCommit()
+        advanceUntilIdle()
+
+        assertEquals(1, closedLeases)
+        assertEquals(PlayerSceneMiningProgress.Idle, coordinator.progress.value)
+    }
+
+    @Test
+    fun `commit boundary prevents cancellation`() = runTest {
+        val coordinator = coordinator()
+        val commitCompletes = CompletableDeferred<Unit>()
+
+        coordinator.launchWithLease(
+            acquireLease = { Closeable {} },
+            block = { commitCompletes.await() },
+        )
+        runCurrent()
+        coordinator.markCommitStarted()
+        coordinator.cancelPreCommit()
+
+        assertEquals(PlayerSceneMiningProgress.Committing, coordinator.progress.value)
+        commitCompletes.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(PlayerSceneMiningProgress.Idle, coordinator.progress.value)
+    }
+
+    @Test
+    fun `cancellation winning the boundary prevents commit`() = runTest {
+        val coordinator = coordinator()
+        coordinator.launchWithLease(
+            acquireLease = { Closeable {} },
+            block = { CompletableDeferred<Unit>().await() },
+        )
+        runCurrent()
+
+        coordinator.cancelPreCommit()
+
+        assertThrows<CancellationException> {
+            coordinator.markCommitStarted()
+        }
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `AVIF failure uses captured WebP fallback`() = runTest {
+        val fallback = AnkiMediaSource.Bytes(
+            data = byteArrayOf(1, 2, 3),
+            preferredBaseName = "still",
+            extension = "webp",
+        )
+        val coordinator = PlayerSceneMiningCoordinator(
+            scope = this,
+            sceneCaptureService = {
+                SceneCaptureService { AnkiScreenshotPreparation.Failed(null) }
+            },
+            stillEncoder = SceneStillFallbackEncoder { fallback },
+        )
+
+        val result = coordinator.prepareScreenshot(request(), AnkiScreenshotMode.ANIMATED_SCENE)
+
+        assertEquals(
+            AnkiScreenshotPreparation.Failed(fallback),
+            result,
+        )
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.coordinator(): PlayerSceneMiningCoordinator {
+        return PlayerSceneMiningCoordinator(
+            scope = this,
+            sceneCaptureService = {
+                SceneCaptureService { AnkiScreenshotPreparation.Failed(null) }
+            },
+            stillEncoder = SceneStillFallbackEncoder { null },
+        )
+    }
+
+    private fun request(): SceneCaptureRequest {
+        val input = SceneVideoInputSpec(
+            value = "/video.mp4",
+            kind = SceneVideoInputKind.LOCAL_FILE,
+            headers = emptyList(),
+        )
+        val bitmap = mockk<Bitmap>(relaxed = true)
+        every { bitmap.isRecycled } returns false
+        return SceneCaptureRequest(
+            videoInput = input,
+            sentenceAudioInput = input,
+            resolvedTiming = SceneResolvedTiming(
+                animationRange = SceneTimeRange(0.0, 1.0),
+                audioRange = SceneTimeRange(0.0, 1.0),
+            ),
+            stillFallback = OwnedBitmap(bitmap),
+        )
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequestTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequestTest.kt
@@ -1,0 +1,179 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.graphics.Bitmap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SceneCaptureRequestTest {
+    @Test
+    fun `unchanged double snapshot creates request`() = runTest {
+        val bitmap = mockBitmap()
+        val factory = SceneCaptureRequestFactory(
+            SceneMpvSnapshotReader(SequencePropertyReader(listOf(snapshot(), snapshot()))),
+        )
+
+        val request = factory.captureSubtitle(
+            videoSnapshot = { inputSnapshot() },
+            parsedSubtitleCandidates = emptyList(),
+            captureFallback = { bitmap },
+        )
+
+        assertNotNull(request)
+        request!!.close()
+        verify(exactly = 1) { bitmap.recycle() }
+    }
+
+    @Test
+    fun `changed player path rejects request and recycles still`() = runTest {
+        val bitmap = mockBitmap()
+        val factory = SceneCaptureRequestFactory(
+            SceneMpvSnapshotReader(
+                SequencePropertyReader(
+                    listOf(
+                        snapshot(path = "https://media.example/one.mp4"),
+                        snapshot(path = "https://media.example/two.mp4"),
+                    ),
+                ),
+            ),
+        )
+
+        val request = factory.captureSubtitle(
+            videoSnapshot = { inputSnapshot() },
+            parsedSubtitleCandidates = emptyList(),
+            captureFallback = { bitmap },
+        )
+
+        assertNull(request)
+        verify(exactly = 1) { bitmap.recycle() }
+    }
+
+    @Test
+    fun `changed frozen video state rejects request`() = runTest {
+        val bitmap = mockBitmap()
+        val factory = SceneCaptureRequestFactory(
+            SceneMpvSnapshotReader(SequencePropertyReader(listOf(snapshot(), snapshot()))),
+        )
+        var reads = 0
+
+        val request = factory.captureSubtitle(
+            videoSnapshot = {
+                inputSnapshot(
+                    headers = listOf("User-Agent" to if (reads++ == 0) "before" else "after"),
+                )
+            },
+            parsedSubtitleCandidates = emptyList(),
+            captureFallback = { bitmap },
+        )
+
+        assertNull(request)
+        verify(exactly = 1) { bitmap.recycle() }
+    }
+
+    @Test
+    fun `selected audio without a frozen ffmpeg index is omitted`() = runTest {
+        val bitmap = mockBitmap()
+        val factory = SceneCaptureRequestFactory(
+            SceneMpvSnapshotReader(
+                SequencePropertyReader(
+                    listOf(
+                        snapshot(selectedAudioId = 2),
+                        snapshot(selectedAudioId = 2),
+                    ),
+                ),
+            ),
+        )
+
+        val request = factory.captureSubtitle(
+            videoSnapshot = { inputSnapshot() },
+            parsedSubtitleCandidates = emptyList(),
+            captureFallback = { bitmap },
+        )
+
+        assertNotNull(request)
+        assertNull(request!!.sentenceAudioInput)
+        request.close()
+    }
+
+    private fun mockBitmap(): Bitmap {
+        return mockk<Bitmap>(relaxed = true).also {
+            every { it.isRecycled } returns false
+        }
+    }
+
+    private fun inputSnapshot(
+        headers: List<Pair<String, String>> = emptyList(),
+    ): SceneCaptureInputSnapshot {
+        val video = SceneVideoInputSnapshot(
+            originalVideoValue = "https://media.example/video.mp4",
+            playableValue = "https://media.example/video.mp4",
+            headers = headers,
+            ffmpegStreamArgs = emptyList(),
+            ffmpegVideoArgs = emptyList(),
+            seekable = true,
+        )
+        return SceneCaptureInputSnapshot(video = video, sentenceAudio = null)
+    }
+
+    private fun snapshot(
+        path: String = "https://media.example/video.mp4",
+        selectedAudioId: Int? = null,
+    ): SnapshotValues {
+        return SnapshotValues(
+            doubles = mapOf(
+                "time-pos" to 5.0,
+                "duration" to 60.0,
+                "sub-start/full" to 4.0,
+                "sub-end/full" to 6.0,
+                "sub-speed" to 1.0,
+                "sub-delay" to 0.0,
+            ),
+            strings = buildMap {
+                put("path", path)
+                put("track-list/0/type", "video")
+                selectedAudioId?.let { put("aid", it.toString()) }
+            },
+            booleans = mapOf(
+                "track-list/0/selected" to true,
+                "track-list/0/external" to false,
+                "seekable" to true,
+            ),
+            ints = mapOf(
+                "track-list/count" to 1,
+                "track-list/0/id" to 1,
+                "track-list/0/ff-index" to 0,
+            ),
+        )
+    }
+
+    private data class SnapshotValues(
+        val doubles: Map<String, Double>,
+        val strings: Map<String, String>,
+        val booleans: Map<String, Boolean>,
+        val ints: Map<String, Int>,
+    )
+
+    private class SequencePropertyReader(
+        private val snapshots: List<SnapshotValues>,
+    ) : SceneMpvPropertyReader {
+        private var index = 0
+        private val current: SnapshotValues
+            get() = snapshots[index.coerceAtMost(snapshots.lastIndex)]
+
+        override fun double(name: String): Double? = current.doubles[name]
+
+        override fun string(name: String): String? = current.strings[name]
+
+        override fun boolean(name: String): Boolean? {
+            return current.booleans[name].also {
+                if (name == "seekable") index++
+            }
+        }
+
+        override fun int(name: String): Int? = current.ints[name]
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbeTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbeTest.kt
@@ -1,0 +1,51 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SceneMediaProbeTest {
+    @Test
+    fun `ordinary eight bit SDR video is safe`() {
+        assertTrue(
+            SceneMediaProbe.inspect(
+                """
+                pix_fmt=yuv420p
+                color_transfer=bt709
+                color_primaries=bt709
+                bits_per_raw_sample=8
+                profile=Main
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `ten bit and HDR video are rejected`() {
+        listOf(
+            "pix_fmt=yuv420p10le\ncolor_transfer=bt709",
+            "pix_fmt=yuv420p\ncolor_transfer=smpte2084",
+            "pix_fmt=yuv420p\ncolor_primaries=bt2020",
+            "pix_fmt=yuv420p\nbits_per_raw_sample=10",
+        ).forEach { output ->
+            assertFalse(SceneMediaProbe.inspect(output))
+        }
+    }
+
+    @Test
+    fun `protected and unprobeable media fail closed`() {
+        listOf(
+            "pix_fmt=yuv420p\nside_data_type=Encryption info",
+            "pix_fmt=unknown",
+            "",
+        ).forEach { output ->
+            assertFalse(SceneMediaProbe.inspect(output))
+        }
+    }
+
+    @Test
+    fun `audio probe requires a clear audio stream`() {
+        assertTrue(SceneMediaProbe.inspectAudio("codec_type=audio\ncodec_name=aac"))
+        assertFalse(SceneMediaProbe.inspectAudio("codec_type=audio\nside_data_type=cenc"))
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneTimingTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneTimingTest.kt
@@ -1,0 +1,134 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SceneTimingTest {
+    @Test
+    fun `subtitle timing is converted to media clock exactly once`() {
+        val result = resolve(
+            snapshot = snapshot(anchor = 7.0, speed = 2.0, delay = 1.0),
+            mpv = subtitleCandidate(2.0, 4.0),
+        )
+
+        assertEquals(SceneTimeRange(5.0, 9.0), result?.animationRange)
+    }
+
+    @Test
+    fun `incomplete mpv endpoints fall back to parsed cue`() {
+        val result = SceneTimingResolver.resolve(
+            snapshot = snapshot(anchor = 6.0),
+            mpvSubtitleRange = SceneRangeEndpointPair(
+                startSeconds = 5.0,
+                endSeconds = null,
+                clockDomain = SceneClockDomain.SUBTITLE,
+                provenance = SceneRangeProvenance.MPV_SUBTITLE_PROPERTIES,
+            ),
+            parsedSubtitleRanges = listOf(
+                subtitleCandidate(5.0, 7.0, SceneRangeProvenance.PARSED_SUBTITLE_CUE),
+            ),
+            playbackFallback = mediaCandidate(5.5, 6.5),
+        )
+
+        assertEquals(SceneTimeRange(5.0, 7.0), result?.animationRange)
+    }
+
+    @Test
+    fun `long cue has independent animation and audio caps`() {
+        val result = resolve(
+            snapshot = snapshot(anchor = 20.0, duration = 60.0),
+            mpv = subtitleCandidate(0.0, 50.0),
+        )
+
+        assertEquals(10.0, result?.animationRange?.durationSeconds)
+        assertEquals(30.0, result?.audioRange?.durationSeconds)
+        assertTrue(result!!.animationRange.contains(20.0))
+        assertTrue(result.audioRange.contains(20.0))
+    }
+
+    @Test
+    fun `short cue expands to minimum duration`() {
+        val result = SceneTimingResolver.deriveCappedRange(
+            sourceRange = SceneTimeRange(2.0, 2.1),
+            anchorSeconds = 2.05,
+            capSeconds = 10.0,
+            mediaDurationSeconds = 20.0,
+        )
+
+        assertEquals(0.25, result?.durationSeconds ?: 0.0, 1e-9)
+        assertTrue(result!!.contains(2.05))
+    }
+
+    @Test
+    fun `candidate outside known media is rejected`() {
+        assertNull(
+            resolve(
+                snapshot = snapshot(anchor = 10.0, duration = 10.0),
+                mpv = subtitleCandidate(9.0, 11.0),
+                fallback = mediaCandidate(11.0, 12.0),
+            ),
+        )
+    }
+
+    @Test
+    fun `ocr padding uses media clock and clamps to media bounds`() {
+        assertEquals(
+            SceneRangeCandidate(
+                startSeconds = 0.0,
+                endSeconds = 2.1,
+                clockDomain = SceneClockDomain.MEDIA,
+                provenance = SceneRangeProvenance.OCR_CAPTURE,
+            ),
+            SceneTimingResolver.ocrRange(
+                anchorSeconds = 0.1,
+                paddingSeconds = 2.0,
+                mediaDurationSeconds = 20.0,
+            ),
+        )
+    }
+
+    private fun resolve(
+        snapshot: SceneTimingSnapshot,
+        mpv: SceneRangeCandidate?,
+        fallback: SceneRangeCandidate = mediaCandidate(0.5, 1.5),
+    ): SceneResolvedTiming? {
+        return SceneTimingResolver.resolve(
+            snapshot = snapshot,
+            mpvSubtitleRange = mpv?.let {
+                SceneRangeEndpointPair(
+                    startSeconds = it.startSeconds,
+                    endSeconds = it.endSeconds,
+                    clockDomain = it.clockDomain,
+                    provenance = it.provenance,
+                )
+            },
+            parsedSubtitleRanges = emptyList(),
+            playbackFallback = fallback,
+        )
+    }
+
+    private fun snapshot(
+        anchor: Double,
+        speed: Double = 1.0,
+        delay: Double = 0.0,
+        duration: Double? = null,
+    ) = SceneTimingSnapshot(anchor, speed, delay, duration)
+
+    private fun subtitleCandidate(
+        start: Double,
+        end: Double,
+        provenance: SceneRangeProvenance = SceneRangeProvenance.MPV_SUBTITLE_PROPERTIES,
+    ) = SceneRangeCandidate(start, end, SceneClockDomain.SUBTITLE, provenance)
+
+    private fun mediaCandidate(
+        start: Double,
+        end: Double,
+    ) = SceneRangeCandidate(
+        start,
+        end,
+        SceneClockDomain.MEDIA,
+        SceneRangeProvenance.PLAYBACK_POSITION,
+    )
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInputTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInputTest.kt
@@ -1,0 +1,207 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SceneVideoInputTest {
+    @Test
+    fun `local file SAF and public HLS are supported`() {
+        assertSupported(snapshot("/video/episode.mkv"))
+        assertSupported(snapshot("file:///video/episode.mkv"))
+        assertSupported(snapshot("content://media/external/video/1"))
+        val hls = resolve(
+            snapshot(
+                "https://media.example/episode.m3u8?keyframe=1&design=2",
+                headers = ALLOWED_HEADERS,
+            ),
+        )
+
+        val input = requireNotNull(hls)
+        assertEquals(SceneVideoInputKind.REMOTE_HTTP, input.kind)
+        assertEquals(ALLOWED_HEADERS, input.headers)
+    }
+
+    @Test
+    fun `sensitive request metadata and signed URLs are rejected`() {
+        listOf(
+            snapshot(
+                "https://media.example/video.mp4",
+                headers = listOf("Authorization" to "Bearer secret"),
+            ),
+            snapshot(
+                "https://media.example/video.mp4?token=secret",
+            ),
+            snapshot(
+                "https://media.example/video.mp4?to%6ben=secret",
+            ),
+            snapshot(
+                "https://user:password@media.example/video.mp4",
+            ),
+        ).forEach { value ->
+            assertNull(resolve(value))
+        }
+    }
+
+    @Test
+    fun `DASH transient and unsafe inputs are rejected`() {
+        val cases = listOf(
+            snapshot("https://media.example/manifest.mpd"),
+            snapshot("ytdl://abc"),
+            snapshot(
+                "https://media.example/video.mp4",
+                ffmpegStreamArgs = listOf("-referer" to "https://private.example"),
+            ),
+            snapshot("https://media.example/video.mp4", seekable = false),
+        )
+
+        cases.forEach { assertNull(resolve(it)) }
+    }
+
+    @Test
+    fun `AVIF command has the single bounded native recipe`() {
+        val input = supportedInput()
+        val arguments = SceneFfmpegArguments.animatedAvif(
+            input = input,
+            acquiredInputValue = "https://media.example/video.mp4",
+            range = SceneTimeRange(1.25, 11.25),
+            outputFile = "/cache/output.avif",
+            encoderName = TEST_AV1_ENCODER_NAME,
+            tlsCaFile = "/files/cacert.pem",
+        ).toList()
+
+        assertTrue(
+            arguments.containsAll(
+                listOf(
+                    "-c:v",
+                    "av1_mediacodec",
+                    "-codec_name",
+                    TEST_AV1_ENCODER_NAME,
+                    "-bitrate_mode",
+                    "cq",
+                    "-global_quality",
+                    "35",
+                ),
+            ),
+        )
+        assertTrue(arguments.containsAll(listOf("-ndk_codec", "1", "-pix_fmt", "yuv420p")))
+        assertTrue(arguments.containsAll(listOf("-frames:v", "80", "-loop", "0", "-f", "avif")))
+        assertTrue(
+            arguments.containsAll(
+                listOf(
+                    "-tls_verify",
+                    "1",
+                    "-ca_file",
+                    "/files/cacert.pem",
+                    "-protocol_whitelist",
+                    "http,https,tls,tcp,crypto",
+                    "-rw_timeout",
+                    "15000000",
+                ),
+            ),
+        )
+        assertEquals(1, arguments.count { it == "-c:v" })
+        assertEquals(SceneFfmpegArguments.FRAME_FILTER, arguments[arguments.indexOf("-vf") + 1])
+        assertTrue(SceneFfmpegArguments.FRAME_FILTER.contains("force_divisible_by=16"))
+        assertFalse(arguments.any { it.contains("webp", ignoreCase = true) })
+    }
+
+    @Test
+    fun `all native input commands restrict decoders without breaking ordinary media`() {
+        val input = supportedInput()
+        val range = SceneTimeRange(1.25, 2.25)
+        val caFile = "/files/cacert.pem"
+        val commands = listOf(
+            SceneFfmpegArguments.animatedAvif(
+                input = input,
+                acquiredInputValue = input.value,
+                range = range,
+                outputFile = "/cache/scene.avif",
+                encoderName = TEST_AV1_ENCODER_NAME,
+                tlsCaFile = caFile,
+            ),
+            SceneFfmpegArguments.videoProbe(input, input.value, caFile),
+            SceneFfmpegArguments.audioProbe(input, input.value, caFile),
+            SceneFfmpegArguments.sentenceAudio(input, input.value, range, "/cache/audio.m4a", caFile),
+        )
+
+        commands.forEach { command ->
+            val arguments = command.toList()
+            val whitelist = arguments[arguments.indexOf("-codec_whitelist") + 1].split(',')
+            assertTrue(whitelist.containsAll(listOf("h264", "hevc", "aac", "av1", "libdav1d")))
+            assertFalse("magicyuv" in whitelist)
+            val inputIndex = arguments.indexOf("-i").takeIf { it >= 0 } ?: arguments.lastIndex
+            assertTrue(arguments.indexOf("-codec_whitelist") < inputIndex)
+        }
+    }
+
+    @Test
+    fun `sentence audio maps the frozen selected stream`() {
+        val input = supportedInput().copy(videoStreamIndex = 2, audioStreamIndex = 3)
+        val range = SceneTimeRange(1.25, 2.25)
+        val caFile = "/files/cacert.pem"
+        val audio = SceneFfmpegArguments
+            .sentenceAudio(input, input.value, range, "/cache/audio.m4a", caFile)
+            .toList()
+        val video = SceneFfmpegArguments
+            .animatedAvif(
+                input = input,
+                acquiredInputValue = input.value,
+                range = range,
+                outputFile = "/cache/scene.avif",
+                encoderName = TEST_AV1_ENCODER_NAME,
+                tlsCaFile = caFile,
+            )
+            .toList()
+        val videoProbe = SceneFfmpegArguments.videoProbe(input, input.value, caFile).toList()
+        val probe = SceneFfmpegArguments.audioProbe(input, input.value, caFile).toList()
+
+        assertEquals("0:2", video[video.indexOf("-map") + 1])
+        assertEquals("2", videoProbe[videoProbe.indexOf("-select_streams") + 1])
+        assertEquals("0:3", audio[audio.indexOf("-map") + 1])
+        assertEquals("3", probe[probe.indexOf("-select_streams") + 1])
+    }
+
+    private fun assertSupported(snapshot: SceneVideoInputSnapshot) {
+        assertNotNull(resolve(snapshot))
+    }
+
+    private fun resolve(snapshot: SceneVideoInputSnapshot): SceneVideoInputSpec? {
+        return SceneVideoInputResolver.resolve(snapshot)
+    }
+
+    private fun supportedInput(): SceneVideoInputSpec {
+        return requireNotNull(resolve(snapshot("https://media.example/video.mp4")))
+    }
+
+    private fun snapshot(
+        value: String,
+        headers: List<Pair<String, String>> = emptyList(),
+        ffmpegStreamArgs: List<Pair<String, String>> = emptyList(),
+        seekable: Boolean = true,
+    ) = SceneVideoInputSnapshot(
+        originalVideoValue = value,
+        playableValue = value,
+        headers = headers,
+        ffmpegStreamArgs = ffmpegStreamArgs,
+        ffmpegVideoArgs = emptyList(),
+        seekable = seekable,
+    )
+
+    private companion object {
+        const val TEST_AV1_ENCODER_NAME = "c2.android.av1.encoder"
+        val ALLOWED_HEADERS = listOf(
+            "User-Agent" to "Chimahon",
+            "Accept" to "*/*",
+            "Accept-Encoding" to "identity",
+            "Accept-Language" to "en-GB",
+            "Cache-Control" to "no-cache",
+            "Origin" to "https://media.example",
+            "Pragma" to "no-cache",
+            "Referer" to "https://media.example/player",
+        )
+    }
+}

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -15,13 +15,17 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import okhttp3.Request
 import org.json.JSONArray
 import org.json.JSONObject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.concurrent.ConcurrentHashMap
 
 // =============================================================================
 // Legacy FieldType enum for UI backwards compatibility
@@ -199,7 +203,7 @@ object Marker {
 // =============================================================================
 
 sealed class AnkiResult {
-    data class Success(val noteId: Long) : AnkiResult()
+    data class Success(val noteId: Long, val warnings: List<AnkiMediaWarning> = emptyList()) : AnkiResult()
     data class CardExists(val noteId: Long) : AnkiResult()
     data class OpenCard(val noteId: Long) : AnkiResult()
     data class Error(val message: String) : AnkiResult()
@@ -216,7 +220,10 @@ object AnkiCardCreator {
     private const val TAG = "AnkiCardCreator"
     private const val TRANSPARENT_IMAGE_DATA_URI =
         "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
-    private val addLocks = ConcurrentHashMap<String, Mutex>()
+    private const val SCREENSHOT_MEDIA_PLACEHOLDER = "__chimahon_screenshot_media__"
+    private const val WORD_AUDIO_MEDIA_PLACEHOLDER = "__chimahon_word_audio_media__"
+    private const val SENTENCE_AUDIO_MEDIA_PLACEHOLDER = "__chimahon_sentence_audio_media__"
+    private val addLocks = List(16) { Mutex() }
 
     private data class DictionaryMediaReference(
         val dictionary: String,
@@ -273,6 +280,7 @@ object AnkiCardCreator {
         syncOnCreate: Boolean = false,
         profileId: String = "",
         titleId: String? = null,
+        mediaRequest: AnkiMediaRequest? = null,
     ): AnkiResult {
         android.util.Log.d(TAG, "addToAnki: deck=$deck, model=$model, forceOpen=$forceOpen, glossaryIndex=$glossaryIndex")
 
@@ -280,6 +288,8 @@ object AnkiCardCreator {
         if (!bridge.hasPermission()) {
             return AnkiResult.PermissionDenied
         }
+
+        val ownedPreparedFiles = mutableListOf<AnkiMediaSource.FileSource>()
         return try {
             val effectiveDeck = deck.ifBlank { bridge.ensureDefaultDeckName() }
             val effectiveModel = if (model.isBlank()) {
@@ -313,146 +323,299 @@ object AnkiCardCreator {
                 null
             }
 
-            var screenshotFilename: String? = null
-            if (screenshotBytes != null) {
-                try {
-                    screenshotFilename = bridge.storeMedia(
-                        filename = generateScreenshotFilename(screenshotBytes),
-                        data = screenshotBytes,
-                    )
-                    android.util.Log.d(TAG, "addToAnki: stored screenshot media as $screenshotFilename")
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "addToAnki: failed to store screenshot media", e)
-                }
-            }
-
-            var wordAudioFilename: String? = null
             val hasWordAudioMarker = fieldMap.values.any {
                 it.contains("{${Marker.WORD_AUDIO}}") || it.contains("{${Marker.AUDIO}}")
             }
-            if (hasWordAudioMarker) {
-                try {
-                    val wordAudioService = Injekt.get<WordAudioService>()
-                    val audioResults = wordAudioService.findWordAudio(result.term.expression, result.term.reading)
-                    if (audioResults.isNotEmpty()) {
-                        // Use the first result (priority order)
-                        val bestAudio = audioResults.first()
-                        val audioData = if (bestAudio.url.startsWith("chimahon-local://")) {
-                            val uri = android.net.Uri.parse(bestAudio.url)
-                            val sourceId = uri.host ?: ""
-                            val filePath = uri.path?.substring(1) ?: ""
-                            wordAudioService.getAudioData(filePath, sourceId)
-                        } else {
-                            wordAudioService.fetchRemoteAudioData(bestAudio.url)
-                        }
-
-                        if (audioData != null) {
-                            val ext = android.net.Uri.parse(bestAudio.url).lastPathSegment
-                                ?.substringAfterLast('.', "mp3")
-                                ?.lowercase() ?: "mp3"
-                            val filename = "chimahon_audio_${result.term.expression}_${result.term.reading}_${System.currentTimeMillis()}.$ext"
-                            wordAudioFilename = bridge.storeMedia(filename, audioData)
-                            android.util.Log.d(TAG, "addToAnki: stored word audio media as $wordAudioFilename")
-                        }
-                    }
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "addToAnki: failed to store word audio media", e)
-                }
-            }
-
-            var sentenceAudioFilename: String? = null
             val hasSentenceAudioMarker = fieldMap.values.any { it.contains("{${Marker.SENTENCE_AUDIO}}") }
-            if (hasSentenceAudioMarker && sentenceAudioBytes != null) {
-                try {
-                    sentenceAudioFilename = bridge.storeMedia(
-                        filename = generateSentenceAudioFilename(sentenceAudioBytes, sentenceAudioExtension),
-                        data = sentenceAudioBytes,
-                    )
-                    android.util.Log.d(TAG, "addToAnki: stored sentence audio media as $sentenceAudioFilename")
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "addToAnki: failed to store sentence audio media", e)
-                }
-            }
-
-            val exportMedia = ExportMediaContext()
-            val fieldsWithPlaceholders = withContext(Dispatchers.Default) {
-                buildFields(
-                    result,
-                    fieldMap,
-                    cloze,
-                    media,
-                    screenshotFilename,
-                    wordAudioFilename,
-                    sentenceAudioFilename,
-                    selectedDict,
-                    popupSelection,
-                    glossaryIndex,
-                    styles,
-                    exportMedia,
-                )
-            }
-            val fields = resolveDictionaryMediaPlaceholders(fieldsWithPlaceholders, exportMedia, bridge)
-            android.util.Log.d(TAG, "addToAnki: built fields=$fields")
-            val tagList = withContext(Dispatchers.Default) {
-                // Split configured tags before rendering markers so commas from a
-                // resolved value (for example a title) stay inside one tag.
-                tags.split(",")
-                    .map { template ->
-                        formatField(
-                            template, result, cloze, media, screenshotFilename, wordAudioFilename,
-                            sentenceAudioFilename, selectedDict, popupSelection, glossaryIndex,
-                            styles, exportMedia,
-                        )
-                    }
-                    .mapNotNull(::normalizeAnkiTag)
-            }
+            val hasScreenshotMarker = fieldMap.values.any { it.contains("{${Marker.SCREENSHOT}}") }
 
             // Keep duplicate lookup and insertion atomic for rapid repeated taps.
-            val lockKey = "${dupScope.lowercase()}|${if (dupScope == "deck") effectiveDeck else ""}|${result.term.expression}"
-            val addLock = addLocks.computeIfAbsent(lockKey) { Mutex() }
-            try {
-                addLock.withLock {
-                    if (dupCheck || forceOpen) {
-                        val targetDeckId = if (dupScope == "deck" && effectiveDeck.isNotBlank()) {
-                            try {
-                                bridge.getDeckId(effectiveDeck)
-                            } catch (e: Exception) {
-                                null
-                            }
-                        } else {
+            val lockKey = "${if (dupScope == "deck") effectiveDeck else ""}\u0000${result.term.expression}"
+            val addLock = addLocks[lockKey.hashCode().ushr(1) % addLocks.size]
+            addLock.withLock {
+                var overwriteNoteId: Long? = null
+                if (dupCheck || forceOpen) {
+                    val targetDeckId = if (dupScope == "deck" && effectiveDeck.isNotBlank()) {
+                        try {
+                            bridge.getDeckId(effectiveDeck)
+                        } catch (e: Exception) {
                             null
                         }
-
-                        val existing = bridge.findNotes(result.term.expression, null, targetDeckId)
-                        if (existing.isNotEmpty()) {
-                            if (forceOpen) return@withLock AnkiResult.OpenCard(existing.first())
-                            when (dupAction) {
-                                "prevent" -> return@withLock AnkiResult.CardExists(existing.first())
-                                "open" -> return@withLock AnkiResult.OpenCard(existing.first())
-                                "overwrite" -> {
-                                    bridge.updateNoteFields(existing.first(), fields)
-                                    com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId, titleId = titleId)
-                                    if (syncOnCreate) bridge.triggerSync()
-                                    return@withLock AnkiResult.Success(existing.first())
-                                }
-                            }
-                        }
+                    } else {
+                        null
                     }
 
-                    val noteId = bridge.addNote(deckName = effectiveDeck, modelName = effectiveModel, fields = fields, tags = tagList)
-                    com.canopus.chimareader.data.AnkiStatsStorage.addCard(context, type, profileId = profileId, titleId = titleId)
-                    if (syncOnCreate) bridge.triggerSync()
-                    AnkiResult.Success(noteId)
+                    val existing = bridge.findNotes(result.term.expression, null, targetDeckId)
+                    if (existing.isNotEmpty()) {
+                        if (forceOpen) return@withLock AnkiResult.OpenCard(existing.first())
+                        when (dupAction) {
+                            "prevent" -> return@withLock AnkiResult.CardExists(existing.first())
+                            "open" -> return@withLock AnkiResult.OpenCard(existing.first())
+                            "overwrite" -> overwriteNoteId = existing.first()
+                        }
+                    }
                 }
-            } finally {
-                addLocks.remove(lockKey, addLock)
+
+                val eagerStill = screenshotBytes?.let { bytes ->
+                    val filename = generateScreenshotFilename(bytes)
+                    AnkiMediaSource.Bytes(
+                        data = bytes,
+                        preferredBaseName = filename.substringBeforeLast('.', filename),
+                        extension = "webp",
+                    )
+                }
+                val screenshotPreparation = when {
+                    !hasScreenshotMarker -> null
+                    mediaRequest?.screenshotProvider != null -> {
+                        val prepared = try {
+                            mediaRequest.screenshotProvider.prepare()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            android.util.Log.w(TAG, "addToAnki: failed to prepare screenshot media", e)
+                            AnkiScreenshotPreparation.Failed(eagerStill)
+                        }
+                        prepared.withStillFallback(eagerStill)
+                    }
+                    eagerStill != null -> AnkiScreenshotPreparation.Still(eagerStill)
+                    else -> null
+                }
+                if (screenshotPreparation is AnkiScreenshotPreparation.Animated) {
+                    ownedPreparedFiles += screenshotPreparation.animation
+                }
+
+                val sentenceAudioSource = if (hasSentenceAudioMarker) {
+                    val lazySource = try {
+                        mediaRequest?.sentenceAudioProvider?.prepare()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        android.util.Log.w(TAG, "addToAnki: failed to prepare sentence audio", e)
+                        null
+                    }
+                    lazySource ?: sentenceAudioBytes?.let { bytes ->
+                        val filename = generateSentenceAudioFilename(bytes, sentenceAudioExtension)
+                        AnkiMediaSource.Bytes(
+                            data = bytes,
+                            preferredBaseName = filename.substringBeforeLast('.', filename),
+                            extension = AnkiMediaNaming.safeExtension(filename, "m4a"),
+                        )
+                    }
+                } else {
+                    null
+                }
+                if (sentenceAudioSource is AnkiMediaSource.FileSource) {
+                    ownedPreparedFiles += sentenceAudioSource
+                }
+
+                val wordAudioSource = if (hasWordAudioMarker) {
+                    prepareWordAudio(result)
+                } else {
+                    null
+                }
+
+                val exportMedia = ExportMediaContext()
+                val fieldsWithPlaceholders = withContext(Dispatchers.Default) {
+                    buildFields(
+                        result,
+                        fieldMap,
+                        cloze,
+                        media,
+                        if (hasScreenshotMarker) SCREENSHOT_MEDIA_PLACEHOLDER else null,
+                        if (hasWordAudioMarker) WORD_AUDIO_MEDIA_PLACEHOLDER else null,
+                        if (hasSentenceAudioMarker) SENTENCE_AUDIO_MEDIA_PLACEHOLDER else null,
+                        selectedDict,
+                        popupSelection,
+                        glossaryIndex,
+                        styles,
+                        exportMedia,
+                    )
+                }
+                val tagsWithPlaceholders = withContext(Dispatchers.Default) {
+                    // Split configured tags before rendering markers so commas from a
+                    // resolved value (for example a title) stay inside one tag.
+                    tags.split(",").map { template ->
+                        formatField(
+                            template,
+                            result,
+                            cloze,
+                            media,
+                            if (hasScreenshotMarker) SCREENSHOT_MEDIA_PLACEHOLDER else null,
+                            if (hasWordAudioMarker) WORD_AUDIO_MEDIA_PLACEHOLDER else null,
+                            if (hasSentenceAudioMarker) SENTENCE_AUDIO_MEDIA_PLACEHOLDER else null,
+                            selectedDict,
+                            popupSelection,
+                            glossaryIndex,
+                            styles,
+                            exportMedia,
+                        )
+                    }
+                }
+
+                // Check the caller's job from inside the non-cancellable
+                // commit block. Cancellation observed before this check
+                // prevents media and note writes; cancellation after it
+                // cannot split those writes.
+                val parentJob = currentCoroutineContext()[Job]
+                withContext(NonCancellable) {
+                    parentJob?.ensureActive()
+                    mediaRequest?.onCommitStarted?.invoke()
+                    val screenshotResult = AnkiScreenshotMediaCommitter(bridge::storeMedia)
+                        .store(screenshotPreparation)
+                    val wordAudioFilename = storeOptionalMedia(
+                        bridge,
+                        wordAudioSource,
+                        "word audio",
+                    )
+                    val sentenceAudioFilename = storeOptionalMedia(
+                        bridge,
+                        sentenceAudioSource,
+                        "sentence audio",
+                    )
+                    val fieldsWithDictionaryMedia = resolveDictionaryMediaPlaceholders(
+                        fieldsWithPlaceholders,
+                        exportMedia,
+                        bridge,
+                    )
+                    val fields = fieldsWithDictionaryMedia.mapValues { (_, value) ->
+                        resolveMediaPlaceholders(
+                            value,
+                            screenshotResult.filename,
+                            wordAudioFilename,
+                            sentenceAudioFilename,
+                        )
+                    }
+                    val tagList = tagsWithPlaceholders
+                        .map { value ->
+                            resolveMediaPlaceholders(
+                                value,
+                                screenshotResult.filename,
+                                wordAudioFilename,
+                                sentenceAudioFilename,
+                            )
+                        }
+                        .mapNotNull(::normalizeAnkiTag)
+                    android.util.Log.d(TAG, "addToAnki: built fields=$fields")
+
+                    val noteId = if (overwriteNoteId != null) {
+                        bridge.updateNoteFields(overwriteNoteId, fields)
+                        overwriteNoteId
+                    } else {
+                        bridge.addNote(
+                            deckName = effectiveDeck,
+                            modelName = effectiveModel,
+                            fields = fields,
+                            tags = tagList,
+                        )
+                    }
+                    com.canopus.chimareader.data.AnkiStatsStorage.addCard(
+                        context,
+                        type,
+                        profileId = profileId,
+                        titleId = titleId,
+                    )
+                    if (syncOnCreate) bridge.triggerSync()
+                    AnkiResult.Success(noteId, screenshotResult.warnings)
+                }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: SecurityException) {
             AnkiResult.PermissionDenied
         } catch (e: Exception) {
             AnkiResult.Error(e.message ?: "Unknown error")
+        } finally {
+            ownedPreparedFiles.forEach { it.file.delete() }
         }
     }
+
+    private fun AnkiScreenshotPreparation.withStillFallback(
+        fallback: AnkiMediaSource.Bytes?,
+    ): AnkiScreenshotPreparation =
+        when (this) {
+            is AnkiScreenshotPreparation.Animated -> {
+                if (stillFallback == null && fallback != null) copy(stillFallback = fallback) else this
+            }
+            is AnkiScreenshotPreparation.Failed -> {
+                if (stillFallback == null && fallback != null) copy(stillFallback = fallback) else this
+            }
+            else -> this
+        }
+
+    private suspend fun prepareWordAudio(result: LookupResult): AnkiMediaSource.Bytes? {
+        return try {
+            val wordAudioService = Injekt.get<WordAudioService>()
+            val bestAudio = wordAudioService
+                .findWordAudio(result.term.expression, result.term.reading)
+                .firstOrNull()
+                ?: return null
+            val audioData = if (bestAudio.url.startsWith("chimahon-local://")) {
+                val uri = android.net.Uri.parse(bestAudio.url)
+                val sourceId = uri.host.orEmpty()
+                val filePath = uri.path?.substring(1).orEmpty()
+                wordAudioService.getAudioData(filePath, sourceId)
+            } else {
+                wordAudioService.fetchRemoteAudioData(bestAudio.url)
+            } ?: return null
+            val extension = android.net.Uri.parse(bestAudio.url).lastPathSegment
+                ?.substringAfterLast('.', "mp3")
+                ?.let { AnkiMediaNaming.safeExtension(it, "mp3") }
+                ?: "mp3"
+            val filename =
+                "chimahon_audio_${result.term.expression}_${result.term.reading}_${System.currentTimeMillis()}.$extension"
+            AnkiMediaSource.Bytes(
+                data = audioData,
+                preferredBaseName = filename.substringBeforeLast('.', filename),
+                extension = extension,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            android.util.Log.w(TAG, "addToAnki: failed to prepare word audio", e)
+            null
+        }
+    }
+
+    private suspend fun storeOptionalMedia(
+        bridge: AnkiDroidBridge,
+        source: AnkiMediaSource?,
+        description: String,
+    ): String? {
+        if (source == null) return null
+        return try {
+            bridge.storeMedia(source)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            android.util.Log.w(TAG, "addToAnki: failed to store $description media", e)
+            null
+        }
+    }
+
+    private fun resolveMediaPlaceholders(
+        value: String,
+        screenshotFilename: String?,
+        wordAudioFilename: String?,
+        sentenceAudioFilename: String?,
+    ): String =
+        value
+            .resolveImagePlaceholder(SCREENSHOT_MEDIA_PLACEHOLDER, screenshotFilename)
+            .resolveSoundPlaceholder(WORD_AUDIO_MEDIA_PLACEHOLDER, wordAudioFilename)
+            .resolveSoundPlaceholder(SENTENCE_AUDIO_MEDIA_PLACEHOLDER, sentenceAudioFilename)
+
+    private fun String.resolveImagePlaceholder(placeholder: String, filename: String?): String =
+        if (filename == null) {
+            replace("<img src=\"$placeholder\">", "").replace(placeholder, "")
+        } else {
+            replace(placeholder, filename)
+        }
+
+    private fun String.resolveSoundPlaceholder(placeholder: String, filename: String?): String =
+        if (filename == null) {
+            replace("[sound:$placeholder]", "").replace(placeholder, "")
+        } else {
+            replace(placeholder, filename)
+        }
 
     private fun filterToSingleGlossary(result: LookupResult, glossaryIndex: Int): LookupResult {
         val glossary = result.term.glossaries.getOrNull(glossaryIndex) ?: return result

--- a/chimahon/src/main/java/chimahon/anki/AnkiDroidBridge.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiDroidBridge.kt
@@ -26,6 +26,7 @@ class AnkiDroidBridge(private val context: Context) {
         private const val SYNC_COOLDOWN_MS = 120_000L
         private var lastSyncTimeMs = 0L
 
+        private const val ANKIDROID_PACKAGE = "com.ichi2.anki"
         const val PERMISSION = "com.ichi2.anki.permission.READ_WRITE_DATABASE"
         const val PERMISSION_REQUEST_CODE = 2001
 
@@ -314,6 +315,24 @@ class AnkiDroidBridge(private val context: Context) {
             saveMediaBytes(filename, data)
         }
 
+    suspend fun storeMedia(source: AnkiMediaSource): String =
+        withContext(Dispatchers.IO) {
+            when (source) {
+                is AnkiMediaSource.Bytes -> {
+                    val extension = AnkiMediaNaming.safeExtension(source.extension, "bin")
+                    val baseName = sanitizePreferredBaseName(source.preferredBaseName)
+                    saveMediaBytes("$baseName.$extension", source.data)
+                }
+                is AnkiMediaSource.FileSource -> {
+                    saveMediaFile(
+                        file = source.file,
+                        preferredBaseName = source.preferredBaseName,
+                        extension = source.extension,
+                    )
+                }
+            }
+        }
+
     suspend fun storeMediaFromBase64(filename: String, base64: String): String =
         storeMedia(filename, Base64.decode(base64, Base64.NO_WRAP))
 
@@ -571,34 +590,84 @@ class AnkiDroidBridge(private val context: Context) {
         mediaDir.mkdirs()
 
         val file = File(mediaDir, name)
-        file.writeBytes(data)
+        return try {
+            file.writeBytes(data)
+            saveMediaFile(
+                file = file,
+                preferredBaseName = name.replace(Regex("\\.[^.]*$"), ""),
+                extension = name.substringAfterLast('.', "bin"),
+            )
+        } finally {
+            file.delete()
+        }
+    }
 
+    private fun saveMediaFile(
+        file: File,
+        preferredBaseName: String,
+        extension: String,
+    ): String {
+        require(file.isFile && file.canRead() && file.length() > 0L) {
+            "Media file is not readable"
+        }
+        val safeBaseName = sanitizePreferredBaseName(preferredBaseName)
+        val expectedExtension = AnkiMediaNaming.safeExtension(extension, "bin")
+        require(file.extension.equals(expectedExtension, ignoreCase = true)) {
+            "Media file extension does not match its declared type"
+        }
         val contentUri = FileProvider.getUriForFile(
             context,
             "${context.packageName}.provider",
             file,
         )
+        if (expectedExtension == "avif") {
+            require(context.contentResolver.getType(contentUri).equals("image/avif", ignoreCase = true)) {
+                "FileProvider did not expose the scene as image/avif"
+            }
+        }
 
         context.grantUriPermission(
-            "com.ichi2.anki",
+            ANKIDROID_PACKAGE,
             contentUri,
             Intent.FLAG_GRANT_READ_URI_PERMISSION,
         )
-
-        val mediaCv = ContentValues().apply {
-            put(MEDIA_FILE_URI, contentUri.toString())
-            put(MEDIA_PREFERRED_NAME, name.replace(Regex("\\.[^.]*$"), ""))
+        try {
+            val mediaCv = ContentValues().apply {
+                put(MEDIA_FILE_URI, contentUri.toString())
+                put(MEDIA_PREFERRED_NAME, safeBaseName)
+            }
+            val result = context.contentResolver.insert(MEDIA_URI, mediaCv)
+                ?: throw Exception("AnkiDroid failed to copy the media")
+            val returnedName = result.lastPathSegment
+                ?.takeIf(String::isNotBlank)
+                ?: result.path
+                    ?.let(::File)
+                    ?.name
+                    ?.takeIf(String::isNotBlank)
+                ?: throw Exception("AnkiDroid returned an invalid media name")
+            if (expectedExtension == "avif") {
+                require(returnedName.substringAfterLast('.', "").equals("avif", ignoreCase = true)) {
+                    "AnkiDroid did not return an AVIF media filename"
+                }
+            }
+            return returnedName
+        } finally {
+            runCatching {
+                context.revokeUriPermission(
+                    ANKIDROID_PACKAGE,
+                    contentUri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
         }
-
-        val res = context.contentResolver.insert(MEDIA_URI, mediaCv)
-        file.delete()
-
-        if (res != null) {
-            return File(res.path!!).name
-        }
-
-        throw Exception("AnkiDroid failed to copy the media")
     }
+
+    private fun sanitizePreferredBaseName(value: String): String =
+        value
+            .replace(Regex("[^A-Za-z0-9_-]"), "_")
+            .trim('_')
+            .take(96)
+            .ifBlank { "chimahon_media" }
 
     private fun isNoteInDeck(noteId: Long, deckId: Long): Boolean {
         val noteUri = Uri.withAppendedPath(NOTES_URI, noteId.toString())

--- a/chimahon/src/main/java/chimahon/anki/AnkiMedia.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiMedia.kt
@@ -1,0 +1,182 @@
+package chimahon.anki
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+import java.util.Locale
+
+enum class AnkiScreenshotMode(val storageValue: String) {
+    FULL("full"),
+    CROP("crop"),
+    NONE("no_screenshot"),
+    ANIMATED_SCENE("animated_scene"),
+    ;
+
+    companion object {
+        fun fromStorageValue(value: String): AnkiScreenshotMode =
+            entries.firstOrNull { it.storageValue == value } ?: FULL
+    }
+}
+
+sealed interface AnkiMediaSource {
+    val preferredBaseName: String
+    val extension: String
+
+    data class Bytes(
+        val data: ByteArray,
+        override val preferredBaseName: String,
+        override val extension: String,
+    ) : AnkiMediaSource
+
+    /**
+     * A temporary app-owned file. Once a provider returns it, AnkiCardCreator
+     * deletes it after the card attempt, whether storage succeeds or fails.
+     */
+    data class FileSource(
+        val file: File,
+        override val preferredBaseName: String,
+        override val extension: String,
+    ) : AnkiMediaSource
+}
+
+sealed interface AnkiMediaWarning {
+    data object SceneGenerationFailed : AnkiMediaWarning
+    data object AnimatedStorageFailed : AnkiMediaWarning
+    data object StillStorageFailed : AnkiMediaWarning
+}
+
+sealed interface AnkiScreenshotPreparation {
+    data class Animated(
+        val animation: AnkiMediaSource.FileSource,
+        val stillFallback: AnkiMediaSource.Bytes?,
+    ) : AnkiScreenshotPreparation
+
+    data class Still(
+        val still: AnkiMediaSource.Bytes?,
+    ) : AnkiScreenshotPreparation
+
+    data class Failed(
+        val stillFallback: AnkiMediaSource.Bytes?,
+    ) : AnkiScreenshotPreparation
+}
+
+fun interface LazyAnkiScreenshotProvider {
+    suspend fun prepare(): AnkiScreenshotPreparation
+}
+
+fun interface LazyAnkiMediaProvider {
+    suspend fun prepare(): AnkiMediaSource?
+}
+
+data class AnkiMediaRequest(
+    val screenshotProvider: LazyAnkiScreenshotProvider? = null,
+    val sentenceAudioProvider: LazyAnkiMediaProvider? = null,
+    val onCommitStarted: () -> Unit = {},
+)
+
+internal data class StoredScreenshotMedia(
+    val filename: String?,
+    val warnings: List<AnkiMediaWarning>,
+)
+
+internal class AnkiScreenshotMediaCommitter(
+    private val store: suspend (AnkiMediaSource) -> String,
+) {
+    suspend fun store(preparation: AnkiScreenshotPreparation?): StoredScreenshotMedia =
+        when (preparation) {
+            null -> StoredScreenshotMedia(filename = null, warnings = emptyList())
+
+            is AnkiScreenshotPreparation.Animated -> storeAnimated(preparation)
+            is AnkiScreenshotPreparation.Still -> storeStill(preparation.still, emptyList())
+            is AnkiScreenshotPreparation.Failed -> storeStill(
+                preparation.stillFallback,
+                listOf(AnkiMediaWarning.SceneGenerationFailed),
+            )
+        }
+
+    private suspend fun storeAnimated(
+        preparation: AnkiScreenshotPreparation.Animated,
+    ): StoredScreenshotMedia {
+        return try {
+            require(preparation.animation.extension.equals(AVIF_EXTENSION, ignoreCase = true)) {
+                "Animated scene media must use AVIF"
+            }
+            val filename = store(preparation.animation)
+            require(filename.substringAfterLast('.', "").equals(AVIF_EXTENSION, ignoreCase = true)) {
+                "AnkiDroid did not return an AVIF media filename"
+            }
+            StoredScreenshotMedia(filename = filename, warnings = emptyList())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            storeStill(
+                preparation.stillFallback,
+                listOf(AnkiMediaWarning.AnimatedStorageFailed),
+            )
+        }
+    }
+
+    private suspend fun storeStill(
+        still: AnkiMediaSource.Bytes?,
+        warnings: List<AnkiMediaWarning>,
+    ): StoredScreenshotMedia {
+        if (still == null) {
+            return StoredScreenshotMedia(filename = null, warnings = warnings)
+        }
+        return try {
+            StoredScreenshotMedia(filename = store(still), warnings = warnings)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            StoredScreenshotMedia(
+                filename = null,
+                warnings = warnings + AnkiMediaWarning.StillStorageFailed,
+            )
+        }
+    }
+
+    private companion object {
+        const val AVIF_EXTENSION = "avif"
+    }
+}
+
+object AnkiMediaNaming {
+    suspend fun sceneFileSource(file: File): AnkiMediaSource.FileSource {
+        val digest = sha256(file)
+        return AnkiMediaSource.FileSource(
+            file = file,
+            preferredBaseName = "chimahon_scene_$digest",
+            extension = "avif",
+        )
+    }
+
+    suspend fun sha256(file: File): String = withContext(Dispatchers.IO) {
+        require(file.isFile && file.canRead()) { "Media file is not readable" }
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                currentCoroutineContext().ensureActive()
+                val read = input.read(buffer)
+                if (read < 0) break
+                if (read > 0) digest.update(buffer, 0, read)
+            }
+        }
+        digest.digest().toHex()
+    }
+
+    fun safeExtension(value: String, fallback: String): String =
+        value
+            .substringBefore('?')
+            .substringAfterLast('.', value)
+            .replace(Regex("[^A-Za-z0-9]"), "")
+            .ifBlank { fallback }
+            .lowercase(Locale.ROOT)
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+}

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -196,5 +196,4 @@ class ChapterRepositoryImpl(
         }
     }
     // SY <--
-
 }

--- a/data/src/main/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImpl.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import tachiyomi.data.handlers.anime.AnimeDatabaseHandler
-import tachiyomi.domain.source.anime.model.AnimeSource as DomainSource
 import tachiyomi.domain.source.anime.model.StubAnimeSource
 import tachiyomi.domain.source.anime.repository.AnimeSourcePagingSourceType
 import tachiyomi.domain.source.anime.repository.AnimeSourceRepository
 import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import tachiyomi.domain.source.anime.model.AnimeSource as DomainSource
 
 class AnimeSourceRepositoryImpl(
     private val sourceManager: AnimeSourceManager,

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -251,6 +251,14 @@
     <string name="pref_dictionary_popup_summary">Layout, theme, OCR</string>
     <string name="pref_category_anki">Anki</string>
     <string name="pref_anki_settings_summary">Deck, fields, export</string>
+    <string name="pref_anki_screenshot_animated_scene">Animated scene (AVIF)</string>
+    <string name="anki_scene_preparing">Preparing scene media…</string>
+    <string name="anki_scene_committing">Saving card to AnkiDroid…</string>
+    <string name="anki_scene_busy">A scene card is already being prepared</string>
+    <string name="anki_scene_cancel">Cancel scene export</string>
+    <string name="anki_scene_fallback_generation">The animated scene could not be created. Chimahon used the captured still screenshot when available.</string>
+    <string name="anki_scene_fallback_storage">AnkiDroid could not store the animated scene. Chimahon used the captured still screenshot when available.</string>
+    <string name="anki_scene_still_storage_failed">The screenshot could not be stored. The card was created without it.</string>
     <string name="pref_settings_section_media">Media</string>
     <string name="pref_settings_section_learning">Learning</string>
     <string name="pref_settings_section_sync">Sync</string>


### PR DESCRIPTION
## Summary

- Add animated AVIF scene capture for Anki using the bundled FFmpegKit AVIF muxer and the selected Android `av1_mediacodec` encoder.
- Keep the requested WebP still-image fallback when AV1 hardware encoding, validation, or media storage is unavailable.
- Preserve selected video/audio timing, sentence audio, OCR/subtitle mining, cancellation, cleanup, and Anki media insertion.
- Support local files, SAF URIs, and ordinary public seekable HTTP/HLS inputs. Signed/authenticated, DASH, and non-seekable inputs fail closed to the still fallback.

## Native pipeline

- 8 fps, maximum 640 px, 16-pixel AV1 alignment, at most 80 frames.
- MediaCodec CQ mode at quality 35, `yuv420p`, AVIF muxer, and infinite loop metadata.
- Concrete CQ/Planar-capable AV1 encoder selection via `-codec_name`.
- TLS verification with the existing CA asset, bounded network timeout/protocols, and a decoder allowlist that excludes unsupported decoders.
- Bounded ISO-BMFF/AVIF validation before handing the file to AnkiDroid.

The bundled FFmpeg build does not contain `libaom-av1`, so this deliberately uses its existing native MediaCodec AV1 encoder rather than adding or replacing the FFmpeg package.

## Scope cleanup

- 31 files, +4,089/-279 (down from 85 files and roughly +16k lines).
- All retained tests are under `app/src/test`.
- No license/NOTICE, documentation, added asset, AboutLibraries, release-gate, or dependency changes.
- No animated WebP pipeline remains.

## Validation

CI is the merge gate for this rewrite. The PR stays draft until real-device checks cover MediaCodec AVIF encoding, SAF input, public HLS/TLS, output quality/time/size, and animated AVIF playback in AnkiDroid on a low-end device.