### PR TITLE
Fix Jimaku API key backup privacy

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.source.sourcePreferences
 import exh.EXHMigrations
 import exh.log.xLogE
 import tachiyomi.core.common.preference.AndroidPreferenceStore
+import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.plusAssign
 import tachiyomi.domain.category.interactor.GetCategories
@@ -93,7 +94,10 @@ class PreferenceRestorer(
                         }
                     }
                     is StringPreferenceValue -> {
-                        if (prefs[key] is String?) {
+                        // Older backups stored this key publicly; restore either form into the private key.
+                        if (key == JIMAKU_API_KEY || key == privateJimakuApiKey) {
+                            preferenceStore.getString(privateJimakuApiKey).set(value.value)
+                        } else if (prefs[key] is String?) {
                             preferenceStore.getString(key).set(value.value)
                         }
                     }
@@ -167,5 +171,10 @@ class PreferenceRestorer(
 
         val valueToSet = EXHMigrations.migrateSourceIds(value)
         preferenceStore.getStringSet(key).set(valueToSet)
+    }
+
+    private companion object {
+        const val JIMAKU_API_KEY = "pref_jimaku_api_key"
+        val privateJimakuApiKey = Preference.privateKey(JIMAKU_API_KEY)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitlesBorderStyle
+import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
 
@@ -18,7 +19,7 @@ class SubtitlePreferences(
     fun preferredSubLanguages() = preferenceStore.getString("pref_subtitle_lang", "")
     fun subtitleWhitelist() = preferenceStore.getString("pref_subtitle_whitelist", "")
     fun subtitleBlacklist() = preferenceStore.getString("pref_subtitle_blacklist", "")
-    fun jimakuApiKey() = preferenceStore.getString("pref_jimaku_api_key", "")
+    fun jimakuApiKey() = preferenceStore.getString(Preference.privateKey(JIMAKU_API_KEY), "")
     fun jimakuTitle() = preferenceStore.getString("pref_jimaku_title", "")
     fun subtitleRegexRemoveSpeakerNames() = preferenceStore.getBoolean(
         "pref_subtitle_regex_remove_speaker_names",
@@ -94,6 +95,10 @@ class SubtitlePreferences(
             )
         }
         ?: subtitlesSecondaryDelay()
+
+    private companion object {
+        const val JIMAKU_API_KEY = "pref_jimaku_api_key"
+    }
 }
 
 enum class SubtitleJustification(

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -56,5 +56,6 @@ val migrations: List<Migration>
         DisabledRepoMigration(),
         SyncPrefKeyMigration(),
         ChapterUrlHashMigration(),
+        MoveJimakuApiKeyToPrivateMigration(),
         // KMK <--
     )

--- a/app/src/main/java/mihon/core/migration/migrations/MoveJimakuApiKeyToPrivateMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/MoveJimakuApiKeyToPrivateMigration.kt
@@ -1,0 +1,32 @@
+package mihon.core.migration.migrations
+
+import mihon.core.migration.MigrateUtils
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.util.lang.withIOContext
+
+class MoveJimakuApiKeyToPrivateMigration : Migration {
+    override val version: Float = 82f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
+        val preferenceStore = migrationContext.get<PreferenceStore>() ?: return@withIOContext false
+
+        migrate(preferenceStore)
+
+        return@withIOContext true
+    }
+
+    internal fun migrate(preferenceStore: PreferenceStore) {
+        MigrateUtils.replacePreferences(
+            preferenceStore = preferenceStore,
+            filterPredicate = { it.key == JIMAKU_API_KEY },
+            newKey = { Preference.privateKey(it) },
+        )
+    }
+
+    private companion object {
+        const val JIMAKU_API_KEY = "pref_jimaku_api_key"
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferencesTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferencesTest.kt
@@ -1,0 +1,47 @@
+package eu.kanade.tachiyomi.ui.player.settings
+
+import eu.kanade.tachiyomi.data.backup.create.creators.PreferenceBackupCreator
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class SubtitlePreferencesTest {
+
+    @Test
+    fun jimakuApiKeyUsesAPrivatePreference() {
+        val preferenceStore = mockk<PreferenceStore>()
+        val apiKeyPreference = mockk<Preference<String>>()
+        every { preferenceStore.getString(PRIVATE_JIMAKU_API_KEY, "") } returns apiKeyPreference
+
+        val preference = SubtitlePreferences(preferenceStore).jimakuApiKey()
+
+        assertSame(apiKeyPreference, preference)
+        verify { preferenceStore.getString(PRIVATE_JIMAKU_API_KEY, "") }
+    }
+
+    @Test
+    fun jimakuApiKeyIsExcludedFromNormalAppBackups() {
+        val preferenceStore = mockk<PreferenceStore>()
+        every { preferenceStore.getAll() } returns mapOf(PRIVATE_JIMAKU_API_KEY to "api-key")
+        val backupCreator = PreferenceBackupCreator(
+            sourceManager = mockk(),
+            preferenceStore = preferenceStore,
+        )
+
+        assertEquals(emptyList<String>(), backupCreator.createApp(includePrivatePreferences = false).map { it.key })
+        assertEquals(
+            listOf(PRIVATE_JIMAKU_API_KEY),
+            backupCreator.createApp(includePrivatePreferences = true).map { it.key },
+        )
+    }
+
+    private companion object {
+        const val JIMAKU_API_KEY = "pref_jimaku_api_key"
+        val PRIVATE_JIMAKU_API_KEY = Preference.privateKey(JIMAKU_API_KEY)
+    }
+}

--- a/app/src/test/java/mihon/core/migration/MigratorTest.kt
+++ b/app/src/test/java/mihon/core/migration/MigratorTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,6 +79,27 @@ class MigratorTest {
 
         @Suppress("DeferredResultUnused")
         verify(exactly = 0) { migrationJobFactory.create(any()) }
+    }
+
+    @Test
+    fun dryRunDoesNotInvokeMigrations() = runBlocking {
+        var invoked = false
+        val dryRunFactory = MigrationJobFactory(
+            migrationContext = MigrationContext(dryrun = true),
+            scope = CoroutineScope(Dispatchers.Main + Job()),
+        )
+
+        val result = dryRunFactory.create(
+            listOf(
+                Migration.of(1f) {
+                    invoked = true
+                    true
+                },
+            ),
+        ).await()
+
+        assertTrue(result)
+        assertFalse(invoked)
     }
 
     @Test

--- a/app/src/test/java/mihon/core/migration/migrations/MoveJimakuApiKeyToPrivateMigrationTest.kt
+++ b/app/src/test/java/mihon/core/migration/migrations/MoveJimakuApiKeyToPrivateMigrationTest.kt
@@ -1,0 +1,37 @@
+package mihon.core.migration.migrations
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class MoveJimakuApiKeyToPrivateMigrationTest {
+
+    @Test
+    fun movesExistingApiKeyToPrivatePreference() {
+        val preferenceStore = mockk<PreferenceStore>()
+        val legacyPreference = mockk<Preference<String>>(relaxed = true)
+        val privatePreference = mockk<Preference<String>>(relaxed = true)
+        every { preferenceStore.getAll() } returns mapOf(JIMAKU_API_KEY to API_KEY)
+        every { preferenceStore.getString(JIMAKU_API_KEY, "") } returns legacyPreference
+        every { preferenceStore.getString(PRIVATE_JIMAKU_API_KEY, "") } returns privatePreference
+
+        MoveJimakuApiKeyToPrivateMigration().migrate(preferenceStore)
+
+        verifyOrder {
+            preferenceStore.getAll()
+            preferenceStore.getString(PRIVATE_JIMAKU_API_KEY, "")
+            privatePreference.set(API_KEY)
+            preferenceStore.getString(JIMAKU_API_KEY, "")
+            legacyPreference.delete()
+        }
+    }
+
+    private companion object {
+        const val JIMAKU_API_KEY = "pref_jimaku_api_key"
+        const val API_KEY = "existing-api-key"
+        val PRIVATE_JIMAKU_API_KEY = Preference.privateKey(JIMAKU_API_KEY)
+    }
+}


### PR DESCRIPTION
## Summary

- Store the Jimaku API key as a private preference so normal app-settings backups exclude it.
- Migrate existing API keys to the private key and remove the legacy value.
- Restore both legacy and private Jimaku API-key backup entries into the private preference.

