### PR TITLE
Fix MPV playback when All files access is enabled

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -647,11 +647,12 @@ class PlayerActivity : BaseActivity() {
 
     private fun setupPlayerMPV() {
         val logLevel = if (networkPreferences.verboseLogging().get()) "info" else "warn"
+        val internalConfigDir = applicationContext.filesDir.path
 
         val configDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()) {
             storageManager.getMPVConfigDirectory()!!.filePath!!
         } else {
-            applicationContext.filesDir.path
+            internalConfigDir
         }
 
         val mpvConfFile = File("$configDir/mpv.conf")
@@ -660,7 +661,11 @@ class PlayerActivity : BaseActivity() {
         advancedPlayerPreferences.mpvInput().get().let { mpvInputFile.writeText(it) }
 
         copyScripts()
-        copyAssets(configDir)
+        copyAssets(configDir, "subfont.ttf")
+        copyAssets(internalConfigDir, "cacert.pem")
+        if (configDir != internalConfigDir) {
+            removeUnmodifiedAssetCopy(configDir, "cacert.pem")
+        }
         setupFontsDirectory()
 
         MPVLib.setOptionString("sub-ass-force-margins", "yes")
@@ -716,9 +721,8 @@ class PlayerActivity : BaseActivity() {
         }
     }
 
-    private fun copyAssets(configDir: String) {
+    private fun copyAssets(configDir: String, vararg files: String) {
         val assetManager = this.assets
-        val files = arrayOf("subfont.ttf", "cacert.pem")
         for (filename in files) {
             var ins: InputStream? = null
             var out: OutputStream? = null
@@ -740,6 +744,24 @@ class PlayerActivity : BaseActivity() {
                 ins?.close()
                 out?.close()
             }
+        }
+    }
+
+    private fun removeUnmodifiedAssetCopy(configDir: String, filename: String) {
+        val file = File(configDir, filename)
+        if (!file.isFile) return
+
+        try {
+            val isBundledAsset = assets.open(filename).use { asset ->
+                file.inputStream().use { copiedAsset ->
+                    copiedAsset.readBytes().contentEquals(asset.readBytes())
+                }
+            }
+            if (isBundledAsset && !file.delete()) {
+                logcat(LogPriority.WARN) { "Failed to remove unused asset file: $filename" }
+            }
+        } catch (e: IOException) {
+            logcat(LogPriority.ERROR, e) { "Failed to remove unused asset file: $filename" }
         }
     }
 


### PR DESCRIPTION
## Problem

On a fresh install with All files access enabled, MPV copied `cacert.pem` to the external config directory but continued to load it from internal storage. TLS verification could therefore fail while loading YouTube videos.

## Changes

- Always store the bundled CA certificate in app internal storage.
- Keep the external MPV directory for user-facing configuration and fonts.
- Remove an external `cacert.pem` only when it exactly matches the bundled asset, preserving user-modified files.

## Result

MPV now uses one canonical CA certificate path regardless of the All files access setting. Switching the permission no longer leaves two bundled CA certificate copies or causes playback to depend on a previous launch state.

## Testing

### before

1. Open emulator
2. Enable **All files access** before opening any video.
3. Launch the app
4. Open a YouTube extension video will showed `loading failed`.

### after

1. Open emulator
2. Enable **All files access** before opening any video.
3. Launch the app
4. Open a YouTube extension video and verify the video starts playing normally.


