### PR TITLE
Add OCR source selection to the reader

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.reader.components.ChapterNavigator
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderOcrSource
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.Viewer
@@ -104,7 +105,9 @@ fun ReaderAppBars(
     // Chimahon -->
     ocrEnabled: Boolean = false,
     ocrLoading: Boolean = false,
+    ocrSource: ReaderOcrSource = ReaderOcrSource.AUTOMATIC,
     onToggleOcr: (() -> Unit)? = null,
+    onSelectOcrSource: (ReaderOcrSource) -> Unit = {},
     // Chimahon <--
 ) {
     val isRtl = viewer is R2LPagerViewer
@@ -140,7 +143,9 @@ fun ReaderAppBars(
                     // Chimahon -->
                     ocrEnabled = ocrEnabled,
                     ocrLoading = ocrLoading,
+                    ocrSource = ocrSource,
                     onToggleOcr = onToggleOcr,
+                    onSelectOcrSource = onSelectOcrSource,
                     // Chimahon <--
                 )
                 // SY -->

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderTopBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderTopBar.kt
@@ -1,17 +1,37 @@
 package eu.kanade.presentation.reader.appbars
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults.rememberTooltipPositionProvider
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderOcrSource
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.TextButton
 import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
@@ -27,7 +47,9 @@ fun ReaderTopBar(
     modifier: Modifier = Modifier,
     ocrEnabled: Boolean = false,
     ocrLoading: Boolean = false,
+    ocrSource: ReaderOcrSource = ReaderOcrSource.AUTOMATIC,
     onToggleOcr: (() -> Unit)? = null,
+    onSelectOcrSource: (ReaderOcrSource) -> Unit = {},
 ) {
     AppBar(
         modifier = modifier,
@@ -36,32 +58,18 @@ fun ReaderTopBar(
         subtitle = chapterTitle,
         navigateUp = navigateUp,
         actions = {
+            onToggleOcr?.let {
+                OcrSourceAction(
+                    enabled = ocrEnabled || !ocrLoading,
+                    ocrEnabled = ocrEnabled,
+                    selectedSource = ocrSource,
+                    onToggleOcr = it,
+                    onSelectSource = onSelectOcrSource,
+                )
+            }
             AppBarActions(
                 actions = persistentListOf<AppBar.AppBarAction>().builder()
                     .apply {
-                        // OCR toggle button
-                        onToggleOcr?.let {
-                            add(
-                                AppBar.Action(
-                                    title = stringResource(
-                                        if (ocrEnabled) {
-                                            MR.strings.action_disable_ocr
-                                        } else {
-                                            MR.strings.action_enable_ocr
-                                        },
-                                    ),
-                                    icon = Icons.Outlined.Search,
-                                    text = "OCR",
-                                    iconTint = if (ocrEnabled) {
-                                        MaterialTheme.colorScheme.primary
-                                    } else {
-                                        null
-                                    },
-                                    onClick = it,
-                                    enabled = ocrEnabled || !ocrLoading,
-                                ),
-                            )
-                        }
                         add(
                             AppBar.Action(
                                 title = stringResource(
@@ -106,6 +114,88 @@ fun ReaderTopBar(
                     }
                     .build(),
             )
+        },
+    )
+}
+
+@Composable
+private fun OcrSourceAction(
+    enabled: Boolean,
+    ocrEnabled: Boolean,
+    selectedSource: ReaderOcrSource,
+    onToggleOcr: () -> Unit,
+    onSelectSource: (ReaderOcrSource) -> Unit,
+) {
+    var sourceMenuExpanded by remember { mutableStateOf(false) }
+    val actionTitle = stringResource(
+        if (ocrEnabled) {
+            MR.strings.action_disable_ocr
+        } else {
+            MR.strings.action_enable_ocr
+        },
+    )
+
+    TooltipBox(
+        positionProvider = rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+        tooltip = {
+            PlainTooltip {
+                Text(actionTitle)
+            }
+        },
+        state = rememberTooltipState(),
+        focusable = false,
+    ) {
+        Box {
+            TextButton(
+                onClick = onToggleOcr,
+                onLongClick = { sourceMenuExpanded = true },
+                enabled = enabled,
+            ) {
+                Text(
+                    text = stringResource(MR.strings.action_ocr),
+                    color = if (ocrEnabled) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        LocalContentColor.current
+                    },
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
+            DropdownMenu(
+                expanded = sourceMenuExpanded,
+                onDismissRequest = { sourceMenuExpanded = false },
+            ) {
+                ReaderOcrSource.availableSources(BuildConfig.HAS_LOCAL_OCR).forEach { source ->
+                    DropdownMenuItem(
+                        text = { Text(source.displayName()) },
+                        onClick = {
+                            sourceMenuExpanded = false
+                            onSelectSource(source)
+                        },
+                        trailingIcon = {
+                            if (source == selectedSource) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Check,
+                                    contentDescription = null,
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReaderOcrSource.displayName(): String {
+    return stringResource(
+        when (this) {
+            ReaderOcrSource.AUTOMATIC -> KMR.strings.ocr_source_automatic
+            ReaderOcrSource.MOKURO -> KMR.strings.ocr_source_mokuro
+            ReaderOcrSource.GOOGLE_LENS -> KMR.strings.ocr_source_google_lens
+            ReaderOcrSource.LOCAL -> KMR.strings.ocr_source_local
         },
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrEngineSelector.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrEngineSelector.kt
@@ -13,14 +13,27 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.ByteArrayOutputStream
 
+enum class OcrEngineType {
+    CLOUD,
+    LOCAL,
+    ;
+
+    companion object {
+        fun fromPreference(value: String): OcrEngineType {
+            return if (value == "local") LOCAL else CLOUD
+        }
+    }
+}
+
 suspend fun recognizePage(
     bytes: ByteArray,
     language: OcrLanguage,
+    engineType: OcrEngineType? = null,
 ): List<OcrResult> {
     val dictPrefs = Injekt.get<eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences>()
-    val engineType = dictPrefs.ocrEngine().get()
+    val resolvedEngineType = engineType ?: OcrEngineType.fromPreference(dictPrefs.ocrEngine().get())
 
-    if (engineType == "local") {
+    if (resolvedEngineType == OcrEngineType.LOCAL) {
         val localOcrBridge = Injekt.get<LocalOcrBridge>()
         val modelDownloader = Injekt.get<ModelDownloader>()
         if (!modelDownloader.isDownloaded) {
@@ -59,11 +72,12 @@ suspend fun recognizePage(
 suspend fun recognizePage(
     bitmap: Bitmap,
     language: OcrLanguage,
+    engineType: OcrEngineType? = null,
 ): List<OcrResult> {
     val dictPrefs = Injekt.get<eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences>()
-    val engineType = dictPrefs.ocrEngine().get()
+    val resolvedEngineType = engineType ?: OcrEngineType.fromPreference(dictPrefs.ocrEngine().get())
 
-    if (engineType == "local") {
+    if (resolvedEngineType == OcrEngineType.LOCAL) {
         val localOcrBridge = Injekt.get<LocalOcrBridge>()
         val modelDownloader = Injekt.get<ModelDownloader>()
         if (!modelDownloader.isDownloaded) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -135,6 +135,7 @@ import tachiyomi.core.common.util.lang.withUIContext
 import logcat.logcat
 import logcat.LogPriority
 import eu.kanade.presentation.reader.stats.MangaStatsSheet
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderOcrSource
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
@@ -1232,6 +1233,21 @@ class ReaderActivity : BaseActivity() {
         )
     }
 
+    private fun selectOcrSourceFromReader(source: ReaderOcrSource) {
+        if (!viewModel.setOcrSource(source) || !viewModel.isOcrEnabled()) return
+
+        when (val viewer = viewModel.state.value.viewer) {
+            is PagerViewer -> {
+                viewer.setOcrEnabled(false)
+                viewer.setOcrEnabled(true)
+            }
+            is WebtoonViewer -> {
+                viewer.setOcrEnabled(false)
+                viewer.setOcrEnabled(true)
+            }
+        }
+    }
+
     /**
      * Called when the user clicks the back key or the button on the toolbar. The call is
      * delegated to the presenter.
@@ -1474,7 +1490,9 @@ class ReaderActivity : BaseActivity() {
             },
             ocrEnabled = ocrEnabled,
             ocrLoading = state.ocrScanProgress != null,
+            ocrSource = state.ocrSource,
             onToggleOcr = ::toggleOcrFromReader,
+            onSelectOcrSource = ::selectOcrSourceFromReader,
             onClickSettings = viewModel::openSettingsDialog,
             onClickMangaStats = viewModel::openMangaStatsSheet,
             // SY -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -49,6 +49,7 @@ import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderOcrSource
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
@@ -187,6 +188,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private data class OcrCacheKey(
         val chapterId: Long,
         val pageIndex: Int,
+        val ocrSource: ReaderOcrSource,
     )
 
     private data class MokuroChapterData(
@@ -547,6 +549,7 @@ class ReaderViewModel @JvmOverloads constructor(
                     mutableState.update {
                         it.copy(
                             manga = manga,
+                            ocrSource = readerPreferences.ocrSource(manga.id).get(),
                             // SY -->
                             meta = metadata,
                             mergedManga = mergedManga,
@@ -1301,6 +1304,17 @@ class ReaderViewModel @JvmOverloads constructor(
 
     fun getOcrBoxOpacity(): Float = dictionaryPreferences.ocrBoxOpacity().get()
 
+    fun setOcrSource(source: ReaderOcrSource): Boolean {
+        val manga = manga ?: return false
+        if (state.value.ocrSource == source) return false
+
+        readerPreferences.ocrSource(manga.id).set(source)
+        cancelOcrScan()
+        ocrScannedChapterIds.clear()
+        mutableState.update { it.copy(ocrSource = source) }
+        return true
+    }
+
     fun toggleOcrEnabled(): Boolean {
         val pref = readerPreferences.ocrOverlayEnabled()
         val enabled = !pref.get()
@@ -1688,9 +1702,11 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     suspend fun getOcrBlocks(page: ReaderPage): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock> {
         val chapterId = page.chapter.chapter.id ?: return emptyList()
+        val ocrSource = state.value.ocrSource
         val cacheKey = OcrCacheKey(
             chapterId = chapterId,
             pageIndex = page.index,
+            ocrSource = ocrSource,
         )
 
         ocrCacheMutex.withLock {
@@ -1699,8 +1715,10 @@ class ReaderViewModel @JvmOverloads constructor(
             }
         }
 
-        loadCachedOcrBlocks(page)?.let { cached ->
-            return cached
+        if (ocrSource.usesPersistentCache) {
+            loadCachedOcrBlocks(page, ocrSource)?.let { cached ->
+                return cached
+            }
         }
 
         val deferred = ocrCacheMutex.withLock {
@@ -1712,7 +1730,7 @@ class ReaderViewModel @JvmOverloads constructor(
                     return@async emptyList()
                 }
 
-                fetchOcrBlocks(page)
+                fetchOcrBlocks(page, ocrSource)
             }.also { created ->
                 ocrInFlight[cacheKey] = created
             }
@@ -1731,23 +1749,31 @@ class ReaderViewModel @JvmOverloads constructor(
 
     suspend fun getCachedOcrBlocks(page: ReaderPage): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock> {
         val chapterId = page.chapter.chapter.id ?: return emptyList()
-        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index)
+        val ocrSource = state.value.ocrSource
+        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index, ocrSource = ocrSource)
 
         ocrCacheMutex.withLock {
             ocrCache[cacheKey]?.let { return it }
         }
 
-        return loadCachedOcrBlocks(page).orEmpty()
+        return if (ocrSource.usesPersistentCache) {
+            loadCachedOcrBlocks(page, ocrSource).orEmpty()
+        } else {
+            emptyList()
+        }
     }
 
-    private suspend fun loadCachedOcrBlocks(page: ReaderPage): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock>? {
+    private suspend fun loadCachedOcrBlocks(
+        page: ReaderPage,
+        ocrSource: ReaderOcrSource,
+    ): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock>? {
         val domainChapter = page.chapter.chapter.toDomainChapter() ?: return null
         val chapterId = domainChapter.id ?: return null
         val manga = state.value.manga ?: return null
-        val source = sourceManager.getOrStub(manga.source)
-        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index)
+        val mangaSource = sourceManager.getOrStub(manga.source)
+        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index, ocrSource = ocrSource)
 
-        val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, source, page.index)
+        val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, mangaSource, page.index)
             ?.takeIf { it.isNotEmpty() }
             ?.map { it.toViewerBlock() }
             ?: return null
@@ -1943,7 +1969,7 @@ class ReaderViewModel @JvmOverloads constructor(
 
         val endPage = minOf(startPage + count, totalPages)
         for (pageIndex in startPage until endPage) {
-            val cacheKey = OcrCacheKey(chapterId, pageIndex)
+            val cacheKey = OcrCacheKey(chapterId, pageIndex, ReaderOcrSource.AUTOMATIC)
             ocrCacheMutex.withLock {
                 if (ocrCache.containsKey(cacheKey)) return@withLock
             }
@@ -2195,13 +2221,16 @@ class ReaderViewModel @JvmOverloads constructor(
         return ext in setOf("jpg", "jpeg", "png", "webp", "gif", "bmp", "avif", "heif", "heic", "jxl")
     }
 
-    private suspend fun fetchOcrBlocks(page: ReaderPage): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock> {
+    private suspend fun fetchOcrBlocks(
+        page: ReaderPage,
+        ocrSource: ReaderOcrSource,
+    ): List<eu.kanade.tachiyomi.ui.reader.viewer.OcrTextBlock> {
         if (!isOcrEnabled()) return emptyList()
         val startMs = SystemClock.elapsedRealtime()
         val dbChapter = page.chapter.chapter
         val domainChapter = dbChapter.toDomainChapter() ?: return emptyList()
         val chapterId = domainChapter.id ?: return emptyList()
-        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index)
+        val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index, ocrSource = ocrSource)
 
         val manga = state.value.manga ?: return emptyList()
         val source = sourceManager.getOrStub(manga.source)
@@ -2218,14 +2247,17 @@ class ReaderViewModel @JvmOverloads constructor(
         }
 
         if (
-            source.isLocal() ||
-            downloadProvider.findChapterDir(
-                domainChapter.name,
-                domainChapter.scanlator,
-                domainChapter.url,
-                manga.ogTitle,
-                source,
-            ) != null
+            ocrSource.usesMokuro &&
+            (
+                source.isLocal() ||
+                    downloadProvider.findChapterDir(
+                        domainChapter.name,
+                        domainChapter.scanlator,
+                        domainChapter.url,
+                        manga.ogTitle,
+                        source,
+                    ) != null
+                )
         ) {
             tryLoadMokuroBlocks(manga, domainChapter, source, page.index)?.let { rawBlocks ->
                 val blocks = rawBlocks.map { it.copy(language = ocrLang.bcp47) }
@@ -2233,7 +2265,8 @@ class ReaderViewModel @JvmOverloads constructor(
                     ocrCache[cacheKey] = blocks
                     trimOcrCacheLocked()
                 }
-                ocrCacheManager.saveOcrBlocks(
+                savePersistentOcrBlocks(
+                    ocrSource = ocrSource,
                     manga = manga,
                     chapter = domainChapter,
                     source = source,
@@ -2257,7 +2290,7 @@ class ReaderViewModel @JvmOverloads constructor(
                 val elapsedMs = SystemClock.elapsedRealtime() - startMs
                 logcat { "OCR mokuro path: chapter=${page.chapter.chapter.id} page=${page.index} blocks=${blocks.size} time=${elapsedMs}ms" }
 
-                if (page.index < 3) {
+                if (ocrSource == ReaderOcrSource.AUTOMATIC && page.index < 3) {
                     val totalPages = page.chapter.pages?.size ?: 0
                     if (totalPages > 0) {
                         viewModelScope.launchIO {
@@ -2270,7 +2303,11 @@ class ReaderViewModel @JvmOverloads constructor(
             }
         }
 
-        val mokuroUrl = buildMokuroExtensionUrl(manga, domainChapter, source)
+        val mokuroUrl = if (ocrSource.usesMokuro) {
+            buildMokuroExtensionUrl(manga, domainChapter, source)
+        } else {
+            null
+        }
         if (mokuroUrl != null) {
             tryLoadMokuroFromUrl(mokuroUrl, manga, domainChapter, source, page.index, page.chapter.pages?.size ?: 0)?.let { rawBlocks ->
                 val mokuroLang = chimahon.ocr.OcrLanguage.JAPANESE.bcp47
@@ -2282,7 +2319,8 @@ class ReaderViewModel @JvmOverloads constructor(
                         ocrCache.remove(firstKey)
                     }
                 }
-                ocrCacheManager.saveOcrBlocks(
+                savePersistentOcrBlocks(
+                    ocrSource = ocrSource,
                     manga = manga,
                     chapter = domainChapter,
                     source = source,
@@ -2309,14 +2347,18 @@ class ReaderViewModel @JvmOverloads constructor(
             }
         }
 
-        val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, source, page.index)
-        if (diskBlocks != null && diskBlocks.isNotEmpty()) {
-            ocrCacheMutex.withLock {
-                ocrCache[cacheKey] = diskBlocks.map { it.toViewerBlock() }
-                trimOcrCacheLocked()
+        if (ocrSource == ReaderOcrSource.MOKURO) return emptyList()
+
+        if (ocrSource.usesPersistentCache) {
+            val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, source, page.index)
+            if (diskBlocks != null && diskBlocks.isNotEmpty()) {
+                ocrCacheMutex.withLock {
+                    ocrCache[cacheKey] = diskBlocks.map { it.toViewerBlock() }
+                    trimOcrCacheLocked()
+                }
+                logcat { "OCR disk hit: chapter=$chapterId page=${page.index} blocks=${diskBlocks.size}" }
+                return diskBlocks.map { it.toViewerBlock() }
             }
-            logcat { "OCR disk hit: chapter=$chapterId page=${page.index} blocks=${diskBlocks.size}" }
-            return diskBlocks.map { it.toViewerBlock() }
         }
 
         return try {
@@ -2353,6 +2395,7 @@ class ReaderViewModel @JvmOverloads constructor(
                 eu.kanade.tachiyomi.data.ocr.recognizePage(
                     bytes = ocrBytes,
                     language = ocrLang,
+                    engineType = ocrSource.recognitionEngine,
                 )
             }
 
@@ -2401,7 +2444,8 @@ class ReaderViewModel @JvmOverloads constructor(
                 blocks
             }
 
-            ocrCacheManager.saveOcrBlocks(
+            savePersistentOcrBlocks(
+                ocrSource = ocrSource,
                 manga = manga,
                 chapter = domainChapter,
                 source = source,
@@ -2448,6 +2492,19 @@ class ReaderViewModel @JvmOverloads constructor(
         }
     }
 
+    private suspend fun savePersistentOcrBlocks(
+        ocrSource: ReaderOcrSource,
+        manga: Manga,
+        chapter: Chapter,
+        source: Source,
+        pageIndex: Int,
+        blocks: List<chimahon.ocr.OcrTextBlock>,
+        language: String,
+    ) {
+        if (!ocrSource.usesPersistentCache) return
+        ocrCacheManager.saveOcrBlocks(manga, chapter, source, pageIndex, blocks, language)
+    }
+
     private fun trimOcrCacheLocked() {
         while (ocrCache.size > maxOcrCacheEntries) {
             val firstKey = ocrCache.keys.firstOrNull() ?: break
@@ -2478,6 +2535,7 @@ class ReaderViewModel @JvmOverloads constructor(
         val menuVisible: Boolean = false,
         @field:IntRange(from = -100, to = 100) val brightnessOverlayValue: Int = 0,
         val ocrScanProgress: OcrScanProgress? = null,
+        val ocrSource: ReaderOcrSource = ReaderOcrSource.AUTOMATIC,
 
         // SY -->
         /** for display page number in double-page mode */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSource.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.ui.reader.setting
+
+import eu.kanade.tachiyomi.data.ocr.OcrEngineType
+
+enum class ReaderOcrSource(
+    val usesMokuro: Boolean,
+    val usesPersistentCache: Boolean,
+    val recognitionEngine: OcrEngineType?,
+) {
+    AUTOMATIC(
+        usesMokuro = true,
+        usesPersistentCache = true,
+        recognitionEngine = null,
+    ),
+    MOKURO(
+        usesMokuro = true,
+        usesPersistentCache = false,
+        recognitionEngine = null,
+    ),
+    GOOGLE_LENS(
+        usesMokuro = false,
+        usesPersistentCache = false,
+        recognitionEngine = OcrEngineType.CLOUD,
+    ),
+    LOCAL(
+        usesMokuro = false,
+        usesPersistentCache = false,
+        recognitionEngine = OcrEngineType.LOCAL,
+    ),
+    ;
+
+    companion object {
+        fun availableSources(localOcrAvailable: Boolean): List<ReaderOcrSource> {
+            return entries.filter { localOcrAvailable || it != LOCAL }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.BlendMode
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerConfig
+import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
 import tachiyomi.i18n.MR
@@ -108,6 +109,11 @@ class ReaderPreferences(
 
     // Chimahon -->
     fun ocrOverlayEnabled() = preferenceStore.getBoolean("reader_ocr_overlay_enabled", false)
+
+    fun ocrSource(mangaId: Long) = preferenceStore.getEnum(
+        readerOcrSourcePreferenceKey(mangaId),
+        ReaderOcrSource.AUTOMATIC,
+    )
 
     fun ocrOutlineVisible() = preferenceStore.getBoolean("reader_ocr_outline_visible", false)
 
@@ -353,4 +359,8 @@ class ReaderPreferences(
         )
         // SY <--
     }
+}
+
+internal fun readerOcrSourcePreferenceKey(mangaId: Long): String {
+    return Preference.appStateKey("reader_ocr_source_$mangaId")
 }

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/data/ocr/OcrEngineTypeTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/data/ocr/OcrEngineTypeTest.kt
@@ -1,0 +1,18 @@
+package eu.kanade.tachiyomi.data.ocr
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OcrEngineTypeTest {
+
+    @Test
+    fun `local preference selects local OCR`() {
+        assertEquals(OcrEngineType.LOCAL, OcrEngineType.fromPreference("local"))
+    }
+
+    @Test
+    fun `other preferences select Google Lens`() {
+        assertEquals(OcrEngineType.CLOUD, OcrEngineType.fromPreference("cloud"))
+        assertEquals(OcrEngineType.CLOUD, OcrEngineType.fromPreference("unexpected"))
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSourceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSourceTest.kt
@@ -1,0 +1,53 @@
+package eu.kanade.tachiyomi.ui.reader.setting
+
+import eu.kanade.tachiyomi.data.ocr.OcrEngineType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+
+class ReaderOcrSourceTest {
+
+    @Test
+    fun `automatic preserves the existing OCR pipeline`() {
+        val source = ReaderOcrSource.AUTOMATIC
+
+        assertTrue(source.usesMokuro)
+        assertTrue(source.usesPersistentCache)
+        assertNull(source.recognitionEngine)
+    }
+
+    @Test
+    fun `explicit sources have strict policies`() {
+        assertTrue(ReaderOcrSource.MOKURO.usesMokuro)
+        assertFalse(ReaderOcrSource.MOKURO.usesPersistentCache)
+        assertNull(ReaderOcrSource.MOKURO.recognitionEngine)
+
+        assertFalse(ReaderOcrSource.GOOGLE_LENS.usesMokuro)
+        assertFalse(ReaderOcrSource.GOOGLE_LENS.usesPersistentCache)
+        assertEquals(OcrEngineType.CLOUD, ReaderOcrSource.GOOGLE_LENS.recognitionEngine)
+
+        assertFalse(ReaderOcrSource.LOCAL.usesMokuro)
+        assertFalse(ReaderOcrSource.LOCAL.usesPersistentCache)
+        assertEquals(OcrEngineType.LOCAL, ReaderOcrSource.LOCAL.recognitionEngine)
+    }
+
+    @Test
+    fun `local source is only offered when available`() {
+        assertEquals(ReaderOcrSource.entries, ReaderOcrSource.availableSources(localOcrAvailable = true))
+        assertFalse(ReaderOcrSource.LOCAL in ReaderOcrSource.availableSources(localOcrAvailable = false))
+    }
+
+    @Test
+    fun `preference key is app state scoped per manga`() {
+        val firstMangaKey = readerOcrSourcePreferenceKey(1)
+        val secondMangaKey = readerOcrSourcePreferenceKey(2)
+
+        assertNotEquals(firstMangaKey, secondMangaKey)
+        assertTrue(Preference.isAppState(firstMangaKey))
+        assertTrue(Preference.isAppState(secondMangaKey))
+    }
+}

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -260,4 +260,8 @@
     <string name="pref_dict_content">Content</string>
     <string name="pref_dict_active_profile">Active profile</string>
     <string name="pref_dict_profile_language">Language</string>
+    <string name="ocr_source_automatic">Automatic</string>
+    <string name="ocr_source_mokuro">Mokuro</string>
+    <string name="ocr_source_google_lens">Google Lens</string>
+    <string name="ocr_source_local">Local</string>
 </resources>


### PR DESCRIPTION
## Summary

- open an OCR source menu by long-pressing the reader OCR action
- offer Automatic, Mokuro, Google Lens, and Local when local OCR is available
- remember the selection per manga and refresh visible pages when it changes
- preserve the existing pipeline for Automatic while keeping explicit source selections strict

## Verification

- `./gradlew testReleaseUnitTest`
- `./gradlew assembleDebug`
- `./gradlew :i18n-kmk:spotlessCheck`

The repository-wide `spotlessCheck` currently fails on unchanged upstream formatting: 141 app files and two `presentation-widget` constant names. Formatting changes outside this PR were reverted.