### PR TITLE
fix(player): Fix delayed and stale subtitle dictionary lookups in the player

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -87,6 +88,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import eu.kanade.presentation.more.settings.screen.player.custombutton.getButtons
 import eu.kanade.presentation.theme.playerRippleConfiguration
+import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
 import eu.kanade.tachiyomi.ui.player.CastManager
 import eu.kanade.tachiyomi.ui.player.Dialogs
 import eu.kanade.tachiyomi.ui.player.Panels
@@ -106,6 +108,7 @@ import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitlesBorderS
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.toColorHexString
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.toFixed
 import eu.kanade.tachiyomi.ui.player.scene.SceneClockDomain
+import eu.kanade.tachiyomi.ui.player.scene.SceneCaptureRequest
 import eu.kanade.tachiyomi.ui.player.scene.SceneRangeCandidate
 import eu.kanade.tachiyomi.ui.player.scene.SceneRangeProvenance
 import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
@@ -147,6 +150,7 @@ fun PlayerControls(
     val gesturePreferences = remember { Injekt.get<GesturePreferences>() }
     val audioPreferences = remember { Injekt.get<AudioPreferences>() }
     val subtitlePreferences = remember { Injekt.get<SubtitlePreferences>() }
+    val dictionaryPreferences = remember { Injekt.get<DictionaryPreferences>() }
     val interactionSource = remember { MutableInteractionSource() }
     val controlsShown by viewModel.controlsShown.collectAsState()
     val areControlsLocked by viewModel.areControlsLocked.collectAsState()
@@ -167,7 +171,17 @@ fun PlayerControls(
     val subtitleCues by viewModel.subtitleHistory.collectAsState()
     val activeSubtitleCueIndex by viewModel.activeSubtitleCueIndex.collectAsState()
     val sceneMiningProgress by viewModel.sceneMiningProgress.collectAsState()
+    val anime by viewModel.currentAnime.collectAsState()
+    val source by viewModel.currentSource.collectAsState()
     val panel by viewModel.panelShown.collectAsState()
+    val dictionaryProfileKey = DictionaryProfileResolutionKey(
+        animeId = anime?.id,
+        sourceId = source?.id,
+        sourceLang = source?.lang,
+    )
+    val dictionaryProfile = remember(dictionaryProfileKey) {
+        dictionaryPreferences.profileResolver.resolveForPlayer(dictionaryProfileKey)
+    }
     val activeSubtitleCue = remember(subtitleCues, activeSubtitleCueIndex) {
         subtitleCues.firstOrNull { it.index == activeSubtitleCueIndex }
     }
@@ -177,6 +191,8 @@ fun PlayerControls(
     var resetControls by remember { mutableStateOf(true) }
     var subtitleLookupRequest by remember { mutableStateOf<SubtitleLookupRequest?>(null) }
     var subtitleLookupCaptureJob by remember { mutableStateOf<Job?>(null) }
+    var subtitleLookupSceneCapturePending by remember { mutableStateOf(false) }
+    var subtitleLookupCaptureGeneration by remember { mutableStateOf(0) }
     var wasPlayerAlreadyPause by remember { mutableStateOf(false) }
     val subtitleLookupScope = rememberCoroutineScope()
     val customButtons by viewModel.customButtons.collectAsState()
@@ -207,26 +223,39 @@ fun PlayerControls(
         subtitleLookupRequest = null
     }
 
-    fun dismissSubtitleLookup() {
+    fun cancelSubtitleLookupSceneCapture() {
+        subtitleLookupCaptureGeneration += 1
         subtitleLookupCaptureJob?.cancel()
         subtitleLookupCaptureJob = null
+        subtitleLookupSceneCapturePending = false
+    }
+
+    fun dismissSubtitleLookup() {
+        cancelSubtitleLookupSceneCapture()
         releaseSubtitleLookupRequest()
         if (!wasPlayerAlreadyPause) viewModel.unpause()
     }
 
     DisposableEffect(Unit) {
         onDispose {
-            subtitleLookupCaptureJob?.cancel()
+            cancelSubtitleLookupSceneCapture()
             releaseSubtitleLookupRequest()
         }
     }
 
     val openSubtitleLookup: (SubtitleLookupSelection) -> Unit = openSubtitleLookup@{ subtitleLookup ->
-        if (subtitleLookupRequest?.matchesTap(subtitleLookup) == true) {
+        val tapTransition = subtitleLookupTapTransition(
+            matchesCurrentTap = subtitleLookupRequest?.matchesTap(subtitleLookup) == true,
+            hasOpenLookup = subtitleLookupRequest != null,
+            hasActiveCapture = subtitleLookupCaptureJob?.isActive == true,
+        )
+        if (tapTransition.action == SubtitleLookupTapAction.Dismiss) {
             dismissSubtitleLookup()
             return@openSubtitleLookup
         }
-        if (subtitleLookupCaptureJob?.isActive == true) return@openSubtitleLookup
+        if (tapTransition.cancelActiveCapture) {
+            cancelSubtitleLookupSceneCapture()
+        }
         val currentPanel = viewModel.panelShown.value
         if (
             viewModel.sheetShown.value != Sheets.None ||
@@ -235,8 +264,14 @@ fun PlayerControls(
         ) {
             return@openSubtitleLookup
         }
-        wasPlayerAlreadyPause = viewModel.paused.value
-        viewModel.pause()
+        wasPlayerAlreadyPause = subtitleLookupPauseStateAfterTap(
+            wasPlayerAlreadyPaused = wasPlayerAlreadyPause,
+            playerWasPausedAtTap = viewModel.paused.value,
+            pausePlayer = tapTransition.pausePlayer,
+        )
+        if (tapTransition.pausePlayer) {
+            viewModel.pause()
+        }
         releaseSubtitleLookupRequest()
         val baseRequest = SubtitleLookupRequest(
             lookupString = subtitleLookup.lookupString,
@@ -255,17 +290,43 @@ fun PlayerControls(
             lineWidth = subtitleLookup.lineWidth,
             lineHeight = subtitleLookup.lineHeight,
         )
+        subtitleLookupRequest = baseRequest
+        if (!dictionaryProfile.requiresSceneMediaCapture()) {
+            return@openSubtitleLookup
+        }
+
+        subtitleLookupSceneCapturePending = true
+        val captureGeneration = subtitleLookupCaptureGeneration + 1
+        subtitleLookupCaptureGeneration = captureGeneration
         subtitleLookupCaptureJob = subtitleLookupScope.launch {
-            var sceneRequest = viewModel.captureSubtitleSceneRequest(
-                parsedSubtitleCandidate = subtitleLookup.parsedSubtitleCandidate,
-            )
-            if (!isActive) {
+            var sceneRequest: SceneCaptureRequest? = null
+            try {
+                // Render the dictionary shell before any potentially slow MPV screenshot work.
+                withFrameNanos { }
+                withFrameNanos { }
+                sceneRequest = viewModel.captureSubtitleSceneRequest(
+                    parsedSubtitleCandidate = subtitleLookup.parsedSubtitleCandidate,
+                )
+                if (
+                    subtitleLookupCaptureResultAction(
+                        captureIsActive = isActive,
+                        captureGeneration = captureGeneration,
+                        currentGeneration = subtitleLookupCaptureGeneration,
+                        hasOpenLookup = subtitleLookupRequest != null,
+                    ) == SubtitleLookupCaptureResultAction.Apply
+                ) {
+                    subtitleLookupRequest = subtitleLookupRequest?.copy(
+                        sceneCaptureRequest = sceneRequest,
+                    )
+                    sceneRequest = null
+                }
+            } finally {
                 sceneRequest?.let(viewModel::releaseSceneRequest)
-                return@launch
+                if (subtitleLookupCaptureGeneration == captureGeneration) {
+                    subtitleLookupSceneCapturePending = false
+                    subtitleLookupCaptureJob = null
+                }
             }
-            subtitleLookupRequest = baseRequest.copy(sceneCaptureRequest = sceneRequest)
-            sceneRequest = null
-            subtitleLookupCaptureJob = null
         }
     }
     val togglePanel: (Panels) -> Unit = { panel ->
@@ -741,7 +802,6 @@ fun PlayerControls(
         val subtitles by viewModel.subtitleTracks.collectAsState()
         val selectedSubtitles by viewModel.selectedSubtitles.collectAsState()
         val jimakuState by viewModel.jimakuState.collectAsState()
-        val anime by viewModel.currentAnime.collectAsState()
         val jimakuTitle by subtitlePreferences.jimakuTitleForAnime(anime?.id).collectAsState()
         val audioTracks by viewModel.audioTracks.collectAsState()
         val selectedAudio by viewModel.selectedAudio.collectAsState()
@@ -848,6 +908,7 @@ fun PlayerControls(
         PlayerSubtitleLookupPopup(
             viewModel = viewModel,
             request = subtitleLookupRequest,
+            sceneCapturePending = subtitleLookupSceneCapturePending,
             onDismiss = ::dismissSubtitleLookup,
             onTermMatched = { count, offset ->
                 subtitleLookupRequest = subtitleLookupRequest?.copy(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSubtitleLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSubtitleLookupPopup.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import chimahon.DictionaryRepository
 import chimahon.MediaInfo
+import chimahon.anki.AnkiProfile
 import chimahon.anki.AnkiScreenshotMode
+import chimahon.anki.Marker
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryPopupWebViewWarmup
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
 import eu.kanade.tachiyomi.ui.dictionary.getDictionaryPaths
@@ -22,6 +24,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.OcrLookupPopup
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
@@ -52,6 +55,7 @@ internal data class SubtitleLookupRequest(
 internal fun PlayerSubtitleLookupPopup(
     viewModel: PlayerViewModel,
     request: SubtitleLookupRequest?,
+    sceneCapturePending: Boolean,
     onDismiss: () -> Unit,
     onTermMatched: (Int, Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -63,11 +67,13 @@ internal fun PlayerSubtitleLookupPopup(
     val episode by viewModel.currentEpisode.collectAsState()
     val source by viewModel.currentSource.collectAsState()
     val miningProgress by viewModel.sceneMiningProgress.collectAsState()
-    val activeProfile = remember(anime?.id, source?.id, source?.lang) {
-        dictionaryPreferences.profileResolver.resolve(
-            sourceId = source?.id ?: 0L,
-            sourceLang = source?.lang.orEmpty(),
-        )
+    val profileResolutionKey = DictionaryProfileResolutionKey(
+        animeId = anime?.id,
+        sourceId = source?.id,
+        sourceLang = source?.lang,
+    )
+    val activeProfile = remember(profileResolutionKey) {
+        dictionaryPreferences.profileResolver.resolveForPlayer(profileResolutionKey)
     }
     val webView: WebView = remember(activeProfile.languageCode) {
         DictionaryPopupWebViewWarmup.acquire(context, activeProfile.languageCode)
@@ -120,7 +126,7 @@ internal fun PlayerSubtitleLookupPopup(
             chapterName = episode?.name.orEmpty(),
         ),
         mediaRequest = mediaRequest,
-        miningBusy = miningProgress.isBusy,
+        miningBusy = sceneCapturePending || miningProgress.isBusy,
         launchMiningJob = launchMiningJob,
         onMiningBusy = {
             context.toast(KMR.strings.anki_scene_busy)
@@ -131,4 +137,23 @@ internal fun PlayerSubtitleLookupPopup(
         modifier = modifier,
         titleId = anime?.id?.toString(),
     )
+}
+
+/**
+ * Capturing a scene touches MPV and is unnecessary for a dictionary-only lookup.
+ */
+internal fun AnkiProfile.requiresSceneMediaCapture(): Boolean {
+    if (!ankiEnabled) return false
+
+    return runCatching {
+        val fieldMap = JSONObject(ankiFieldMap)
+        val fieldValues = fieldMap.keys().asSequence()
+            .map { key -> fieldMap.optString(key) }
+            .toList()
+        val capturesScreenshot =
+            AnkiScreenshotMode.fromStorageValue(ankiCropMode) != AnkiScreenshotMode.NONE &&
+                fieldValues.any { it.contains(Marker.SCREENSHOT) }
+        val capturesSentenceAudio = fieldValues.any { it.contains(Marker.SENTENCE_AUDIO) }
+        capturesScreenshot || capturesSentenceAudio
+    }.getOrDefault(false)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/SubtitleLookupState.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/SubtitleLookupState.kt
@@ -1,0 +1,82 @@
+package eu.kanade.tachiyomi.ui.player.controls
+
+import chimahon.anki.AnkiProfile
+import chimahon.dictionary.DictionaryProfileResolver
+
+internal enum class SubtitleLookupTapAction {
+    Dismiss,
+    Open,
+    Replace,
+}
+
+internal data class SubtitleLookupTapTransition(
+    val action: SubtitleLookupTapAction,
+    val cancelActiveCapture: Boolean,
+    val pausePlayer: Boolean,
+)
+
+internal enum class SubtitleLookupCaptureResultAction {
+    Apply,
+    Release,
+}
+
+internal data class DictionaryProfileResolutionKey(
+    val animeId: Long?,
+    val sourceId: Long?,
+    val sourceLang: String?,
+)
+
+internal fun subtitleLookupTapTransition(
+    matchesCurrentTap: Boolean,
+    hasOpenLookup: Boolean,
+    hasActiveCapture: Boolean,
+): SubtitleLookupTapTransition {
+    return when {
+        matchesCurrentTap -> SubtitleLookupTapTransition(
+            action = SubtitleLookupTapAction.Dismiss,
+            cancelActiveCapture = false,
+            pausePlayer = false,
+        )
+        hasOpenLookup || hasActiveCapture -> SubtitleLookupTapTransition(
+            action = SubtitleLookupTapAction.Replace,
+            cancelActiveCapture = hasActiveCapture,
+            pausePlayer = false,
+        )
+        else -> SubtitleLookupTapTransition(
+            action = SubtitleLookupTapAction.Open,
+            cancelActiveCapture = false,
+            pausePlayer = true,
+        )
+    }
+}
+
+internal fun subtitleLookupPauseStateAfterTap(
+    wasPlayerAlreadyPaused: Boolean,
+    playerWasPausedAtTap: Boolean,
+    pausePlayer: Boolean,
+): Boolean {
+    return if (pausePlayer) playerWasPausedAtTap else wasPlayerAlreadyPaused
+}
+
+internal fun subtitleLookupCaptureResultAction(
+    captureIsActive: Boolean,
+    captureGeneration: Int,
+    currentGeneration: Int,
+    hasOpenLookup: Boolean,
+): SubtitleLookupCaptureResultAction {
+    return if (captureIsActive && captureGeneration == currentGeneration && hasOpenLookup) {
+        SubtitleLookupCaptureResultAction.Apply
+    } else {
+        SubtitleLookupCaptureResultAction.Release
+    }
+}
+
+internal fun DictionaryProfileResolver.resolveForPlayer(
+    key: DictionaryProfileResolutionKey,
+): AnkiProfile {
+    return resolve(
+        mangaId = key.animeId ?: 0L,
+        sourceId = key.sourceId ?: 0L,
+        sourceLang = key.sourceLang.orEmpty(),
+    )
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/controls/SubtitleLookupStateTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/controls/SubtitleLookupStateTest.kt
@@ -1,0 +1,100 @@
+package eu.kanade.tachiyomi.ui.player.controls
+
+import chimahon.anki.AnkiProfile
+import chimahon.anki.AnkiProfileStore
+import chimahon.dictionary.DictionaryProfileResolver
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SubtitleLookupStateTest {
+
+    @Test
+    fun `a different subtitle tap replaces an in progress capture without pausing again`() {
+        val transition = subtitleLookupTapTransition(
+            matchesCurrentTap = false,
+            hasOpenLookup = true,
+            hasActiveCapture = true,
+        )
+
+        assertEquals(SubtitleLookupTapAction.Replace, transition.action)
+        assertTrue(transition.cancelActiveCapture)
+        assertFalse(transition.pausePlayer)
+        assertFalse(
+            subtitleLookupPauseStateAfterTap(
+                wasPlayerAlreadyPaused = false,
+                playerWasPausedAtTap = true,
+                pausePlayer = transition.pausePlayer,
+            ),
+        )
+    }
+
+    @Test
+    fun `a repeated subtitle tap dismisses the current lookup`() {
+        val transition = subtitleLookupTapTransition(
+            matchesCurrentTap = true,
+            hasOpenLookup = true,
+            hasActiveCapture = true,
+        )
+
+        assertEquals(SubtitleLookupTapAction.Dismiss, transition.action)
+    }
+
+    @Test
+    fun `profile resolution key changes with the anime id`() {
+        val firstAnime = DictionaryProfileResolutionKey(
+            animeId = 1L,
+            sourceId = 2L,
+            sourceLang = "ja",
+        )
+        val secondAnime = firstAnime.copy(animeId = 3L)
+
+        assertNotEquals(firstAnime, secondAnime)
+    }
+
+    @Test
+    fun `a late capture result is released after a newer lookup replaces it`() {
+        assertEquals(
+            SubtitleLookupCaptureResultAction.Release,
+            subtitleLookupCaptureResultAction(
+                captureIsActive = true,
+                captureGeneration = 1,
+                currentGeneration = 2,
+                hasOpenLookup = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `profile resolution applies the current anime override`() {
+        var profilesJson = "[]"
+        var activeProfileId = ""
+        val defaultProfile = AnkiProfile(id = "default", name = "Default", languageCode = "ja")
+        val animeProfile = AnkiProfile(id = "anime", name = "Anime", languageCode = "en")
+        val store = AnkiProfileStore(
+            readProfiles = { profilesJson },
+            writeProfiles = { profilesJson = it },
+            readActiveId = { activeProfileId },
+            writeActiveId = { activeProfileId = it },
+        )
+        store.saveProfiles(listOf(defaultProfile, animeProfile))
+        store.setActiveProfile(defaultProfile.id)
+        val resolver = DictionaryProfileResolver(
+            profileStore = store,
+            readMangaOverride = { mangaId -> if (mangaId == 42L) animeProfile.id else "" },
+            readSourceOverride = { "" },
+        )
+
+        val resolved = resolver.resolveForPlayer(
+            DictionaryProfileResolutionKey(
+                animeId = 42L,
+                sourceId = 7L,
+                sourceLang = "ja",
+            ),
+        )
+
+        assertEquals(animeProfile, resolved)
+    }
+}


### PR DESCRIPTION
## Problem

Subtitle lookup could wait for MPV scene capture before showing the dictionary. A second tap during that capture was ignored, leaving the user waiting on the previous selection.

## Changes

- Show the dictionary lookup request before optional scene-media capture completes.
- Cancel and supersede an active capture when the user taps a different subtitle term.
- Reject and release stale capture results with a generation check.
- Preserve the original player pause state across replacement lookups.
- Resolve dictionary profiles using the current anime ID, source, and language consistently in both player controls and popup.

## Result

A new subtitle selection replaces an in-progress capture instead of being ignored, while dictionary-only profiles avoid unnecessary MPV media capture.
