### PR TITLE
refactor(player): isolate scene FFmpeg processing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -216,6 +216,14 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- The process suffix MUST stay in sync with SceneCommandProcess.SUFFIX; App.onCreate keys
+             its lightweight-init early return off it. Renaming one without the other silently
+             reintroduces full DI/Conscrypt/WebView init in this FFmpeg-only child process. -->
+        <service
+            android:name=".ui.player.scene.IsolatedSceneCommandService"
+            android:exported="false"
+            android:process=":scene_processing" />
+
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
             android:value="eu.kanade.tachiyomi.ui.player.cast.CastOptionsProvider" />

--- a/app/src/main/aidl/eu/kanade/tachiyomi/ui/player/scene/ISceneCommandCallback.aidl
+++ b/app/src/main/aidl/eu/kanade/tachiyomi/ui/player/scene/ISceneCommandCallback.aidl
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.ui.player.scene;
+
+oneway interface ISceneCommandCallback {
+    void onCompleted(long requestId, boolean success, String output);
+}

--- a/app/src/main/aidl/eu/kanade/tachiyomi/ui/player/scene/ISceneCommandService.aidl
+++ b/app/src/main/aidl/eu/kanade/tachiyomi/ui/player/scene/ISceneCommandService.aidl
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.ui.player.scene;
+
+import eu.kanade.tachiyomi.ui.player.scene.ISceneCommandCallback;
+
+interface ISceneCommandService {
+    void execute(
+        long requestId,
+        int commandType,
+        in String[] arguments,
+        ISceneCommandCallback callback
+    );
+
+    void cancel(long requestId);
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -46,8 +46,8 @@ import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
-import eu.kanade.tachiyomi.data.coil.AnimeImageFetcher
 import eu.kanade.tachiyomi.data.coil.AnimeCoverKeyer
+import eu.kanade.tachiyomi.data.coil.AnimeImageFetcher
 import eu.kanade.tachiyomi.data.coil.AnimeKeyer
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher
@@ -65,6 +65,7 @@ import eu.kanade.tachiyomi.di.PreferenceModule
 import eu.kanade.tachiyomi.di.SYPreferenceModule
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.ui.base.delegate.SecureActivityDelegate
+import eu.kanade.tachiyomi.ui.player.scene.SceneCommandProcess
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.GLUtil
@@ -114,6 +115,15 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     @SuppressLint("LaunchActivityFromNotification")
     override fun onCreate() {
         super<Application>.onCreate()
+        if (SceneCommandProcess.isCurrent()) {
+            if (!LogcatLogger.isInstalled) {
+                LogcatLogger.install()
+            }
+            if (LogcatLogger.loggers.none { it is AndroidLogcatLogger }) {
+                LogcatLogger.loggers += AndroidLogcatLogger(LogPriority.INFO)
+            }
+            return
+        }
         patchInjekt()
 
         // KMK -->
@@ -223,7 +233,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         }
 
         initializeMigrator()
-        
+
         // Chimahon -->
         com.canopus.chimareader.data.NovelMigration.migrateOldBooks(this)
         chimahon.DictionaryRepository.migrateFlatDictionaries(File(getExternalFilesDir(null), "dictionaries"))
@@ -318,7 +328,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         // AM (DISCORD) -->
         DiscordRPCService.stop(applicationContext)
         // <-- AM (DISCORD)
-        
+
         eu.kanade.tachiyomi.glance.ChimahonWidgetManager.updateAllWidgets(this)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
@@ -26,7 +26,7 @@ internal class AndroidSceneCaptureService private constructor(
     constructor(context: Context) : this(
         sceneDirectory = File(context.cacheDir, SCENE_CACHE_DIRECTORY),
         inputAcquirer = AndroidSceneInputAcquirer(context),
-        commandExecutor = FfmpegKitSceneCommandExecutor(),
+        commandExecutor = IsolatedSceneCommandExecutor(context),
         validate = AnimatedAvifValidator::validate,
         av1EncoderName = ::platformAv1EncoderName,
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
@@ -40,16 +40,13 @@ internal class AndroidSceneInputAcquirer(
         }.getOrNull()
     }
 
+    /**
+     * Keep the SAF URI encoded until it reaches the process that owns FFmpegKit. A
+     * `/proc/self/fd/N` path is process-local and cannot be handed to the isolated worker.
+     */
     private fun acquireContentUri(value: String): SceneInputLease? {
-        val descriptor = runCatching {
-            applicationContext.contentResolver.openFileDescriptor(Uri.parse(value), "r")
-        }.getOrNull() ?: return null
-        return object : SceneInputLease {
-            override val ffmpegValue = "/proc/self/fd/${descriptor.fd}"
-            override val tlsCaFile: String? = null
-
-            override fun close() = descriptor.close()
-        }
+        val uri = runCatching { Uri.parse(value) }.getOrNull() ?: return null
+        return acquired(SceneSafInput.encodeForRead(uri))
     }
 
     private fun acquired(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/IsolatedSceneCommandExecutor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/IsolatedSceneCommandExecutor.kt
@@ -1,0 +1,226 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.resume
+
+/**
+ * Runs FFmpegKit in a dedicated process (`:scene_processing`).
+ *
+ * NOTE: an earlier version of this comment claimed the process split was required to avoid a
+ * duplicate-SONAME linker conflict between `aniyomi-mpv-lib` and `ffmpeg-kit`. That is not correct.
+ * `aniyomi-mpv-lib`'s AAR ships NO `libav*.so`; its `libmpv.so` DT_NEEDEDs `libavcodec.so`,
+ * `libavformat.so`, `libavutil.so`, etc., and `ffmpeg-kit` is the sole provider of those SONAMEs.
+ * Both consumers therefore share the one FFmpeg build already present in the process -- there is no
+ * competing second implementation and no ABI-level collision. Consistently, this app also invokes
+ * FFmpegKit in the main process from [eu.kanade.tachiyomi.data.animedownload.AnimeDownloader] and
+ * [eu.kanade.tachiyomi.util.storage.FFmpegUtils] without any such conflict.
+ *
+ * The remaining defensible reasons for a separate process are unproven here: isolating FFmpegKit's
+ * process-global state (log/statistics callbacks, session registry) from a live libmpv, and
+ * containing native crashes in the media path by allowing Android to terminate only the worker
+ * process. Neither is backed by a reproduction, so retain the process boundary pending explicit
+ * crash and process-global-state testing. A future change may fold scene mining back into the main
+ * process without a linker conflict, but a native crash there would terminate the whole app.
+ */
+internal class IsolatedSceneCommandExecutor(
+    context: Context,
+) : SceneCommandExecutor {
+    private val applicationContext = context.applicationContext
+
+    override suspend fun executeFfmpeg(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return execute(COMMAND_FFMPEG, arguments, onNativeFinished)
+    }
+
+    override suspend fun executeFfprobe(
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return execute(COMMAND_FFPROBE, arguments, onNativeFinished)
+    }
+
+    private suspend fun execute(
+        commandType: Int,
+        arguments: Array<String>,
+        onNativeFinished: () -> Unit,
+    ): SceneCommandResult {
+        return suspendCancellableCoroutine { continuation ->
+            val call = CommandCall(
+                context = applicationContext,
+                requestId = NEXT_REQUEST_ID.getAndIncrement(),
+                commandType = commandType,
+                arguments = arguments.copyOf(),
+                onNativeFinished = onNativeFinished,
+                deliver = { result ->
+                    if (continuation.isActive) {
+                        continuation.resume(result)
+                    }
+                },
+            )
+            continuation.invokeOnCancellation { call.cancel() }
+            call.bind()
+        }
+    }
+
+    private class CommandCall(
+        private val context: Context,
+        private val requestId: Long,
+        private val commandType: Int,
+        private val arguments: Array<String>,
+        private val onNativeFinished: () -> Unit,
+        private val deliver: (SceneCommandResult) -> Unit,
+    ) {
+        private val lock = Any()
+        private var remote: ISceneCommandService? = null
+        private var bound = false
+        private var submitted = false
+        private var finished = false
+
+        private val callback = object : ISceneCommandCallback.Stub() {
+            override fun onCompleted(
+                completedRequestId: Long,
+                success: Boolean,
+                output: String?,
+            ) {
+                if (completedRequestId != requestId) return
+                complete(
+                    if (success) {
+                        SceneCommandResult.Success(output.orEmpty())
+                    } else {
+                        SceneCommandResult.Failed
+                    },
+                )
+            }
+        }
+
+        private val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                val commandService = ISceneCommandService.Stub.asInterface(service)
+                    ?: run {
+                        complete(SceneCommandResult.Failed)
+                        return
+                    }
+                val submittedSuccessfully = synchronized(lock) {
+                    if (finished) {
+                        false
+                    } else {
+                        remote = commandService
+                        try {
+                            commandService.execute(requestId, commandType, arguments, callback)
+                            submitted = true
+                            true
+                        } catch (_: Exception) {
+                            false
+                        }
+                    }
+                }
+                if (!submittedSuccessfully) {
+                    complete(SceneCommandResult.Failed)
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                complete(SceneCommandResult.Failed)
+            }
+
+            override fun onBindingDied(name: ComponentName?) {
+                complete(SceneCommandResult.Failed)
+            }
+
+            override fun onNullBinding(name: ComponentName?) {
+                complete(SceneCommandResult.Failed)
+            }
+        }
+
+        fun bind() {
+            val didBind = runCatching {
+                context.bindService(
+                    Intent(context, IsolatedSceneCommandService::class.java),
+                    connection,
+                    Context.BIND_AUTO_CREATE or Context.BIND_IMPORTANT,
+                )
+            }.getOrDefault(false)
+            val shouldUnbind = synchronized(lock) {
+                bound = didBind
+                didBind && finished
+            }
+            if (shouldUnbind) {
+                synchronized(lock) {
+                    bound = false
+                }
+                runCatching { context.unbindService(connection) }
+            } else if (!didBind) {
+                complete(SceneCommandResult.Failed)
+            }
+        }
+
+        fun cancel() {
+            val action = synchronized(lock) {
+                when {
+                    finished -> CancelAction.None
+                    submitted -> CancelAction.Remote(remote)
+                    else -> {
+                        finished = true
+                        CancelAction.Local
+                    }
+                }
+            }
+            when (action) {
+                CancelAction.None -> Unit
+                CancelAction.Local -> finish(SceneCommandResult.Failed)
+                is CancelAction.Remote -> {
+                    try {
+                        action.service?.cancel(requestId)
+                    } catch (_: Exception) {
+                        complete(SceneCommandResult.Failed)
+                    }
+                }
+            }
+        }
+
+        private fun complete(result: SceneCommandResult) {
+            val shouldFinish = synchronized(lock) {
+                if (finished) {
+                    false
+                } else {
+                    finished = true
+                    true
+                }
+            }
+            if (shouldFinish) finish(result)
+        }
+
+        private fun finish(result: SceneCommandResult) {
+            runCatching(onNativeFinished)
+            deliver(result)
+            val shouldUnbind = synchronized(lock) {
+                remote = null
+                bound.also { bound = false }
+            }
+            if (shouldUnbind) {
+                runCatching { context.unbindService(connection) }
+            }
+        }
+
+        private sealed interface CancelAction {
+            data object None : CancelAction
+            data object Local : CancelAction
+            data class Remote(val service: ISceneCommandService?) : CancelAction
+        }
+    }
+
+    internal companion object {
+        const val COMMAND_FFMPEG = 1
+        const val COMMAND_FFPROBE = 2
+
+        private val NEXT_REQUEST_ID = AtomicLong(1L)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/IsolatedSceneCommandService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/IsolatedSceneCommandService.kt
@@ -1,0 +1,165 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.os.Process
+import com.arthenica.ffmpegkit.FFmpegKitConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import logcat.logcat
+import java.util.concurrent.ConcurrentHashMap
+
+class IsolatedSceneCommandService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val jobs = ConcurrentHashMap<Long, Job>()
+    private val executor by lazy(LazyThreadSafetyMode.NONE) {
+        FfmpegKitSceneCommandExecutor()
+    }
+
+    private val binder = object : ISceneCommandService.Stub() {
+        override fun execute(
+            requestId: Long,
+            commandType: Int,
+            arguments: Array<out String>?,
+            callback: ISceneCommandCallback?,
+        ) {
+            if (arguments == null || callback == null) return
+            val copiedArguments = Array(arguments.size) { arguments[it] }
+            logcat(LogPriority.DEBUG) {
+                "execute: accepted request=$requestId type=$commandType pid=${Process.myPid()}"
+            }
+            val job = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    val result = try {
+                        executeAndAwaitNative(commandType, copiedArguments)
+                    } catch (_: CancellationException) {
+                        SceneCommandResult.Failed
+                    } catch (_: Exception) {
+                        SceneCommandResult.Failed
+                    }
+                    withContext(NonCancellable) {
+                        logcat(LogPriority.DEBUG) {
+                            "execute: completed request=$requestId success=" +
+                                "${result is SceneCommandResult.Success} pid=${Process.myPid()}"
+                        }
+                        deliverResult(requestId, result, callback)
+                    }
+                } finally {
+                    jobs.remove(requestId)
+                }
+            }
+            // Request IDs come from a single AtomicLong in the one main-process executor, so they
+            // are unique for this service process's lifetime and cannot collide here.
+            jobs[requestId] = job
+            job.start()
+        }
+
+        override fun cancel(requestId: Long) {
+            jobs[requestId]?.cancel()
+        }
+    }
+
+    /**
+     * Delivers the result over the (oneway) callback, capping the payload well under Binder's ~1 MB
+     * transaction limit. An oversized successful output is reported as a failure with a distinct log
+     * line so it is not silently mistaken for a genuine ffmpeg/ffprobe failure.
+     */
+    private fun deliverResult(
+        requestId: Long,
+        result: SceneCommandResult,
+        callback: ISceneCommandCallback,
+    ) {
+        val output = (result as? SceneCommandResult.Success)?.output
+        val (success, payload) = when {
+            output == null -> false to ""
+            output.length <= MAX_SCENE_CALLBACK_OUTPUT_CHARS -> true to output
+            else -> {
+                logcat(LogPriority.WARN) {
+                    "execute: dropping oversized output request=$requestId chars=${output.length}"
+                }
+                false to ""
+            }
+        }
+        runCatching { callback.onCompleted(requestId, success, payload) }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        logcat(LogPriority.DEBUG) { "onCreate: isolated FFmpeg process pid=${Process.myPid()}" }
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private suspend fun executeAndAwaitNative(
+        commandType: Int,
+        arguments: Array<String>,
+    ): SceneCommandResult {
+        val nativeFinished = CompletableDeferred<Unit>()
+        val resolvedArguments = runCatching { resolveSafArguments(arguments) }.getOrNull() ?: run {
+            nativeFinished.complete(Unit)
+            return SceneCommandResult.Failed
+        }
+        var result: SceneCommandResult = SceneCommandResult.Failed
+        try {
+            result = when (commandType) {
+                IsolatedSceneCommandExecutor.COMMAND_FFMPEG -> {
+                    executor.executeFfmpeg(resolvedArguments) {
+                        nativeFinished.complete(Unit)
+                    }
+                }
+                IsolatedSceneCommandExecutor.COMMAND_FFPROBE -> {
+                    executor.executeFfprobe(resolvedArguments) {
+                        nativeFinished.complete(Unit)
+                    }
+                }
+                else -> {
+                    nativeFinished.complete(Unit)
+                    SceneCommandResult.Failed
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            result = SceneCommandResult.Failed
+        } finally {
+            withContext(NonCancellable) {
+                nativeFinished.await()
+            }
+        }
+        return result
+    }
+
+    private fun resolveSafArguments(arguments: Array<String>): Array<String>? {
+        return Array(arguments.size) { index ->
+            val value = arguments[index]
+            if (!SceneSafInput.isReadToken(value)) {
+                value
+            } else {
+                val uri = SceneSafInput.decodeForRead(value) ?: return null
+                FFmpegKitConfig.getSafParameterForRead(applicationContext, uri)
+                    ?.takeIf(String::isNotBlank)
+                    ?: return null
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_SCENE_CALLBACK_OUTPUT_CHARS = 128 * 1024
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCommandProcess.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCommandProcess.kt
@@ -1,0 +1,21 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.app.Application
+import android.os.Build
+import java.io.File
+
+internal object SceneCommandProcess {
+    // Must match android:process on IsolatedSceneCommandService in AndroidManifest.xml.
+    const val SUFFIX = ":scene_processing"
+
+    fun isCurrent(): Boolean = currentProcessName().endsWith(SUFFIX)
+
+    private fun currentProcessName(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Application.getProcessName()
+        }
+        return runCatching {
+            File("/proc/self/cmdline").readText().substringBefore('\u0000')
+        }.getOrDefault("")
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneSafInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneSafInput.kt
@@ -1,0 +1,32 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import android.net.Uri
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+ * Keeps a content URI out of FFmpeg arguments until they reach the process that owns FFmpegKit.
+ */
+internal object SceneSafInput {
+    private const val READ_PREFIX = "chimahon-saf-read:"
+
+    fun encodeForRead(uri: Uri): String {
+        require(uri.scheme.equals("content", ignoreCase = true))
+        val encoded = Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(uri.toString().toByteArray(StandardCharsets.UTF_8))
+        return READ_PREFIX + encoded
+    }
+
+    fun decodeForRead(value: String): Uri? {
+        if (!value.startsWith(READ_PREFIX)) return null
+        val encoded = value.removePrefix(READ_PREFIX)
+        val decoded = runCatching {
+            String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8)
+        }.getOrNull() ?: return null
+        return Uri.parse(decoded)
+            .takeIf { it.scheme.equals("content", ignoreCase = true) }
+    }
+
+    fun isReadToken(value: String): Boolean = value.startsWith(READ_PREFIX)
+}


### PR DESCRIPTION
> [!WARNING]
> **Ready for architecture review; not ready to merge without targeted validation.** This PR is intentionally candid: the original duplicate-native-library rationale was disproved, and there is not yet a reproduced crash proving that process isolation is required. Review should focus on whether the proposed boundary is justified and whether the validation plan is sufficient.

## The problem we are trying to contain

Animated scene capture runs ffprobe and FFmpeg while the player is live. In the original design those commands execute inside Chimahon's main app process, alongside libmpv and the rest of the UI.

That creates two plausible—but not yet reproduced here—risks:

1. **FFmpegKit owns process-global state**, including session bookkeeping and log/statistics callbacks. Scene capture can change or exercise that state while libmpv is active.
2. **A native fault in the scene-capture path terminates the whole app** when FFmpegKit runs in the main process. A Java mutex can serialize calls, but it cannot contain SIGSEGV/SIGABRT or reset corrupted process-global state.

The user-visible goal is therefore narrow: if scene FFmpeg/ffprobe fails catastrophically, lose the optional animated scene and fall back cleanly rather than taking the player and card-creation flow down with it.

## What we considered—and corrected

### “There are duplicate FFmpeg SONAMEs, so a second process is mandatory”

That was the first explanation, and it was wrong.

`aniyomi-mpv-lib` does **not** package a competing set of `libavcodec.so`, `libavformat.so`, and related libraries. Its `libmpv.so` depends on the FFmpeg libraries that FFmpegKit supplies. Chimahon also already calls FFmpegKit from `AnimeDownloader` and `FFmpegUtils` in the main process.

Because there is no second implementation to separate, mutexes, load ordering, symbol visibility, and `dlopen` tricks do not solve a real linker collision. This PR does not claim otherwise.

### Keep everything in-process and add a mutex

That remains the simplest design and may ultimately be the correct choice. A mutex can prevent concurrent FFmpegKit commands, but it cannot provide a native-crash boundary and does not isolate process-global callbacks/session state from the player.

### Spawn a command-line binary

Chimahon ships FFmpegKit libraries rather than a stable external executable. A subprocess wrapper would add packaging, ABI, permissions, argument transport, and lifecycle problems without using Android's service/process model.

## Why this specific design

The chosen boundary is an Android service declared as:

```xml
android:exported="false"
android:process=":scene_processing"
```

This gives scene capture a real address-space/process boundary while keeping the service private to the app.

The interface is deliberately small:

- AIDL carries a request ID, command type, argument array, and one-way completion callback.
- The main process binds only for the lifetime of a command and treats bind failure, binder death, null binding, or service disconnect as a failed optional animation.
- Request IDs come from one `AtomicLong`; the service tracks active jobs only for cancellation.
- Cancellation before submission prevents the command from starting. Cancellation after submission is forwarded to FFmpegKit.
- Cleanup waits for the native completion signal before input/output ownership is released, so cancellation cannot close a descriptor or delete a file still in native use.
- Callback output is capped at 128 Ki characters, well below Binder's transaction limit. Oversized successful output becomes a distinct logged failure rather than risking `TransactionTooLargeException`.

### Why SAF is tokenized

A `content://` URI cannot be converted to an FFmpegKit `saf:` parameter in one process and blindly reused in another. The native SAF registration must happen in the process that executes FFmpegKit.

The main process therefore sends a private, URL-safe encoded token. The worker decodes only `content` URIs and calls `FFmpegKitConfig.getSafParameterForRead()` locally. This avoids the earlier `/proc/self/fd/N` approach, whose descriptor/grant semantics do not survive a process boundary and can fail with `EACCES`.

### Why the worker has minimal application initialization

Android still invokes `Application.onCreate()` in a named child process. Repeating full DI, Conscrypt, WebView, migrations, widgets, and unrelated app startup work in an FFmpeg-only worker adds latency and new failure modes.

`App.onCreate()` detects the exact `:scene_processing` suffix, installs only logging, and returns. The manifest comment and `SceneCommandProcess.SUFFIX` cross-reference each other so renaming one side does not silently restore full initialization.

## Failure behavior

This PR does not make FFmpeg crash-proof. It changes the blast radius and normalizes failure:

- worker bind/death/error → scene command fails;
- oversized callback → logged scene failure;
- cancellation → native command is cancelled and awaited;
- invalid SAF token/registration → fail closed;
- service destruction → worker scope is cancelled;
- the surrounding capture flow retains its still-image fallback.

Only scene mining uses this boundary. Existing downloader/storage FFmpegKit callers remain in the main process.

## Scope

This PR contains only the worker-process plumbing:

- private manifest service;
- AIDL request/callback contracts;
- main-process executor and lifecycle handling;
- worker service and bounded result delivery;
- process-aware lightweight app startup;
- SAF token transport and worker-side registration.

It deliberately excludes:

- native FFmpeg fixes/dependency pin (#99);
- MediaCodec selection and AVIF capture portability (#101);
- player surface/PiP/UI lifecycle fixes (#102).

## Verification so far

- One commit directly on upstream `main`.
- Changed Kotlin/XML files pass scoped Spotless checks.
- `git diff --check` passes.
- `./gradlew :app:compileDebugKotlin` passes.
- Earlier integrated worker builds completed real scene-mining happy paths on:
  - [Lenovo TB132FU / Android 14](https://github.com/bee-san/chimahon/issues/17#issuecomment-5142526155)
  - [Samsung Galaxy S24 Ultra / Android 16](https://github.com/bee-san/chimahon/issues/17#issuecomment-5143060749)
  - [HiBy M500 / Android 14](https://github.com/bee-san/chimahon/issues/17#issuecomment-5143703608)
- Those runs validate predecessor integrated worktrees—not this exact standalone commit—and did not deliberately crash/kill the worker or reproduce process-global-state interference.
- Upstream PR CI currently stops at repository-wide Spotless failures in untouched baseline `domain` files before build/tests.

## Why this should not merge yet

The code establishes a defensible process boundary, but the premise still needs evidence. Additional limitations matter:

- this is a private app process under the normal application UID, **not** an Android isolated-UID security sandbox;
- the Base64 SAF token is transport encoding, not authorization or redaction;
- multiple scene requests still share one worker and its FFmpegKit global state;
- this split adds no AIDL/service instrumentation tests—the existing JVM scene tests inject a fake executor;
- command arguments cross Binder without an explicit aggregate-size cap;
- another process adds startup, memory, Binder, and lifecycle complexity.

Before merge:

- [ ] Reproduce or stress FFmpegKit process-global callback/session interference with live libmpv.
- [ ] Force-kill/crash the worker and verify the main player survives and the still fallback completes.
- [ ] Test cancellation before bind, during probe, and during encode.
- [ ] Test service disconnect/binder death and repeated bind/unbind cycles.
- [ ] Test SAF providers across worker restart and revoked grants.
- [ ] Stress ffprobe output above the Binder cap.
- [ ] Measure startup/memory cost versus keeping scene commands in-process.

If those tests do not demonstrate a benefit, the correct follow-up may be to drop this PR and keep the simpler in-process executor. The split exists so that decision can be made independently of the required portability fixes.
