### PR TITLE
feat(sync): add Extensions from Sync section

### DIFF
--- a/app/src/main/java/eu/kanade/domain/animeextension/interactor/GetAnimeExtensionsByType.kt
+++ b/app/src/main/java/eu/kanade/domain/animeextension/interactor/GetAnimeExtensionsByType.kt
@@ -6,6 +6,9 @@ import eu.kanade.tachiyomi.animeextension.AnimeExtensionManager
 import eu.kanade.tachiyomi.animeextension.model.AnimeExtension
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import mihon.feature.extension.sync.SyncExtensionCandidate
+import mihon.feature.extension.sync.SyncExtensionIdentity
+import mihon.feature.extension.sync.matchRememberedExtensions
 
 class GetAnimeExtensionsByType(
     private val preferences: SourcePreferences,
@@ -20,7 +23,10 @@ class GetAnimeExtensionsByType(
             animeExtensionManager.installedExtensionsFlow,
             animeExtensionManager.untrustedExtensionsFlow,
             animeExtensionManager.availableExtensionsFlow,
-        ) { enabledLanguages, _installed, _untrusted, _available ->
+            // Chimahon -->
+            preferences.rememberedAnimeExtensions().changes(),
+            // Chimahon <--
+        ) { enabledLanguages, _installed, _untrusted, _available, _remembered ->
             val (updates, installed) = _installed
                 .filter { (showNsfwSources || !it.isNsfw) }
                 .sortedWith(
@@ -32,9 +38,34 @@ class GetAnimeExtensionsByType(
             val untrusted = _untrusted
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
 
+            // Chimahon -->
+            // Packages remembered from sync and installable from this device's catalog.
+            val fromSyncPkgNames = matchRememberedExtensions(
+                remembered = _remembered.mapNotNullTo(mutableSetOf(), SyncExtensionIdentity::decode),
+                candidates = _available.map { extension ->
+                    SyncExtensionCandidate(
+                        pkgName = extension.pkgName,
+                        signatureHash = extension.signatureHash,
+                        isNsfw = extension.isNsfw,
+                        languages = extension.sources.map { it.lang }.toSet()
+                            .ifEmpty { setOf(extension.lang) },
+                    )
+                },
+                installedPkgNames = _installed.mapTo(mutableSetOf()) { it.pkgName },
+                showNsfw = showNsfwSources,
+                enabledLanguages = enabledLanguages,
+            )
+            val fromSync = _available
+                .filter { it.pkgName in fromSyncPkgNames }
+                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+            // Chimahon <--
+
             val available = _available
                 .filter { extension ->
-                    _installed.none { it.pkgName == extension.pkgName } &&
+                    // Chimahon --> matched entries are shown in the "Extensions from Sync" section instead
+                    extension.pkgName !in fromSyncPkgNames &&
+                        // Chimahon <--
+                        _installed.none { it.pkgName == extension.pkgName } &&
                         _untrusted.none { it.pkgName == extension.pkgName } &&
                         (showNsfwSources || !extension.isNsfw)
                 }
@@ -54,7 +85,7 @@ class GetAnimeExtensionsByType(
                 }
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
 
-            AnimeExtensions(updates, installed, available, untrusted)
+            AnimeExtensions(updates, installed, available, untrusted, /* Chimahon */ fromSync)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/animeextension/model/AnimeExtensions.kt
+++ b/app/src/main/java/eu/kanade/domain/animeextension/model/AnimeExtensions.kt
@@ -7,4 +7,8 @@ data class AnimeExtensions(
     val installed: List<AnimeExtension.Installed>,
     val available: List<AnimeExtension.Available>,
     val untrusted: List<AnimeExtension.Untrusted>,
+    // Chimahon -->
+    /** Remembered-from-sync anime extensions available in this device's catalog, one per package. */
+    val fromSync: List<AnimeExtension.Available> = emptyList(),
+    // Chimahon <--
 )

--- a/app/src/main/java/eu/kanade/domain/extension/interactor/GetExtensionsByType.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/interactor/GetExtensionsByType.kt
@@ -6,6 +6,9 @@ import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.extension.model.Extension
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import mihon.feature.extension.sync.SyncExtensionCandidate
+import mihon.feature.extension.sync.SyncExtensionIdentity
+import mihon.feature.extension.sync.matchRememberedExtensions
 
 class GetExtensionsByType(
     private val preferences: SourcePreferences,
@@ -20,7 +23,10 @@ class GetExtensionsByType(
             extensionManager.installedExtensionsFlow,
             extensionManager.untrustedExtensionsFlow,
             extensionManager.availableExtensionsFlow,
-        ) { enabledLanguages, _installed, _untrusted, _available ->
+            // Chimahon -->
+            preferences.rememberedMangaExtensions().changes(),
+            // Chimahon <--
+        ) { enabledLanguages, _installed, _untrusted, _available, _remembered ->
             val (updates, installed) = _installed
                 .filter { (showNsfwSources || !it.isNsfw) }
                 .sortedWith(
@@ -33,14 +39,38 @@ class GetExtensionsByType(
             val untrusted = _untrusted
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
 
+            // Chimahon -->
+            // Packages remembered from sync and installable from this device's catalog.
+            val fromSyncPkgNames = matchRememberedExtensions(
+                remembered = _remembered.mapNotNullTo(mutableSetOf(), SyncExtensionIdentity::decode),
+                candidates = _available.map { extension ->
+                    SyncExtensionCandidate(
+                        pkgName = extension.pkgName,
+                        signatureHash = extension.signatureHash,
+                        isNsfw = extension.isNsfw,
+                        languages = extension.sources.mapTo(mutableSetOf()) { it.lang },
+                    )
+                },
+                installedPkgNames = _installed.mapTo(mutableSetOf()) { it.pkgName },
+                showNsfw = showNsfwSources,
+                enabledLanguages = enabledLanguages,
+            )
+            val fromSync = _available
+                .filter { it.pkgName in fromSyncPkgNames }
+                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+            // Chimahon <--
+
             val available = _available
                 .filter { extension ->
-                    _installed.none {
-                        // KMK -->
-                        it.signatureHash == extension.signatureHash &&
-                            // KMK <--
-                            it.pkgName == extension.pkgName
-                    } &&
+                    // Chimahon --> matched entries are shown in the "Extensions from Sync" section instead
+                    extension.pkgName !in fromSyncPkgNames &&
+                        // Chimahon <--
+                        _installed.none {
+                            // KMK -->
+                            it.signatureHash == extension.signatureHash &&
+                                // KMK <--
+                                it.pkgName == extension.pkgName
+                        } &&
                         _untrusted.none {
                             // KMK -->
                             it.signatureHash == extension.signatureHash &&
@@ -62,7 +92,7 @@ class GetExtensionsByType(
                 }
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
 
-            Extensions(updates, installed, available, untrusted)
+            Extensions(updates, installed, available, untrusted, /* Chimahon */ fromSync)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/extension/model/Extensions.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/model/Extensions.kt
@@ -7,4 +7,8 @@ data class Extensions(
     val installed: List<Extension.Installed>,
     val available: List<Extension.Available>,
     val untrusted: List<Extension.Untrusted>,
+    // Chimahon -->
+    /** Remembered-from-sync extensions available in this device's catalog, one entry per package. */
+    val fromSync: List<Extension.Available> = emptyList(),
+    // Chimahon <--
 )

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -79,6 +79,26 @@ class SourcePreferences(
         emptySet(),
     )
 
+    // Chimahon -->
+    /**
+     * Cumulative history of manga extension identities (encoded as "pkgName|signatureHash") that
+     * this device has installed or seen via sync. Powers the "Extensions from Sync" section.
+     * Stored as app-state so it is never included in preference backups/restores.
+     */
+    fun rememberedMangaExtensions() = preferenceStore.getStringSet(
+        Preference.appStateKey("remembered_manga_extensions"),
+        emptySet(),
+    )
+
+    /**
+     * Cumulative history of anime extension identities. See [rememberedMangaExtensions].
+     */
+    fun rememberedAnimeExtensions() = preferenceStore.getStringSet(
+        Preference.appStateKey("remembered_anime_extensions"),
+        emptySet(),
+    )
+    // Chimahon <--
+
     fun globalSearchFilterState() = preferenceStore.getBoolean(
         Preference.appStateKey("has_filters_toggle_state"),
         false,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/Backup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/Backup.kt
@@ -60,5 +60,8 @@ data class Backup(
     @ProtoNumber(701) var backupNovelCategories: List<BackupNovelCategory> = emptyList(),
     @ProtoNumber(710) var backupMangaStats: List<com.canopus.chimareader.data.MangaStats> = emptyList(),
     @ProtoNumber(711) var backupAnkiStats: List<com.canopus.chimareader.data.AnkiStats> = emptyList(),
+    // Remembered extension identities for the "Extensions from Sync" feature (package id + signing hash only)
+    @ProtoNumber(720) var backupMangaExtensions: List<BackupExtension> = emptyList(),
+    @ProtoNumber(721) var backupAnimeExtensions: List<BackupExtension> = emptyList(),
     // Chimahon <--
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupExtension.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupExtension.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.data.backup.models
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+// Chimahon -->
+/**
+ * A lightweight, backward-compatible identity for a manga or anime extension used by the
+ * "Extensions from Sync" feature.
+ *
+ * Only the package id and signing hash are remembered so devices can recognise an extension
+ * they previously had without syncing APKs, download URLs, or repositories. The display name is
+ * intentionally omitted: matches are rendered using the current device's catalog name.
+ */
+@Serializable
+data class BackupExtension(
+    @ProtoNumber(1) val pkgName: String = "",
+    @ProtoNumber(2) val signatureHash: String = "",
+)
+// Chimahon <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -2,7 +2,9 @@ package eu.kanade.tachiyomi.data.sync
 
 import android.content.Context
 import android.net.Uri
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.animeextension.AnimeExtensionManager
 import eu.kanade.tachiyomi.data.backup.create.BackupCreator
 import eu.kanade.tachiyomi.data.backup.create.BackupOptions
 import eu.kanade.tachiyomi.data.backup.models.Backup
@@ -15,10 +17,14 @@ import eu.kanade.tachiyomi.data.sync.service.GoogleDriveSyncService
 import eu.kanade.tachiyomi.data.sync.service.SyncData
 import eu.kanade.tachiyomi.data.sync.service.SyncYomiSyncService
 import eu.kanade.tachiyomi.data.sync.service.WebDavSyncService
+import eu.kanade.tachiyomi.extension.ExtensionManager
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
 import logcat.logcat
+import mihon.feature.extension.sync.SyncExtensionIdentity
+import mihon.feature.extension.sync.combineRememberedWithInstalled
+import mihon.feature.extension.sync.cumulativeExtensionHistory
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.data.Chapters
 import tachiyomi.data.DatabaseHandler
@@ -47,6 +53,11 @@ class SyncManager(
         ignoreUnknownKeys = true
     },
     private val getCategories: GetCategories = Injekt.get(),
+    // Chimahon -->
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+    private val extensionManager: ExtensionManager = Injekt.get(),
+    private val animeExtensionManager: AnimeExtensionManager = Injekt.get(),
+    // Chimahon <--
 ) {
     private val backupCreator: BackupCreator = BackupCreator(context, false)
     private val notifier: SyncNotifier = SyncNotifier(context)
@@ -107,6 +118,32 @@ class SyncManager(
         logcat(LogPriority.DEBUG) { "Begin create backup" }
         val backupManga = backupCreator.backupMangas(databaseManga, backupOptions)
         val backupAnime = backupCreator.backupAnimes(backupOptions)
+
+        // Chimahon -->
+        // Combine remembered extension identities with currently installed extensions before syncing.
+        val rememberedMangaExtensionsPref = sourcePreferences.rememberedMangaExtensions()
+        val rememberedAnimeExtensionsPref = sourcePreferences.rememberedAnimeExtensions()
+        val backupMangaExtensions = combineRememberedWithInstalled(
+            remembered = rememberedMangaExtensionsPref.get(),
+            installed = extensionManager.installedExtensionsFlow.value.map {
+                SyncExtensionIdentity(pkgName = it.pkgName, signatureHash = it.signatureHash)
+            },
+        )
+        val backupAnimeExtensions = combineRememberedWithInstalled(
+            remembered = rememberedAnimeExtensionsPref.get(),
+            installed = animeExtensionManager.installedExtensionsFlow.value.map {
+                SyncExtensionIdentity(pkgName = it.pkgName, signatureHash = it.signatureHash)
+            },
+        )
+        // Keep the local history cumulative even when nothing is received from remote.
+        rememberedMangaExtensionsPref.set(
+            cumulativeExtensionHistory(rememberedMangaExtensionsPref.get(), backupMangaExtensions),
+        )
+        rememberedAnimeExtensionsPref.set(
+            cumulativeExtensionHistory(rememberedAnimeExtensionsPref.get(), backupAnimeExtensions),
+        )
+        // Chimahon <--
+
         val backup = Backup(
             backupManga = backupManga,
             backupCategories = backupCreator.backupCategories(backupOptions),
@@ -129,6 +166,8 @@ class SyncManager(
             // Chimahon -->
             backupNovels = backupCreator.backupNovels(backupOptions),
             backupNovelCategories = backupCreator.backupNovelCategories(backupOptions),
+            backupMangaExtensions = backupMangaExtensions,
+            backupAnimeExtensions = backupAnimeExtensions,
             // Chimahon <--
         )
         logcat(LogPriority.DEBUG) { "End create backup" }
@@ -173,6 +212,17 @@ class SyncManager(
             // should we call showSyncError?
             return
         }
+
+        // Chimahon -->
+        // Persist the union of local and remote extension identities before any early return so the
+        // "Extensions from Sync" history keeps accumulating even when there is nothing else to restore.
+        rememberedMangaExtensionsPref.set(
+            cumulativeExtensionHistory(rememberedMangaExtensionsPref.get(), remoteBackup.backupMangaExtensions),
+        )
+        rememberedAnimeExtensionsPref.set(
+            cumulativeExtensionHistory(rememberedAnimeExtensionsPref.get(), remoteBackup.backupAnimeExtensions),
+        )
+        // Chimahon <--
 
         if (remoteBackup == syncData.backup) {
             // nothing changed

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import logcat.logcat
+import mihon.feature.extension.sync.mergeExtensionIdentities
 
 @Serializable
 data class SyncData(
@@ -107,6 +108,14 @@ abstract class SyncService(
             remoteSyncData.backup?.backupNovelCategories ?: emptyList(),
             mergedNovelCategoriesList,
         )
+        val mergedMangaExtensions = mergeExtensionIdentities(
+            localSyncData.backup?.backupMangaExtensions,
+            remoteSyncData.backup?.backupMangaExtensions,
+        )
+        val mergedAnimeExtensions = mergeExtensionIdentities(
+            localSyncData.backup?.backupAnimeExtensions,
+            remoteSyncData.backup?.backupAnimeExtensions,
+        )
         // Chimahon <--
 
         // Create the merged Backup object
@@ -129,6 +138,8 @@ abstract class SyncService(
             // Chimahon -->
             backupNovels = mergedNovelsList,
             backupNovelCategories = mergedNovelCategoriesList,
+            backupMangaExtensions = mergedMangaExtensions,
+            backupAnimeExtensions = mergedAnimeExtensions,
             // Chimahon <--
         )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/animeextension/AnimeExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/animeextension/AnimeExtensionsScreenModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlin.time.Duration.Companion.seconds
@@ -62,7 +63,7 @@ class AnimeExtensionsScreenModel(
                     .map { searchQueryPredicate(it ?: "") },
                 currentDownloads,
                 getAnimeExtensions.subscribe(),
-            ) { predicate, downloads, (_updates, _installed, _available, _untrusted) ->
+            ) { predicate, downloads, (_updates, _installed, _available, _untrusted, _fromSync) ->
                 buildMap {
                     val updates = _updates.filter(predicate).map(extensionMapper(downloads))
                     if (updates.isNotEmpty()) {
@@ -76,6 +77,13 @@ class AnimeExtensionsScreenModel(
                     if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
                         put(AnimeExtensionUiModel.Header.Resource(MR.strings.ext_installed), installed + untrusted)
                     }
+
+                    // Chimahon -->
+                    val fromSync = _fromSync.filter(predicate).map(extensionMapper(downloads))
+                    if (fromSync.isNotEmpty()) {
+                        put(AnimeExtensionUiModel.Header.Resource(KMR.strings.extensions_from_sync), fromSync)
+                    }
+                    // Chimahon <--
 
                     val languagesWithExtensions = _available
                         .filter(predicate)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -74,7 +74,7 @@ class ExtensionsScreenModel(
                 // KMK <--
                 currentDownloads,
                 getExtensions.subscribe(),
-            ) { predicate, nsfwOnly, downloads, (_updates, _installed, _available, _untrusted) ->
+            ) { predicate, nsfwOnly, downloads, (_updates, _installed, _available, _untrusted, _fromSync) ->
                 buildMap {
                     val updates = _updates.filter(predicate).map(extensionMapper(downloads))
                         // KMK -->
@@ -95,6 +95,14 @@ class ExtensionsScreenModel(
                     if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
                         put(ExtensionUiModel.Header.Resource(MR.strings.ext_installed), installed + untrusted)
                     }
+
+                    // Chimahon -->
+                    val fromSync = _fromSync.filter(predicate).map(extensionMapper(downloads))
+                        .filter { !nsfwOnly || it.extension.isNsfw }
+                    if (fromSync.isNotEmpty()) {
+                        put(ExtensionUiModel.Header.Resource(KMR.strings.extensions_from_sync), fromSync)
+                    }
+                    // Chimahon <--
 
                     val languagesWithExtensions = _available
                         .filter(predicate)

--- a/app/src/main/java/mihon/feature/extension/sync/ExtensionIdentitySync.kt
+++ b/app/src/main/java/mihon/feature/extension/sync/ExtensionIdentitySync.kt
@@ -1,0 +1,112 @@
+package mihon.feature.extension.sync
+
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
+
+// Chimahon -->
+/**
+ * Lightweight identity for a manga or anime extension: its package id and signing hash.
+ * This is everything the "Extensions from Sync" feature remembers about an extension.
+ */
+data class SyncExtensionIdentity(
+    val pkgName: String,
+    val signatureHash: String,
+) {
+    /** Encode for storage in an app-state [Set] preference. */
+    fun encode(): String = "$pkgName$SEPARATOR$signatureHash"
+
+    fun toBackup(): BackupExtension = BackupExtension(pkgName = pkgName, signatureHash = signatureHash)
+
+    companion object {
+        private const val SEPARATOR = "|"
+
+        /** Decode a preference entry produced by [encode]. Returns null for malformed values. */
+        fun decode(value: String): SyncExtensionIdentity? {
+            val separatorIndex = value.indexOf(SEPARATOR)
+            if (separatorIndex <= 0 || separatorIndex >= value.length - 1) return null
+            val pkgName = value.substring(0, separatorIndex)
+            val signatureHash = value.substring(separatorIndex + 1)
+            if (SEPARATOR in signatureHash) return null
+            return SyncExtensionIdentity(pkgName, signatureHash)
+        }
+
+        fun from(backup: BackupExtension): SyncExtensionIdentity =
+            SyncExtensionIdentity(pkgName = backup.pkgName, signatureHash = backup.signatureHash)
+    }
+}
+
+/**
+ * A candidate extension available in the current device's catalog, used to match remembered
+ * identities against what is actually installable here.
+ */
+data class SyncExtensionCandidate(
+    val pkgName: String,
+    val signatureHash: String,
+    val isNsfw: Boolean,
+    val languages: Set<String>,
+)
+
+/**
+ * Union and de-duplicate two lists of remembered extension identities. Used while merging the
+ * local and remote sync payloads so history accumulates across every device.
+ */
+fun mergeExtensionIdentities(
+    local: List<BackupExtension>?,
+    remote: List<BackupExtension>?,
+): List<BackupExtension> =
+    (local.orEmpty() + remote.orEmpty())
+        .distinctBy { it.pkgName to it.signatureHash }
+
+/**
+ * Combine the remembered identities (encoded preference set) with the currently installed
+ * extensions to build the payload sent during sync. This is the "before syncing" step that keeps
+ * history cumulative even for extensions that were only ever installed locally.
+ */
+fun combineRememberedWithInstalled(
+    remembered: Set<String>,
+    installed: List<SyncExtensionIdentity>,
+): List<BackupExtension> {
+    val decoded = remembered.mapNotNull(SyncExtensionIdentity::decode)
+    return (decoded + installed)
+        .distinct()
+        .map(SyncExtensionIdentity::toBackup)
+}
+
+/**
+ * Fold a backup's identities into the existing remembered set to produce the new cumulative
+ * history. History is never pruned, so uninstalling an extension does not forget it.
+ */
+fun cumulativeExtensionHistory(
+    existing: Set<String>,
+    backup: List<BackupExtension>,
+): Set<String> =
+    existing + backup.map { SyncExtensionIdentity.from(it).encode() }
+
+/**
+ * Match remembered identities against the device's available catalog, returning the set of package
+ * ids that should appear in the "Extensions from Sync" section.
+ *
+ * A package is shown only when:
+ * - its (pkgName, signatureHash) pair is remembered — this hides unmatched identities and
+ *   signature mismatches,
+ * - it is present in the local catalog (i.e. is one of [candidates]),
+ * - it is not already installed,
+ * - it passes the NSFW content filter, and
+ * - it has at least one source in an enabled language (or declares no languages at all).
+ */
+fun matchRememberedExtensions(
+    remembered: Set<SyncExtensionIdentity>,
+    candidates: List<SyncExtensionCandidate>,
+    installedPkgNames: Set<String>,
+    showNsfw: Boolean,
+    enabledLanguages: Set<String>,
+): Set<String> {
+    if (remembered.isEmpty()) return emptySet()
+    return candidates.asSequence()
+        .filter { it.pkgName !in installedPkgNames }
+        .filter { SyncExtensionIdentity(it.pkgName, it.signatureHash) in remembered }
+        .filter { showNsfw || !it.isNsfw }
+        .filter { candidate -> candidate.languages.isEmpty() || candidate.languages.any { it in enabledLanguages } }
+        .map { it.pkgName }
+        .toSet()
+}
+// Chimahon <--

--- a/app/src/test/java/mihon/feature/extension/sync/ExtensionIdentitySyncTest.kt
+++ b/app/src/test/java/mihon/feature/extension/sync/ExtensionIdentitySyncTest.kt
@@ -1,0 +1,199 @@
+package mihon.feature.extension.sync
+
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ExtensionIdentitySyncTest {
+
+    @Test
+    fun `identity encodes and decodes round trip`() {
+        val identity = SyncExtensionIdentity(pkgName = "com.example.ext.en.foo", signatureHash = "abc123")
+
+        SyncExtensionIdentity.decode(identity.encode()) shouldBe identity
+    }
+
+    @Test
+    fun `decode rejects malformed values`() {
+        SyncExtensionIdentity.decode("no-separator").shouldBeNull()
+        SyncExtensionIdentity.decode("|onlyHash").shouldBeNull()
+        SyncExtensionIdentity.decode("onlyPkg|").shouldBeNull()
+        SyncExtensionIdentity.decode("pkg|hash|extra").shouldBeNull()
+    }
+
+    @Test
+    fun `mergeExtensionIdentities unions and de-duplicates`() {
+        val local = listOf(
+            BackupExtension("pkg.a", "hashA"),
+            BackupExtension("pkg.b", "hashB"),
+        )
+        val remote = listOf(
+            BackupExtension("pkg.b", "hashB"), // duplicate
+            BackupExtension("pkg.c", "hashC"),
+        )
+
+        val merged = mergeExtensionIdentities(local, remote)
+
+        merged.map { it.pkgName to it.signatureHash }.shouldContainExactlyInAnyOrder(
+            "pkg.a" to "hashA",
+            "pkg.b" to "hashB",
+            "pkg.c" to "hashC",
+        )
+    }
+
+    @Test
+    fun `mergeExtensionIdentities keeps distinct signature hashes for same package`() {
+        val merged = mergeExtensionIdentities(
+            listOf(BackupExtension("pkg.a", "hashA")),
+            listOf(BackupExtension("pkg.a", "hashB")),
+        )
+
+        merged.map { it.pkgName to it.signatureHash }.shouldContainExactlyInAnyOrder(
+            "pkg.a" to "hashA",
+            "pkg.a" to "hashB",
+        )
+    }
+
+    @Test
+    fun `mergeExtensionIdentities tolerates null inputs (extension-only payloads)`() {
+        mergeExtensionIdentities(null, null) shouldBe emptyList()
+        mergeExtensionIdentities(listOf(BackupExtension("pkg.a", "hashA")), null)
+            .map { it.pkgName }.shouldContainExactly("pkg.a")
+    }
+
+    @Test
+    fun `combineRememberedWithInstalled unions remembered prefs with installed and drops malformed`() {
+        val remembered = setOf(
+            SyncExtensionIdentity("pkg.a", "hashA").encode(),
+            "malformed-entry",
+        )
+        val installed = listOf(
+            SyncExtensionIdentity("pkg.a", "hashA"), // duplicate of remembered
+            SyncExtensionIdentity("pkg.b", "hashB"),
+        )
+
+        val combined = combineRememberedWithInstalled(remembered, installed)
+
+        combined.map { it.pkgName to it.signatureHash }.shouldContainExactlyInAnyOrder(
+            "pkg.a" to "hashA",
+            "pkg.b" to "hashB",
+        )
+    }
+
+    @Test
+    fun `cumulativeExtensionHistory accumulates and never prunes`() {
+        val existing = setOf(SyncExtensionIdentity("pkg.a", "hashA").encode())
+        val fromBackup = listOf(
+            BackupExtension("pkg.a", "hashA"), // already known
+            BackupExtension("pkg.b", "hashB"), // new
+        )
+
+        val history = cumulativeExtensionHistory(existing, fromBackup)
+
+        history shouldContainExactlyInAnyOrder setOf(
+            SyncExtensionIdentity("pkg.a", "hashA").encode(),
+            SyncExtensionIdentity("pkg.b", "hashB").encode(),
+        )
+
+        // Removing an extension from the payload does not remove it from history.
+        cumulativeExtensionHistory(history, emptyList()) shouldContainExactlyInAnyOrder history
+    }
+
+    @Test
+    fun `matchRememberedExtensions returns exact catalog matches`() {
+        val remembered = setOf(SyncExtensionIdentity("pkg.a", "hashA"))
+        val candidates = listOf(candidate("pkg.a", "hashA"))
+
+        matchRememberedExtensions(
+            remembered = remembered,
+            candidates = candidates,
+            installedPkgNames = emptySet(),
+            showNsfw = true,
+            enabledLanguages = setOf("en"),
+        ) shouldBe setOf("pkg.a")
+    }
+
+    @Test
+    fun `matchRememberedExtensions hides unmatched identities and signature mismatches`() {
+        val remembered = setOf(SyncExtensionIdentity("pkg.a", "hashA"))
+
+        // Not in the catalog at all -> hidden.
+        matchRememberedExtensions(
+            remembered = remembered,
+            candidates = listOf(candidate("pkg.other", "hashOther")),
+            installedPkgNames = emptySet(),
+            showNsfw = true,
+            enabledLanguages = setOf("en"),
+        ) shouldBe emptySet()
+
+        // Same package but a different signing hash -> signature mismatch -> hidden.
+        matchRememberedExtensions(
+            remembered = remembered,
+            candidates = listOf(candidate("pkg.a", "hashDIFFERENT")),
+            installedPkgNames = emptySet(),
+            showNsfw = true,
+            enabledLanguages = setOf("en"),
+        ) shouldBe emptySet()
+    }
+
+    @Test
+    fun `matchRememberedExtensions hides already installed packages`() {
+        matchRememberedExtensions(
+            remembered = setOf(SyncExtensionIdentity("pkg.a", "hashA")),
+            candidates = listOf(candidate("pkg.a", "hashA")),
+            installedPkgNames = setOf("pkg.a"),
+            showNsfw = true,
+            enabledLanguages = setOf("en"),
+        ) shouldBe emptySet()
+    }
+
+    @Test
+    fun `matchRememberedExtensions respects the NSFW content filter`() {
+        val remembered = setOf(SyncExtensionIdentity("pkg.a", "hashA"))
+        val candidates = listOf(candidate("pkg.a", "hashA", isNsfw = true))
+
+        matchRememberedExtensions(remembered, candidates, emptySet(), showNsfw = false, enabledLanguages = setOf("en"))
+            .shouldBe(emptySet())
+        matchRememberedExtensions(remembered, candidates, emptySet(), showNsfw = true, enabledLanguages = setOf("en"))
+            .shouldBe(setOf("pkg.a"))
+    }
+
+    @Test
+    fun `matchRememberedExtensions respects the enabled-languages content filter`() {
+        val remembered = setOf(SyncExtensionIdentity("pkg.a", "hashA"))
+        val candidates = listOf(candidate("pkg.a", "hashA", languages = setOf("ja")))
+
+        // No enabled language matches -> hidden.
+        matchRememberedExtensions(remembered, candidates, emptySet(), showNsfw = true, enabledLanguages = setOf("en"))
+            .shouldBe(emptySet())
+        // An enabled language matches -> shown.
+        matchRememberedExtensions(remembered, candidates, emptySet(), showNsfw = true, enabledLanguages = setOf("ja"))
+            .shouldBe(setOf("pkg.a"))
+    }
+
+    @Test
+    fun `matchRememberedExtensions returns nothing when nothing is remembered`() {
+        matchRememberedExtensions(
+            remembered = emptySet(),
+            candidates = listOf(candidate("pkg.a", "hashA")),
+            installedPkgNames = emptySet(),
+            showNsfw = true,
+            enabledLanguages = setOf("en"),
+        ) shouldBe emptySet()
+    }
+
+    private fun candidate(
+        pkgName: String,
+        signatureHash: String,
+        isNsfw: Boolean = false,
+        languages: Set<String> = setOf("en"),
+    ) = SyncExtensionCandidate(
+        pkgName = pkgName,
+        signatureHash = signatureHash,
+        isNsfw = isNsfw,
+        languages = languages,
+    )
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/data/backup/BackupExtensionProtoTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/data/backup/BackupExtensionProtoTest.kt
@@ -1,0 +1,73 @@
+package eu.kanade.tachiyomi.data.backup
+
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import org.junit.jupiter.api.Test
+
+class BackupExtensionProtoTest {
+
+    @Test
+    fun `round-trips manga and anime extension identities`() {
+        val original = Backup(
+            backupMangaExtensions = listOf(
+                BackupExtension("com.example.manga.en.foo", "hashFoo"),
+                BackupExtension("com.example.manga.ja.bar", "hashBar"),
+            ),
+            backupAnimeExtensions = listOf(
+                BackupExtension("com.example.anime.en.baz", "hashBaz"),
+            ),
+        )
+
+        val decoded = ProtoBuf.decodeFromByteArray(
+            Backup.serializer(),
+            ProtoBuf.encodeToByteArray(Backup.serializer(), original),
+        )
+
+        decoded.backupMangaExtensions shouldContainExactly original.backupMangaExtensions
+        decoded.backupAnimeExtensions shouldContainExactly original.backupAnimeExtensions
+    }
+
+    @Test
+    fun `existing sync files without extension fields decode with empty histories`() {
+        val legacyBytes = ProtoBuf.encodeToByteArray(
+            LegacyBackupWithoutExtensions.serializer(),
+            LegacyBackupWithoutExtensions(
+                backupCategories = listOf(BackupCategory(name = "Reading", order = 0L)),
+            ),
+        )
+
+        val decoded = ProtoBuf.decodeFromByteArray(Backup.serializer(), legacyBytes)
+
+        decoded.backupCategories.map { it.name } shouldContainExactly listOf("Reading")
+        decoded.backupMangaExtensions.shouldBeEmpty()
+        decoded.backupAnimeExtensions.shouldBeEmpty()
+    }
+
+    @Test
+    fun `extension identities are ignored by readers that do not know the fields`() {
+        val bytes = ProtoBuf.encodeToByteArray(
+            Backup.serializer(),
+            Backup(
+                backupCategories = listOf(BackupCategory(name = "Reading", order = 0L)),
+                backupMangaExtensions = listOf(BackupExtension("pkg", "hash")),
+                backupAnimeExtensions = listOf(BackupExtension("anime.pkg", "hash")),
+            ),
+        )
+
+        val decoded = ProtoBuf.decodeFromByteArray(LegacyBackupWithoutExtensions.serializer(), bytes)
+
+        decoded.backupCategories.map { it.name } shouldContainExactly listOf("Reading")
+    }
+
+    /** Mirrors a pre-feature backup that has no extension identity fields (720/721). */
+    @Serializable
+    private data class LegacyBackupWithoutExtensions(
+        @ProtoNumber(2) val backupCategories: List<BackupCategory> = emptyList(),
+    )
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/data/sync/service/SyncServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/data/sync/service/SyncServiceTest.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.backup.models.BackupAnime
 import eu.kanade.tachiyomi.data.backup.models.BackupAnimeSource
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupEpisode
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
 import eu.kanade.tachiyomi.data.backup.models.BackupExtensionRepos
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -106,6 +107,37 @@ class SyncServiceTest {
         merged.backupAnime.single().version shouldBe 2L
         merged.backupAnime.single().episodes.map { it.name }
             .shouldContainExactlyInAnyOrder("Episode 1", "Episode 2")
+    }
+
+    @Test
+    fun `merge unions and de-duplicates extension identities (extension-only payload)`() {
+        val service = TestSyncService()
+
+        val merged = service.merge(
+            local = SyncData(
+                backup = Backup(
+                    backupMangaExtensions = listOf(
+                        BackupExtension("pkg.manga.a", "hashA"),
+                        BackupExtension("pkg.manga.shared", "hashShared"),
+                    ),
+                    backupAnimeExtensions = listOf(BackupExtension("pkg.anime.a", "hashAnimeA")),
+                ),
+            ),
+            remote = SyncData(
+                backup = Backup(
+                    backupMangaExtensions = listOf(
+                        BackupExtension("pkg.manga.shared", "hashShared"), // duplicate
+                        BackupExtension("pkg.manga.b", "hashB"),
+                    ),
+                    backupAnimeExtensions = listOf(BackupExtension("pkg.anime.b", "hashAnimeB")),
+                ),
+            ),
+        ).backup!!
+
+        merged.backupMangaExtensions.map { it.pkgName }
+            .shouldContainExactlyInAnyOrder("pkg.manga.a", "pkg.manga.shared", "pkg.manga.b")
+        merged.backupAnimeExtensions.map { it.pkgName }
+            .shouldContainExactlyInAnyOrder("pkg.anime.a", "pkg.anime.b")
     }
 
     private fun extensionRepo(baseUrl: String) = BackupExtensionRepos(

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -103,6 +103,7 @@
     <!-- Extension section -->
     <string name="extensions_page_need_refresh">Refresh extension page to update list.</string>
     <string name="extensions_page_more">More extensions...</string>
+    <string name="extensions_from_sync">Extensions from Sync</string>
     <!-- Extension repos -->
       <!-- Downloads section -->
     <string name="download_cache_renew_interval">Download cache renew interval</string>


### PR DESCRIPTION
Remember lightweight manga and anime extension identities (package id + signing hash) in the shared sync payload, without syncing APKs, download URLs, or repositories. Cumulative history is kept in app-state prefs and matched against each device's independently configured catalog to surface installable matches in a new "Extensions from Sync" section shown after "Installed" on both extension screens.

- Add backward-compatible Backup fields (720/721) + BackupExtension model
- Union/de-duplicate identities during sync merge; persist returned history before any early return
- Combine remembered identities with installed extensions before syncing
- Match exact (pkg+hash) catalog entries; hide unmatched, signature mismatches, installed, and content-filtered entries; de-dupe from language sections
- Extract testable grouping helpers for both extension screens
- Tests: protobuf round-trip/compat, sync union/dedupe/history, matcher, and both screen groupings

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
