### PR TITLE
fix(player): harden animated scene capture portability

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureService.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 
 internal fun interface SceneCaptureService {
     suspend fun prepare(request: SceneCaptureRequest): AnkiScreenshotPreparation
@@ -21,90 +22,209 @@ internal class AndroidSceneCaptureService private constructor(
     private val inputAcquirer: SceneInputAcquirer,
     private val commandExecutor: SceneCommandExecutor,
     private val validate: (File) -> AnimatedAvifInfo?,
-    private val av1EncoderName: () -> String?,
+    private val av1Encoder: (SceneVideoDimensions) -> Av1EncoderSelection?,
 ) : SceneCaptureService {
     constructor(context: Context) : this(
         sceneDirectory = File(context.cacheDir, SCENE_CACHE_DIRECTORY),
         inputAcquirer = AndroidSceneInputAcquirer(context),
         commandExecutor = FfmpegKitSceneCommandExecutor(),
         validate = AnimatedAvifValidator::validate,
-        av1EncoderName = ::platformAv1EncoderName,
+        av1Encoder = ::platformAv1Encoder,
     )
 
     override suspend fun prepare(request: SceneCaptureRequest): AnkiScreenshotPreparation {
-        val input = request.videoInput ?: return AnkiScreenshotPreparation.Failed(stillFallback = null)
-        val range = request.resolvedTiming?.animationRange
-            ?: return AnkiScreenshotPreparation.Failed(stillFallback = null)
-        val encoderName = av1EncoderName()
-        if (encoderName.isNullOrBlank()) {
+        val input = request.videoInput ?: run {
+            sceneLog { "prepare: videoInput was null" }
             return AnkiScreenshotPreparation.Failed(stillFallback = null)
         }
-
-        return withContext(Dispatchers.IO) {
-            if (!isSafe(input)) {
-                return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+        val range = request.resolvedTiming?.animationRange
+            ?: run {
+                sceneLog { "prepare: resolvedTiming.animationRange was null" }
+                return AnkiScreenshotPreparation.Failed(stillFallback = null)
             }
-            val lease = inputAcquirer.acquire(input)
-                ?: return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
-            sceneDirectory.mkdirs()
-            val output = File(sceneDirectory, "${UUID.randomUUID()}.avif")
-            val inputCleanup = SceneNativeCleanup(lease::close)
-            val outputCleanup = SceneNativeCleanup(output::delete)
-            var transferred = false
-            try {
-                val result = commandExecutor.executeFfmpeg(
-                    SceneFfmpegArguments.animatedAvif(
+
+        val undeliveredOutput = AtomicReference<SceneNativeCleanup?>()
+        return try {
+            val result = withContext(Dispatchers.IO) {
+                try {
+                    val sourceDimensions = inspectSafeVideo(input)
+                    if (sourceDimensions == null) {
+                        sceneLog { "prepare: input rejected by ffprobe safety check" }
+                        return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+                    }
+                    val encoder = av1Encoder(sourceDimensions)
+                        ?: run {
+                            sceneLog {
+                                "prepare: no usable av1 MediaCodec encoder found for " +
+                                    "${sourceDimensions.width}x${sourceDimensions.height}"
+                            }
+                            return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
+                        }
+                    sceneLog {
+                        "prepare: starting, encoder=${encoder.name} source=${sourceDimensions.width}x" +
+                            "${sourceDimensions.height} content=${encoder.contentSize.width}x" +
+                            "${encoder.contentSize.height} output=${encoder.outputSize.width}x" +
+                            "${encoder.outputSize.height} range=${range.startSeconds}..${range.endSeconds} " +
+                            "(${range.durationSeconds}s) input=${input.describe()}"
+                    }
+                    prepareOnIo(
                         input = input,
-                        acquiredInputValue = lease.ffmpegValue,
                         range = range,
-                        outputFile = output.absolutePath,
-                        encoderName = encoderName,
-                        tlsCaFile = lease.tlsCaFile,
-                    ),
-                ) {
+                        encoder = encoder,
+                        undeliveredOutput = undeliveredOutput,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    sceneLog(throwable = e) { "prepare: threw before scene generation" }
+                    AnkiScreenshotPreparation.Failed(stillFallback = null)
+                }
+            }
+            undeliveredOutput.set(null)
+            result
+        } finally {
+            undeliveredOutput.getAndSet(null)?.release()
+        }
+    }
+
+    private suspend fun prepareOnIo(
+        input: SceneVideoInputSpec,
+        range: SceneTimeRange,
+        encoder: Av1EncoderSelection,
+        undeliveredOutput: AtomicReference<SceneNativeCleanup?>,
+    ): AnkiScreenshotPreparation {
+        sceneDirectory.mkdirs()
+        val outputBaseName = UUID.randomUUID().toString()
+        val output = File(sceneDirectory, "$outputBaseName.avif")
+        val lease = inputAcquirer.acquire(input)
+            ?: run {
+                sceneLog { "prepare: could not acquire input lease" }
+                return AnkiScreenshotPreparation.Failed(stillFallback = null)
+            }
+        val encodeArguments = try {
+            SceneFfmpegArguments.animatedAvifMediaCodec(
+                input = input,
+                acquiredInputValue = lease.ffmpegValue,
+                range = range,
+                outputFile = output.absolutePath,
+                encoderName = encoder.name,
+                contentSize = encoder.contentSize,
+                outputSize = encoder.outputSize,
+                tlsCaFile = lease.tlsCaFile,
+            )
+        } catch (e: Exception) {
+            lease.close()
+            sceneLog(throwable = e) { "prepare: could not build AV1 encode arguments" }
+            return AnkiScreenshotPreparation.Failed(stillFallback = null)
+        }
+        val inputCleanup = SceneNativeCleanup(lease::close)
+        val outputCleanup = SceneNativeCleanup(output::delete)
+        var transferred = false
+        return try {
+            val encodeResult = try {
+                commandExecutor.executeFfmpeg(encodeArguments) {
                     inputCleanup.nativeFinished()
                     outputCleanup.nativeFinished()
                 }
-                when (result) {
-                    SceneCommandResult.Failed -> {
-                        return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
-                    }
-                    is SceneCommandResult.Success -> Unit
-                }
-                val info = validate(output)
-                    ?.takeIf {
-                        it.width in 1..MAX_OUTPUT_DIMENSION &&
-                            it.height in 1..MAX_OUTPUT_DIMENSION &&
-                            it.frameCount in 2..SceneFfmpegArguments.MAX_FRAME_COUNT &&
-                            it.totalDurationMillis > 0L
-                    }
-                    ?: return@withContext AnkiScreenshotPreparation.Failed(stillFallback = null)
-                val animation = AnkiMediaNaming.sceneFileSource(output)
-                transferred = true
-                AnkiScreenshotPreparation.Animated(
-                    animation = animation,
-                    stillFallback = null,
-                )
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
-                AnkiScreenshotPreparation.Failed(stillFallback = null)
-            } finally {
-                inputCleanup.release()
-                if (!transferred) outputCleanup.release()
+            } catch (e: Exception) {
+                inputCleanup.nativeFinished()
+                outputCleanup.nativeFinished()
+                throw e
+            }
+            inputCleanup.release()
+            when (encodeResult) {
+                SceneCommandResult.Failed -> {
+                    sceneLog { "prepare: direct av1_mediacodec AVIF encode failed" }
+                    return AnkiScreenshotPreparation.Failed(stillFallback = null)
+                }
+                is SceneCommandResult.Success -> Unit
+            }
+            val validated = validate(output)
+            if (validated == null) {
+                sceneLog { "prepare: AVIF structure validation failed, ${output.length()} bytes" }
+                return AnkiScreenshotPreparation.Failed(stillFallback = null)
+            }
+            val info = validated
+                .takeIf {
+                    it.width == encoder.outputSize.width &&
+                        it.height == encoder.outputSize.height &&
+                        it.frameCount in 2..SceneFfmpegArguments.MAX_FRAME_COUNT &&
+                        it.totalDurationMillis > 0L
+                }
+                ?: run {
+                    sceneLog {
+                        "prepare: AVIF outside selection, width=${validated.width} " +
+                            "height=${validated.height} expected=${encoder.outputSize.width}x" +
+                            "${encoder.outputSize.height} frameCount=${validated.frameCount} " +
+                            "(need 2..${SceneFfmpegArguments.MAX_FRAME_COUNT}) " +
+                            "durationMs=${validated.totalDurationMillis}"
+                    }
+                    return AnkiScreenshotPreparation.Failed(stillFallback = null)
+                }
+            val animation = AnkiMediaNaming.sceneFileSource(output)
+            val prepared = AnkiScreenshotPreparation.Animated(
+                animation = animation,
+                stillFallback = null,
+            )
+            undeliveredOutput.set(outputCleanup)
+            transferred = true
+            sceneLog {
+                "prepare: success, ${info.frameCount} frames ${info.width}x${info.height} " +
+                    "${info.totalDurationMillis}ms ${output.length()} bytes"
+            }
+            prepared
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            sceneLog(throwable = e) { "prepare: threw during scene generation" }
+            return AnkiScreenshotPreparation.Failed(stillFallback = null)
+        } finally {
+            inputCleanup.release()
+            if (!transferred) {
+                outputCleanup.release()
             }
         }
     }
 
-    private suspend fun isSafe(input: SceneVideoInputSpec): Boolean {
-        val lease = inputAcquirer.acquire(input) ?: return false
+    private suspend fun inspectSafeVideo(input: SceneVideoInputSpec): SceneVideoDimensions? {
+        val lease = inputAcquirer.acquire(input) ?: run {
+            sceneLog { "isSafe: could not acquire input lease for probe" }
+            return null
+        }
+        val arguments = try {
+            SceneFfmpegArguments.videoProbe(input, lease.ffmpegValue, lease.tlsCaFile)
+        } catch (e: Exception) {
+            lease.close()
+            sceneLog(throwable = e) { "isSafe: could not build ffprobe arguments" }
+            return null
+        }
         val cleanup = SceneNativeCleanup(lease::close)
         return try {
-            val result = commandExecutor.executeFfprobe(
-                SceneFfmpegArguments.videoProbe(input, lease.ffmpegValue, lease.tlsCaFile),
-                cleanup::nativeFinished,
-            )
-            result is SceneCommandResult.Success && SceneMediaProbe.inspect(result.output)
+            val result = try {
+                commandExecutor.executeFfprobe(arguments, cleanup::nativeFinished)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                cleanup.nativeFinished()
+                throw e
+            }
+            when (result) {
+                SceneCommandResult.Failed -> {
+                    sceneLog { "isSafe: ffprobe failed to run" }
+                    null
+                }
+                is SceneCommandResult.Success -> {
+                    // An absent pix_fmt and an HDR rejection both return false, so print the output.
+                    SceneMediaProbe.inspectVideo(result.output).also { inspected ->
+                        if (inspected == null) {
+                            val output = redactSceneLogLine(result.output)
+                            sceneLog { "isSafe: probe rejected input, ffprobe output=<<<$output>>>" }
+                        }
+                    }
+                }
+            }
         } finally {
             cleanup.release()
         }
@@ -112,25 +232,24 @@ internal class AndroidSceneCaptureService private constructor(
 
     internal companion object {
         private const val SCENE_CACHE_DIRECTORY = "chimahon_scene_capture"
-        private const val MAX_OUTPUT_DIMENSION = 640
 
         fun forTests(
             sceneDirectory: File,
             inputAcquirer: SceneInputAcquirer,
             commandExecutor: SceneCommandExecutor,
             validate: (File) -> AnimatedAvifInfo?,
-            av1EncoderName: () -> String? = { TEST_AV1_ENCODER_NAME },
+            av1Encoder: (SceneVideoDimensions) -> Av1EncoderSelection? = ::testAv1Encoder,
         ): AndroidSceneCaptureService {
             return AndroidSceneCaptureService(
                 sceneDirectory = sceneDirectory,
                 inputAcquirer = inputAcquirer,
                 commandExecutor = commandExecutor,
                 validate = validate,
-                av1EncoderName = av1EncoderName,
+                av1Encoder = av1Encoder,
             )
         }
 
-        private fun platformAv1EncoderName(): String? {
+        private fun platformAv1Encoder(source: SceneVideoDimensions): Av1EncoderSelection? {
             val mimeTypes = MimeTypeMap.getSingleton()
             val hasMimeMapping = mimeTypes.getMimeTypeFromExtension("avif")
                 ?.equals("image/avif", ignoreCase = true) == true &&
@@ -139,34 +258,68 @@ internal class AndroidSceneCaptureService private constructor(
             if (!hasMimeMapping) return null
 
             return runCatching {
-                MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+                val candidates = MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
                     .asSequence()
                     .filter(MediaCodecInfo::isEncoder)
                     .filter { info ->
                         info.supportedTypes.any { it.equals(AV1_MIME_TYPE, ignoreCase = true) }
                     }
-                    .firstOrNull { info ->
+                    .mapNotNull { info ->
                         runCatching {
                             val capabilities = info.getCapabilitiesForType(AV1_MIME_TYPE)
-                            val encoder = capabilities.encoderCapabilities ?: return@runCatching false
-                            val video = capabilities.videoCapabilities ?: return@runCatching false
-                            val supportsYuv420Planar = capabilities.colorFormats.contains(
-                                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
-                            )
-                            supportsYuv420Planar &&
-                                encoder.isBitrateModeSupported(
+                            val encoder = capabilities.encoderCapabilities ?: return@runCatching null
+                            val video = capabilities.videoCapabilities ?: return@runCatching null
+                            Av1EncoderCandidate(
+                                name = info.name,
+                                supportsPlanarYuv420 = capabilities.colorFormats.contains(
+                                    MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar,
+                                ),
+                                supportsConstantQuality = encoder.isBitrateModeSupported(
                                     MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CQ,
-                                ) &&
-                                encoder.qualityRange.contains(MEDIACODEC_QUALITY) &&
-                                video.areSizeAndRateSupported(
-                                    MAX_OUTPUT_DIMENSION,
-                                    MAX_OUTPUT_DIMENSION,
-                                    SceneFfmpegArguments.FRAME_RATE,
-                                )
-                        }.getOrDefault(false)
+                                ),
+                                supportsTargetQuality = encoder.qualityRange.contains(MEDIACODEC_QUALITY),
+                                widthAlignment = video.widthAlignment,
+                                heightAlignment = video.heightAlignment,
+                                minimumWidth = video.supportedWidths.lower,
+                                minimumHeight = video.supportedHeights.lower,
+                                maximumWidth = video.supportedWidths.upper,
+                                maximumHeight = video.supportedHeights.upper,
+                                supportedWidthsForHeight = { height ->
+                                    runCatching {
+                                        video.getSupportedWidthsFor(height)
+                                    }.getOrNull()?.let { range ->
+                                        range.lower..range.upper
+                                    }
+                                },
+                                supportsSizeAndRate = { size, rate ->
+                                    video.areSizeAndRateSupported(size.width, size.height, rate)
+                                },
+                            )
+                        }.getOrNull()
                     }
-                    ?.name
+                selectAv1Encoder(
+                    source = source,
+                    candidates = candidates,
+                    frameRate = SceneFfmpegArguments.FRAME_RATE,
+                )
             }.getOrNull()
+        }
+
+        private fun testAv1Encoder(source: SceneVideoDimensions): Av1EncoderSelection? {
+            return selectAv1Encoder(
+                source = source,
+                candidates = sequenceOf(
+                    Av1EncoderCandidate(
+                        name = TEST_AV1_ENCODER_NAME,
+                        supportsPlanarYuv420 = true,
+                        supportsConstantQuality = true,
+                        supportsTargetQuality = true,
+                        widthAlignment = SCENE_PIXEL_ALIGNMENT,
+                        heightAlignment = SCENE_PIXEL_ALIGNMENT,
+                        supportsSizeAndRate = { _, _ -> true },
+                    ),
+                ),
+            )
         }
 
         internal const val TEST_AV1_ENCODER_NAME = "test.av1.encoder"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneInputAcquirer.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.player.scene
 
 import android.content.Context
 import android.net.Uri
+import com.arthenica.ffmpegkit.FFmpegKitConfig
 import java.io.Closeable
 import java.io.File
 
@@ -40,16 +41,28 @@ internal class AndroidSceneInputAcquirer(
         }.getOrNull()
     }
 
+    /**
+     * FFmpeg must not be handed a `/proc/self/fd/N` path for a SAF document. Although FFmpegKit
+     * runs in this process and so shares the descriptor table, opening that symlink by path
+     * re-resolves to the real file and re-checks permissions against it. Shared storage is
+     * FUSE-backed and `media_rw`-owned, and the SAF grant attaches to the descriptor rather than
+     * to the path, so the reopen fails with `EACCES` and the probe rejects a perfectly good file.
+     *
+     * FFmpegKit's `saf:` protocol exists for this: it retains the [Uri] and opens the descriptor
+     * from inside the native handler, so the grant still applies.
+     */
     private fun acquireContentUri(value: String): SceneInputLease? {
-        val descriptor = runCatching {
-            applicationContext.contentResolver.openFileDescriptor(Uri.parse(value), "r")
-        }.getOrNull() ?: return null
-        return object : SceneInputLease {
-            override val ffmpegValue = "/proc/self/fd/${descriptor.fd}"
-            override val tlsCaFile: String? = null
-
-            override fun close() = descriptor.close()
+        val uri = runCatching { Uri.parse(value) }.getOrNull() ?: run {
+            sceneLog { "acquire: could not parse content uri" }
+            return null
         }
+        val safParameter = runCatching {
+            FFmpegKitConfig.getSafParameterForRead(applicationContext, uri)
+        }.getOrNull()?.takeIf(String::isNotBlank) ?: run {
+            sceneLog { "acquire: could not register content uri with FFmpegKit" }
+            return null
+        }
+        return acquired(safParameter)
     }
 
     private fun acquired(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidator.kt
@@ -74,6 +74,12 @@ internal object AnimatedAvifValidator {
             val (width, height) = parseSampleDescription(sampleBoxes.only("stsd") ?: return null) ?: return null
             val timing = parseTiming(sampleBoxes.only("stts") ?: return null) ?: return null
             val sizes = parseSizes(sampleBoxes.only("stsz") ?: return null) ?: return null
+            val syncTables = sampleBoxes.filter { it.type == "stss" }
+            if (syncTables.size > 1 ||
+                syncTables.singleOrNull()?.let { !hasFirstSyncSample(it, timing.frames) } == true
+            ) {
+                return null
+            }
             return Track(
                 width = width,
                 height = height,
@@ -153,6 +159,23 @@ internal object AnimatedAvifValidator {
                 offset += 4
             }
             return Sizes(frames.toInt(), total)
+        }
+
+        private fun hasFirstSyncSample(box: Box, frames: Int): Boolean {
+            if (box.dataSize < 12 || u32(box.start) != 0L) return false
+            val entries = u32(box.start + 4)
+            if (entries !in 1..frames.toLong() || box.dataSize.toLong() != 8L + entries * 4L) {
+                return false
+            }
+            var previous = 0L
+            var offset = box.start + 8
+            repeat(entries.toInt()) {
+                val sample = u32(offset)
+                if (sample <= previous || sample > frames) return false
+                previous = sample
+                offset += 4
+            }
+            return u32(box.start + 8) == 1L
         }
 
         private fun boxes(start: Int, end: Int): List<Box>? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/FfmpegKitSceneCommandExecutor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/FfmpegKitSceneCommandExecutor.kt
@@ -3,10 +3,13 @@ package eu.kanade.tachiyomi.ui.player.scene
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFprobeSession
+import com.arthenica.ffmpegkit.Level
 import com.arthenica.ffmpegkit.LogCallback
 import com.arthenica.ffmpegkit.LogRedirectionStrategy
 import com.arthenica.ffmpegkit.ReturnCode
+import com.arthenica.ffmpegkit.Session
 import com.arthenica.ffmpegkit.StatisticsCallback
+import eu.kanade.tachiyomi.data.animedownload.buildFFmpegFailureMessage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.concurrent.atomic.AtomicBoolean
@@ -37,24 +40,52 @@ internal interface SceneCommandExecutor {
 internal class SceneNativeCleanup(
     private val cleanup: () -> Unit,
 ) {
-    private val nativeFinished = AtomicBoolean(false)
-    private val released = AtomicBoolean(false)
-    private val cleaned = AtomicBoolean(false)
+    private val lock = Any()
+    private val initialNativeFinished = AtomicBoolean(false)
+    private var activeNativeUses = 1
+    private var released = false
+    private var cleaned = false
 
     fun nativeFinished() {
-        nativeFinished.set(true)
-        cleanIfReady()
+        finishNativeUse(initialNativeFinished)
+    }
+
+    fun retainNativeUse(): () -> Unit {
+        synchronized(lock) {
+            check(!released) { "Cannot retain a released native resource" }
+            activeNativeUses++
+        }
+        val finished = AtomicBoolean(false)
+        return {
+            finishNativeUse(finished)
+        }
     }
 
     fun release() {
-        released.set(true)
-        cleanIfReady()
+        val shouldClean = synchronized(lock) {
+            released = true
+            markCleanIfReady()
+        }
+        if (shouldClean) runCatching(cleanup)
     }
 
-    private fun cleanIfReady() {
-        if (nativeFinished.get() && released.get() && cleaned.compareAndSet(false, true)) {
-            runCatching(cleanup)
+    private fun finishNativeUse(finished: AtomicBoolean) {
+        if (finished.compareAndSet(false, true)) {
+            val shouldClean = synchronized(lock) {
+                check(activeNativeUses > 0)
+                activeNativeUses--
+                markCleanIfReady()
+            }
+            if (shouldClean) runCatching(cleanup)
         }
+    }
+
+    private fun markCleanIfReady(): Boolean {
+        if (activeNativeUses == 0 && released && !cleaned) {
+            cleaned = true
+            return true
+        }
+        return false
     }
 }
 
@@ -68,7 +99,7 @@ internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
                 FFmpegSession.create(
                     arguments,
                     {},
-                    DISCARD_LOG_CALLBACK,
+                    SCENE_LOG_CALLBACK,
                     DISCARD_STATISTICS_CALLBACK,
                     LogRedirectionStrategy.NEVER_PRINT_LOGS,
                 )
@@ -79,6 +110,7 @@ internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
                 if (ReturnCode.isSuccess(session.returnCode)) {
                     SceneCommandResult.Success()
                 } else {
+                    sceneLog { "ffmpeg: ${session.describeFailure()}" }
                     SceneCommandResult.Failed
                 }
             },
@@ -95,7 +127,7 @@ internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
                 FFprobeSession.create(
                     arguments,
                     {},
-                    DISCARD_LOG_CALLBACK,
+                    SCENE_LOG_CALLBACK,
                     LogRedirectionStrategy.NEVER_PRINT_LOGS,
                 )
             },
@@ -105,6 +137,7 @@ internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
                 if (ReturnCode.isSuccess(session.returnCode)) {
                     SceneCommandResult.Success(session.output.orEmpty())
                 } else {
+                    sceneLog { "ffprobe: ${session.describeFailure()}" }
                     SceneCommandResult.Failed
                 }
             },
@@ -201,7 +234,28 @@ internal class FfmpegKitSceneCommandExecutor : SceneCommandExecutor {
     }
 
     private companion object {
-        val DISCARD_LOG_CALLBACK = LogCallback {}
         val DISCARD_STATISTICS_CALLBACK = StatisticsCallback {}
+
+        /**
+         * FFmpegKit hands every line to the session callback before consulting the redirection
+         * strategy, so [LogRedirectionStrategy.NEVER_PRINT_LOGS] still yields the full output here
+         * while suppressing FFmpegKit's own unredacted logcat writes.
+         */
+        val SCENE_LOG_CALLBACK = LogCallback { log ->
+            if (log.level.value <= Level.AV_LOG_WARNING.value) {
+                log.message?.takeIf(String::isNotBlank)?.let { message ->
+                    sceneLog { "ffmpeg output: ${redactSceneLogLine(message)}" }
+                }
+            }
+        }
+
+        fun Session.describeFailure(): String {
+            val message = buildFFmpegFailureMessage(
+                exitCode = returnCode?.toString() ?: "<none>",
+                failStackTrace = failStackTrace,
+                logs = allLogsAsString,
+            )
+            return redactSceneLogLine(message)
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/PlayerSceneMiningCoordinator.kt
@@ -26,7 +26,10 @@ internal fun interface SceneStillFallbackEncoder {
 
 internal object AndroidSceneStillFallbackEncoder : SceneStillFallbackEncoder {
     override suspend fun encode(request: SceneCaptureRequest): AnkiMediaSource.Bytes? {
-        val bitmap = request.fallbackBitmapOrNull() ?: return null
+        val bitmap = request.fallbackBitmapOrNull() ?: run {
+            sceneLog { "stillFallback: no bitmap available" }
+            return null
+        }
         return withContext(Dispatchers.Default) {
             try {
                 val bytes = ImageEncoder.encode(bitmap).bytes.takeIf(ByteArray::isNotEmpty) ?: return@withContext null
@@ -40,7 +43,8 @@ internal object AndroidSceneStillFallbackEncoder : SceneStillFallbackEncoder {
                 )
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                sceneLog(throwable = e) { "stillFallback: encode threw" }
                 null
             }
         }
@@ -120,6 +124,7 @@ internal class PlayerSceneMiningCoordinator(
         request: SceneCaptureRequest,
         mode: AnkiScreenshotMode,
     ): AnkiScreenshotPreparation {
+        sceneLog { "prepareScreenshot: resolved screenshot mode=${mode.storageValue}" }
         return when (mode) {
             AnkiScreenshotMode.NONE -> AnkiScreenshotPreparation.Still(null)
             AnkiScreenshotMode.FULL,
@@ -177,6 +182,10 @@ internal class PlayerSceneMiningCoordinator(
             request.videoInput == null ||
             request.resolvedTiming == null
         ) {
+            sceneLog {
+                "prepareAnimated: bailed before capture, videoInput null=${request.videoInput == null} " +
+                    "resolvedTiming null=${request.resolvedTiming == null}"
+            }
             return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
         }
         val prepared = try {
@@ -184,13 +193,16 @@ internal class PlayerSceneMiningCoordinator(
                 sceneCaptureService().prepare(request)
             }
         } catch (_: TimeoutCancellationException) {
+            sceneLog { "prepareAnimated: timed out after ${sceneTimeoutMillis}ms" }
             return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            sceneLog(throwable = e) { "prepareAnimated: capture threw" }
             return AnkiScreenshotPreparation.Failed(stillEncoder.encode(request))
         }
         if (prepared !is AnkiScreenshotPreparation.Animated) {
+            sceneLog { "prepareAnimated: capture returned ${prepared::class.simpleName}, not Animated" }
             return prepared.withStillFallback(request)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneAv1EncoderSelector.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneAv1EncoderSelector.kt
@@ -1,0 +1,299 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import kotlin.math.abs
+import kotlin.math.min
+
+internal data class SceneVideoDimensions(
+    val width: Int,
+    val height: Int,
+)
+
+internal data class Av1EncoderCandidate(
+    val name: String,
+    val supportsPlanarYuv420: Boolean,
+    val supportsConstantQuality: Boolean,
+    val supportsTargetQuality: Boolean,
+    val widthAlignment: Int,
+    val heightAlignment: Int,
+    val minimumWidth: Int = 1,
+    val minimumHeight: Int = 1,
+    val maximumWidth: Int = Int.MAX_VALUE,
+    val maximumHeight: Int = Int.MAX_VALUE,
+    val supportedWidthsForHeight: (Int) -> IntRange? = {
+        minimumWidth..maximumWidth
+    },
+    val supportsSizeAndRate: (SceneVideoDimensions, Double) -> Boolean,
+)
+
+internal data class Av1EncoderSelection(
+    val name: String,
+    val contentSize: SceneVideoDimensions,
+    val outputSize: SceneVideoDimensions,
+)
+
+internal fun selectAv1Encoder(
+    source: SceneVideoDimensions,
+    candidates: Sequence<Av1EncoderCandidate>,
+    frameRate: Double = SCENE_FRAME_RATE,
+): Av1EncoderSelection? {
+    if (source.width <= 0 || source.height <= 0) return null
+    if (!frameRate.isFinite() || frameRate <= 0.0) return null
+    val boundedOutputDimension = SCENE_MAX_OUTPUT_DIMENSION
+
+    var bestSelection: Av1EncoderSelection? = null
+    candidates.forEach { candidate ->
+        if (candidate.name.isBlank() ||
+            !candidate.supportsPlanarYuv420 ||
+            !candidate.supportsConstantQuality ||
+            !candidate.supportsTargetQuality ||
+            candidate.widthAlignment <= 0 ||
+            candidate.heightAlignment <= 0 ||
+            candidate.minimumWidth <= 0 ||
+            candidate.minimumHeight <= 0 ||
+            candidate.maximumWidth < candidate.minimumWidth ||
+            candidate.maximumHeight < candidate.minimumHeight
+        ) {
+            return@forEach
+        }
+
+        val widthAlignment = combinedAlignment(candidate.widthAlignment, SCENE_MEDIACODEC_CANVAS_ALIGNMENT)
+            ?: return@forEach
+        val heightAlignment = combinedAlignment(candidate.heightAlignment, SCENE_MEDIACODEC_CANVAS_ALIGNMENT)
+            ?: return@forEach
+        if (widthAlignment > boundedOutputDimension || heightAlignment > boundedOutputDimension) {
+            return@forEach
+        }
+        val checkedSizes = mutableSetOf<SceneVideoDimensions>()
+        val queriedHeights = mutableSetOf<Int>()
+        val widthRanges = mutableMapOf<Int, IntRange?>()
+        val selection = (boundedOutputDimension downTo SCENE_PIXEL_ALIGNMENT)
+            .firstNotNullOfOrNull { contentCap ->
+                val contentSize = scaledSceneSize(
+                    source = source,
+                    maxOutputDimension = contentCap,
+                    widthAlignment = SCENE_PIXEL_ALIGNMENT,
+                    heightAlignment = SCENE_PIXEL_ALIGNMENT,
+                ) ?: return@firstNotNullOfOrNull null
+                val outputSize = supportedCanvasSize(
+                    contentSize = contentSize,
+                    candidate = candidate,
+                    widthAlignment = widthAlignment,
+                    heightAlignment = heightAlignment,
+                    frameRate = frameRate,
+                    maxOutputDimension = boundedOutputDimension,
+                    checkedSizes = checkedSizes,
+                    queriedHeights = queriedHeights,
+                    widthRanges = widthRanges,
+                ) ?: return@firstNotNullOfOrNull null
+                Av1EncoderSelection(
+                    name = candidate.name,
+                    contentSize = contentSize,
+                    outputSize = outputSize,
+                )
+            }
+            ?: return@forEach
+        if (selection.isBetterThan(bestSelection, source)) {
+            bestSelection = selection
+        }
+    }
+    return bestSelection
+}
+
+private fun supportedCanvasSize(
+    contentSize: SceneVideoDimensions,
+    candidate: Av1EncoderCandidate,
+    widthAlignment: Int,
+    heightAlignment: Int,
+    frameRate: Double,
+    maxOutputDimension: Int,
+    checkedSizes: MutableSet<SceneVideoDimensions>,
+    queriedHeights: MutableSet<Int>,
+    widthRanges: MutableMap<Int, IntRange?>,
+): SceneVideoDimensions? {
+    val minimumWidth = maxOf(contentSize.width, candidate.minimumWidth)
+        .alignUp(widthAlignment, maxOutputDimension)
+        ?: return null
+    val minimumHeight = maxOf(contentSize.height, candidate.minimumHeight)
+        .alignUp(heightAlignment, maxOutputDimension)
+        ?: return null
+    val maximumWidth = min(candidate.maximumWidth, maxOutputDimension)
+        .alignDown(widthAlignment)
+    val maximumHeight = min(candidate.maximumHeight, maxOutputDimension)
+        .alignDown(heightAlignment)
+    if (minimumWidth > maximumWidth || minimumHeight > maximumHeight) return null
+
+    var best: SceneVideoDimensions? = null
+    var height = minimumHeight
+    while (height <= maximumHeight) {
+        val bestArea = best?.let { it.width.toLong() * it.height }
+        if (bestArea != null && height.toLong() * minimumWidth >= bestArea) break
+
+        val widthRange = if (queriedHeights.add(height)) {
+            runCatching {
+                candidate.supportedWidthsForHeight(height)
+            }.getOrNull().also { widthRanges[height] = it }
+        } else {
+            widthRanges[height]
+        }
+        if (widthRange != null && !widthRange.isEmpty()) {
+            val rangeMaximum = min(widthRange.last, maximumWidth)
+            var width = maxOf(minimumWidth, widthRange.first)
+                .alignUp(widthAlignment, rangeMaximum)
+            while (width != null && width <= rangeMaximum) {
+                if (bestArea != null && height.toLong() * width >= bestArea) break
+                val outputSize = SceneVideoDimensions(width = width, height = height)
+                val supported = checkedSizes.add(outputSize) &&
+                    runCatching {
+                        candidate.supportsSizeAndRate(outputSize, frameRate)
+                    }.getOrDefault(false)
+                if (supported) {
+                    best = outputSize
+                    if (outputSize == contentSize) return outputSize
+                    break
+                }
+                width = (width + widthAlignment)
+                    .takeIf { it <= rangeMaximum }
+            }
+        }
+        height += heightAlignment
+    }
+    return best
+}
+
+private fun Int.alignUp(alignment: Int, maximum: Int): Int? {
+    val aligned = ((toLong() + alignment - 1L) / alignment) * alignment
+    return aligned
+        .takeIf { it in alignment.toLong()..maximum.toLong() }
+        ?.toInt()
+}
+
+private fun scaledSceneSize(
+    source: SceneVideoDimensions,
+    maxOutputDimension: Int,
+    widthAlignment: Int,
+    heightAlignment: Int,
+): SceneVideoDimensions? {
+    val (fittedWidth, fittedHeight) = when {
+        source.width <= maxOutputDimension && source.height <= maxOutputDimension -> {
+            source.width to source.height
+        }
+        source.width >= source.height -> {
+            maxOutputDimension to
+                (maxOutputDimension.toLong() * source.height / source.width).toInt()
+        }
+        else -> {
+            (maxOutputDimension.toLong() * source.width / source.height).toInt() to
+                maxOutputDimension
+        }
+    }
+    val maximumWidth = fittedWidth.alignDown(widthAlignment)
+    val maximumHeight = fittedHeight.alignDown(heightAlignment)
+    if (maximumWidth < widthAlignment || maximumHeight < heightAlignment) return null
+
+    var best: SceneVideoDimensions? = null
+    fun consider(width: Int, height: Int) {
+        if (width !in widthAlignment..maximumWidth ||
+            height !in heightAlignment..maximumHeight ||
+            width % widthAlignment != 0 ||
+            height % heightAlignment != 0
+        ) {
+            return
+        }
+        val candidate = SceneVideoDimensions(width = width, height = height)
+        if (candidate.aspectErrorFrom(source) > MAX_CONTENT_ASPECT_ERROR) return
+        if (candidate.isBetterContentThan(best, source)) {
+            best = candidate
+        }
+    }
+
+    alignedValueClosest(
+        numerator = maximumWidth.toLong() * source.height,
+        denominator = source.width.toLong(),
+        alignment = heightAlignment,
+        maximum = maximumHeight,
+    )?.let { height -> consider(maximumWidth, height) }
+    alignedValueClosest(
+        numerator = maximumHeight.toLong() * source.width,
+        denominator = source.height.toLong(),
+        alignment = widthAlignment,
+        maximum = maximumWidth,
+    )?.let { width -> consider(width, maximumHeight) }
+    return best
+}
+
+private fun alignedValueClosest(
+    numerator: Long,
+    denominator: Long,
+    alignment: Int,
+    maximum: Int,
+): Int? {
+    val alignedUnitDenominator = denominator * alignment
+    val floorUnits = numerator / alignedUnitDenominator
+    return sequenceOf(floorUnits, floorUnits + 1L)
+        .filter { units -> units in 1..(maximum / alignment).toLong() }
+        .map { units -> (units * alignment).toInt() }
+        .distinct()
+        .minWithOrNull(
+            compareBy<Int> { value ->
+                abs(numerator - value.toLong() * denominator)
+            }.thenByDescending { it },
+        )
+}
+
+private fun Int.alignDown(alignment: Int): Int {
+    return this - (this % alignment)
+}
+
+private fun SceneVideoDimensions.isBetterContentThan(
+    other: SceneVideoDimensions?,
+    source: SceneVideoDimensions,
+): Boolean {
+    other ?: return true
+    val area = width.toLong() * height
+    val otherArea = other.width.toLong() * other.height
+    if (area != otherArea) return area > otherArea
+    val aspectError = aspectErrorFrom(source)
+    val otherAspectError = other.aspectErrorFrom(source)
+    if (aspectError != otherAspectError) return aspectError < otherAspectError
+    if (width != other.width) return width > other.width
+    return height > other.height
+}
+
+private fun Av1EncoderSelection.isBetterThan(
+    other: Av1EncoderSelection?,
+    source: SceneVideoDimensions,
+): Boolean {
+    other ?: return true
+    if (contentSize != other.contentSize) {
+        val thisIsBetter = contentSize.isBetterContentThan(other.contentSize, source)
+        val otherIsBetter = other.contentSize.isBetterContentThan(contentSize, source)
+        if (thisIsBetter != otherIsBetter) return thisIsBetter
+    }
+    val outputArea = outputSize.width.toLong() * outputSize.height
+    val otherOutputArea = other.outputSize.width.toLong() * other.outputSize.height
+    return outputArea < otherOutputArea
+}
+
+private fun SceneVideoDimensions.aspectErrorFrom(source: SceneVideoDimensions): Double {
+    val scaledSourceWidth = width.toLong() * source.height
+    val scaledOutputWidth = height.toLong() * source.width
+    return abs(scaledSourceWidth - scaledOutputWidth).toDouble() / scaledOutputWidth
+}
+
+private fun combinedAlignment(first: Int, second: Int): Int? {
+    var a = first
+    var b = second
+    while (b != 0) {
+        val remainder = a % b
+        a = b
+        b = remainder
+    }
+    val combined = first.toLong() / a * second
+    return combined.takeIf { it in 1..Int.MAX_VALUE }?.toInt()
+}
+
+internal const val SCENE_MAX_OUTPUT_DIMENSION = 640
+internal const val SCENE_PIXEL_ALIGNMENT = 2
+internal const val SCENE_MEDIACODEC_CANVAS_ALIGNMENT = 16
+internal const val SCENE_FRAME_RATE = 8.0
+private const val MAX_CONTENT_ASPECT_ERROR = 0.002

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequest.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneCaptureRequest.kt
@@ -157,16 +157,28 @@ internal class SceneMpvSnapshotReader(
     fun read(): SceneMpvSnapshot? {
         val anchor = properties.double("time-pos")
             ?.takeIf { it.isFinite() && it >= 0.0 }
-            ?: return null
+            ?: run {
+                sceneLog { "mpvSnapshot: unusable time-pos" }
+                return null
+            }
         val duration = properties.double("duration")
             ?.takeIf { it.isFinite() && it >= 0.0 }
         val speed = properties.double("sub-speed")
             ?.takeIf { it.isFinite() && it > 0.0 }
-            ?: return null
+            ?: run {
+                sceneLog { "mpvSnapshot: unusable sub-speed" }
+                return null
+            }
         val delay = properties.double("sub-delay")
             ?.takeIf(Double::isFinite)
-            ?: return null
-        val selectedVideo = selectedVideo() ?: return null
+            ?: run {
+                sceneLog { "mpvSnapshot: unusable sub-delay" }
+                return null
+            }
+        val selectedVideo = selectedVideo() ?: run {
+            sceneLog { "mpvSnapshot: no selected internal video track with a valid ff-index" }
+            return null
+        }
         val selectedAudio = selectedAudio()
 
         return SceneMpvSnapshot(
@@ -293,14 +305,36 @@ internal class SceneCaptureRequestFactory(
         captureFallback: suspend () -> Bitmap?,
         resolveTiming: (SceneMpvSnapshot) -> SceneResolvedTiming?,
     ): SceneCaptureRequest? {
-        val beforeMpv = mpvSnapshotReader.read() ?: return null
-        val beforeVideo = videoSnapshot(beforeMpv) ?: return null
-        val fallback = captureFallback() ?: return null
+        val beforeMpv = mpvSnapshotReader.read() ?: run {
+            sceneLog { "capture: could not read mpv snapshot before still capture" }
+            return null
+        }
+        val beforeVideo = videoSnapshot(beforeMpv) ?: run {
+            sceneLog { "capture: no video snapshot before still capture (currentVideo null?)" }
+            return null
+        }
+        val fallback = captureFallback() ?: run {
+            sceneLog { "capture: still-frame capture returned no bitmap" }
+            return null
+        }
         var transferred = false
         try {
-            val afterMpv = mpvSnapshotReader.read() ?: return null
-            val afterVideo = videoSnapshot(afterMpv) ?: return null
-            if (!sameCaptureState(beforeMpv, afterMpv) || beforeVideo != afterVideo) return null
+            val afterMpv = mpvSnapshotReader.read() ?: run {
+                sceneLog { "capture: could not read mpv snapshot after still capture" }
+                return null
+            }
+            val afterVideo = videoSnapshot(afterMpv) ?: run {
+                sceneLog { "capture: no video snapshot after still capture" }
+                return null
+            }
+            if (!sameCaptureState(beforeMpv, afterMpv) || beforeVideo != afterVideo) {
+                sceneLog {
+                    "capture: player state changed during capture, " +
+                        "divergence=${describeDivergence(beforeMpv, afterMpv)} " +
+                        "videoSnapshotChanged=${beforeVideo != afterVideo}"
+                }
+                return null
+            }
 
             val videoInput = SceneVideoInputResolver.resolve(beforeVideo.video)
             val sentenceAudioInput = when {
@@ -311,10 +345,17 @@ internal class SceneCaptureRequestFactory(
                     beforeMpv.selectedAudioFfmpegIndex == null -> null
                 else -> videoInput
             }
+            val resolvedTiming = resolveTiming(beforeMpv)
+            sceneLog {
+                "capture: resolved videoInput=${videoInput?.describe() ?: "null"} " +
+                    "resolvedTiming=${resolvedTiming?.animationRange?.let {
+                        "${it.startSeconds}..${it.endSeconds}"
+                    } ?: "null"}"
+            }
             val request = SceneCaptureRequest(
                 videoInput = videoInput,
                 sentenceAudioInput = sentenceAudioInput,
-                resolvedTiming = resolveTiming(beforeMpv),
+                resolvedTiming = resolvedTiming,
                 stillFallback = OwnedBitmap(fallback),
             )
             transferred = true
@@ -322,6 +363,34 @@ internal class SceneCaptureRequestFactory(
         } finally {
             if (!transferred && !fallback.isRecycled) fallback.recycle()
         }
+    }
+
+    /** Names the fields that moved, so a spurious rejection can be told from a real seek. */
+    private fun describeDivergence(before: SceneMpvSnapshot, after: SceneMpvSnapshot): String {
+        val changed = buildList {
+            if (!closeEnough(
+                    before.anchorMediaSeconds,
+                    after.anchorMediaSeconds,
+                    SCENE_ANCHOR_TOLERANCE_SECONDS,
+                )
+            ) {
+                add("anchor(${before.anchorMediaSeconds}->${after.anchorMediaSeconds})")
+            }
+            if (!nullableDoubleEquals(before.mediaDurationSeconds, after.mediaDurationSeconds)) add("duration")
+            if (!nullableDoubleEquals(before.subtitleStartSeconds, after.subtitleStartSeconds)) add("subStart")
+            if (!nullableDoubleEquals(before.subtitleEndSeconds, after.subtitleEndSeconds)) add("subEnd")
+            if (!nullableDoubleEquals(before.subtitleSpeed, after.subtitleSpeed)) add("subSpeed")
+            if (!nullableDoubleEquals(before.subtitleDelaySeconds, after.subtitleDelaySeconds)) add("subDelay")
+            if (before.playableValue != after.playableValue) add("playableValue")
+            if (before.selectedVideoId != after.selectedVideoId) add("videoId")
+            if (before.selectedVideoFfmpegIndex != after.selectedVideoFfmpegIndex) add("videoFfIndex")
+            if (before.selectedAudioId != after.selectedAudioId) add("audioId")
+            if (before.selectedExternalAudioValue != after.selectedExternalAudioValue) add("externalAudio")
+            if (before.selectedAudioIsExternal != after.selectedAudioIsExternal) add("audioIsExternal")
+            if (before.seekable != after.seekable) add("seekable")
+            if (before.selectedAudioFfmpegIndex != after.selectedAudioFfmpegIndex) add("audioFfIndex")
+        }
+        return if (changed.isEmpty()) "none" else changed.joinToString(",")
     }
 
     private fun sameCaptureState(before: SceneMpvSnapshot, after: SceneMpvSnapshot): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbe.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbe.kt
@@ -1,14 +1,78 @@
 package eu.kanade.tachiyomi.ui.player.scene
 
 import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 internal object SceneMediaProbe {
     fun inspect(output: String): Boolean {
+        return isSafeVideo(output, parseValues(output))
+    }
+
+    fun inspectVideo(output: String): SceneVideoDimensions? {
+        val values = parseValues(output)
+        if (!isSafeVideo(output, values)) return null
+
+        val width = values.firstOrNull { it.first == "width" }?.second?.toIntOrNull()
+            ?.takeIf { it > 0 }
+            ?: return null
+        val height = values.firstOrNull { it.first == "height" }?.second?.toIntOrNull()
+            ?.takeIf { it > 0 }
+            ?: return null
+        val sampleAspectRatio = values
+            .firstOrNull { it.first == "sample_aspect_ratio" }
+            ?.second
+            .toSampleAspectRatio()
+        val displayWidthValue = width.toDouble() * sampleAspectRatio
+        if (!displayWidthValue.isFinite() || displayWidthValue !in 1.0..Int.MAX_VALUE.toDouble()) {
+            return null
+        }
+        val displayWidth = displayWidthValue.roundToInt()
+        val rotationValue = values.firstOrNull { it.first == "rotation" }?.second
+            ?.toDoubleOrNull()
+            ?: 0.0
+        if (!rotationValue.isFinite()) return null
+        val normalizedRotationValue = ((rotationValue % 360.0) + 360.0) % 360.0
+        val rotation = normalizedRotationValue.roundToInt()
+        if (abs(normalizedRotationValue - rotation) > ROTATION_EPSILON || rotation % 90 != 0) {
+            return null
+        }
+        val normalizedRotation = ((rotation % 360) + 360) % 360
+        return if (normalizedRotation == 90 || normalizedRotation == 270) {
+            SceneVideoDimensions(width = height, height = displayWidth)
+        } else {
+            SceneVideoDimensions(width = displayWidth, height = height)
+        }
+    }
+
+    fun inspectAudio(output: String): Boolean {
+        val normalized = output.lowercase(Locale.ROOT)
+        return PROTECTION_MARKERS.none(normalized::contains) && "codec_type=audio" in normalized
+    }
+
+    private fun isSafeVideo(
+        output: String,
+        values: List<Pair<String, String>>,
+    ): Boolean {
         val normalized = output.lowercase(Locale.ROOT)
         if (PROTECTION_MARKERS.any(normalized::contains)) {
             return false
         }
-        val values = output.lineSequence()
+        val pixelFormat = values.firstOrNull { it.first == "pix_fmt" }?.second
+            ?: return false
+        if (pixelFormat in setOf("none", "unknown")) {
+            return false
+        }
+        val transfer = values.firstOrNull { it.first == "color_transfer" }?.second.orEmpty()
+        val primaries = values.firstOrNull { it.first == "color_primaries" }?.second.orEmpty()
+        if (transfer in HDR_TRANSFERS || primaries == "bt2020") {
+            return false
+        }
+        return true
+    }
+
+    private fun parseValues(output: String): List<Pair<String, String>> {
+        return output.lineSequence()
             .mapNotNull { line ->
                 val separator = line.indexOf('=')
                 if (separator <= 0) {
@@ -19,35 +83,19 @@ internal object SceneMediaProbe {
                 }
             }
             .toList()
-        val pixelFormat = values.firstOrNull { it.first == "pix_fmt" }?.second
-            ?: return false
-        if (pixelFormat in setOf("none", "unknown")) {
-            return false
-        }
-        val rawBits = values.firstOrNull { it.first == "bits_per_raw_sample" }
-            ?.second
-            ?.toIntOrNull()
-        val transfer = values.firstOrNull { it.first == "color_transfer" }?.second.orEmpty()
-        val primaries = values.firstOrNull { it.first == "color_primaries" }?.second.orEmpty()
-        val profile = values.firstOrNull { it.first == "profile" }?.second.orEmpty()
-        if (
-            rawBits?.let { it > 8 } == true ||
-            TEN_BIT_PIXEL_FORMAT.containsMatchIn(pixelFormat) ||
-            transfer in HDR_TRANSFERS ||
-            primaries == "bt2020" ||
-            profile.contains("main 10")
-        ) {
-            return false
-        }
-        return true
     }
 
-    fun inspectAudio(output: String): Boolean {
-        val normalized = output.lowercase(Locale.ROOT)
-        return PROTECTION_MARKERS.none(normalized::contains) && "codec_type=audio" in normalized
+    private fun String?.toSampleAspectRatio(): Double {
+        val parts = this?.split(':', limit = 2)
+        val numerator = parts?.getOrNull(0)?.toLongOrNull()
+        val denominator = parts?.getOrNull(1)?.toLongOrNull()
+        if (numerator == null || denominator == null || numerator <= 0L || denominator <= 0L) {
+            return 1.0
+        }
+        return numerator.toDouble() / denominator.toDouble()
     }
 
     private val HDR_TRANSFERS = setOf("smpte2084", "arib-std-b67")
-    private val TEN_BIT_PIXEL_FORMAT = Regex("(p0(?:10|12|16)|p(?:9|10|12|14|16)(?:le|be)?)(?:$|[^0-9])")
+    private const val ROTATION_EPSILON = 0.001
     private val PROTECTION_MARKERS = setOf("cenc", "cbcs", "crypto", "encrypted", "encryption", "drm")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMiningLog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneMiningLog.kt
@@ -1,0 +1,56 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import logcat.LogPriority
+import logcat.asLog
+import logcat.logcat
+import java.net.URI
+import java.util.Locale
+
+internal const val SCENE_LOG_TAG = "SceneMining"
+
+/**
+ * Scene mining downgrades to a still image on any failure, so every early return needs to say why.
+ *
+ * Fixed at [LogPriority.INFO] because release-derived builds drop anything lower. Emits
+ * [SCENE_LOG_TAG] as the real logcat tag rather than as a message prefix, so that
+ * `adb logcat -s SceneMining` selects the whole trace; the house `logcat` helper in
+ * `tachiyomi.core.common` keeps the calling class as the tag and would leave the filter empty.
+ * The calling class is named in each message instead, since that is what the tag gave up.
+ */
+internal inline fun Any.sceneLog(
+    throwable: Throwable? = null,
+    message: () -> String,
+    // Positional, so the String first parameter picks the top-level tag-first overload rather than
+    // the `Any.logcat` extension that is also in scope here.
+) = logcat(SCENE_LOG_TAG, LogPriority.INFO) {
+    val caller = this::class.java.simpleName.takeIf(String::isNotBlank) ?: "Scene"
+    buildString {
+        append(caller).append(": ").append(message())
+        if (throwable != null) append('\n').append(throwable.asLog())
+    }
+}
+
+/**
+ * Remote scene inputs are rejected outright when they carry credentials, so logging one verbatim
+ * would defeat that check. Keeps only the scheme and host; paths can be signed too.
+ */
+internal fun redactSceneValue(value: String?): String {
+    if (value.isNullOrBlank()) return "<blank>"
+    val lowered = value.lowercase(Locale.ROOT)
+    if (!lowered.startsWith("http://") && !lowered.startsWith("https://")) return value
+    val uri = runCatching { URI(value) }.getOrNull() ?: return "<unparsable-http-url>"
+    return "${uri.scheme}://${uri.host ?: "<no-host>"}/<redacted>"
+}
+
+/**
+ * FFmpeg echoes the input URL into its own diagnostics, so its output is redacted line by line
+ * rather than as a single value: a URL can appear anywhere inside otherwise useful error text.
+ */
+internal fun redactSceneLogLine(line: String): String =
+    EMBEDDED_HTTP_URL.replace(line) { match -> redactSceneValue(match.value) }
+
+private val EMBEDDED_HTTP_URL = Regex("""https?://\S+""", RegexOption.IGNORE_CASE)
+
+internal fun SceneVideoInputSpec.describe(): String =
+    "kind=$kind value=${redactSceneValue(value)} videoStreamIndex=$videoStreamIndex " +
+        "audioStreamIndex=$audioStreamIndex headerCount=${headers.size}"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInput.kt
@@ -33,26 +33,53 @@ internal data class SceneVideoInputSnapshot(
 internal object SceneVideoInputResolver {
     fun resolve(snapshot: SceneVideoInputSnapshot): SceneVideoInputSpec? {
         if (snapshot.originalVideoValue.isBlank() && snapshot.playableValue.isNullOrBlank()) {
+            sceneLog { "resolve: rejected, both originalVideoValue and playableValue blank" }
             return null
         }
-        if (isDash(snapshot.originalVideoValue) || isDash(snapshot.playableValue)) return null
+        if (isDash(snapshot.originalVideoValue) || isDash(snapshot.playableValue)) {
+            sceneLog { "resolve: rejected, DASH input is unsupported" }
+            return null
+        }
         if (snapshot.ffmpegStreamArgs.isNotEmpty() || snapshot.ffmpegVideoArgs.isNotEmpty()) {
+            sceneLog {
+                "resolve: rejected, extension supplied ffmpeg args " +
+                    "(stream=${snapshot.ffmpegStreamArgs.size} video=${snapshot.ffmpegVideoArgs.size})"
+            }
             return null
         }
-        if (snapshot.seekable != true) return null
+        if (snapshot.seekable != true) {
+            sceneLog { "resolve: rejected, input not seekable (seekable=${snapshot.seekable})" }
+            return null
+        }
 
         val original = snapshot.originalVideoValue.takeIf(String::isNotBlank)
-        if (original != null && isTransient(original)) return null
+        if (original != null && isTransient(original)) {
+            sceneLog { "resolve: rejected, originalVideoValue has a transient scheme" }
+            return null
+        }
         val normalized = original?.let(::normalizeInput)
             ?: snapshot.playableValue?.takeIf(String::isNotBlank)?.let { playable ->
-                if (isTransient(playable)) return null
+                if (isTransient(playable)) {
+                    sceneLog { "resolve: rejected, playableValue has a transient scheme" }
+                    return null
+                }
                 normalizeInput(playable)
             }
-            ?: return null
+            ?: run {
+                sceneLog {
+                    "resolve: rejected, unrecognized input scheme " +
+                        "original=${redactSceneValue(snapshot.originalVideoValue)} " +
+                        "playable=${redactSceneValue(snapshot.playableValue)}"
+                }
+                return null
+            }
 
         val headers = when (normalized.second) {
             SceneVideoInputKind.REMOTE_HTTP -> validateRemoteInput(normalized.first, snapshot.headers)
-                ?: return null
+                ?: run {
+                    sceneLog { "resolve: rejected, remote input failed validation (credentials or headers)" }
+                    return null
+                }
             SceneVideoInputKind.LOCAL_FILE,
             SceneVideoInputKind.CONTENT_URI,
             -> emptyList()
@@ -163,12 +190,14 @@ internal object SceneVideoInputResolver {
 }
 
 internal object SceneFfmpegArguments {
-    fun animatedAvif(
+    fun animatedAvifMediaCodec(
         input: SceneVideoInputSpec,
         acquiredInputValue: String,
         range: SceneTimeRange,
         outputFile: String,
         encoderName: String,
+        contentSize: SceneVideoDimensions,
+        outputSize: SceneVideoDimensions,
         tlsCaFile: String? = null,
     ): Array<String> {
         require(encoderName.isNotBlank()) { "AV1 encoder name must not be blank" }
@@ -186,7 +215,7 @@ internal object SceneFfmpegArguments {
             add("-t")
             add(range.durationSeconds.toFfmpegSeconds())
             add("-vf")
-            add(FRAME_FILTER)
+            add(frameFilter(contentSize, outputSize))
             add("-frames:v")
             add(MAX_FRAME_COUNT.toString())
             add("-c:v")
@@ -222,7 +251,10 @@ internal object SceneFfmpegArguments {
             add("-select_streams")
             add(input.videoProbeSelector())
             add("-show_entries")
-            add("stream=pix_fmt,color_transfer,color_primaries,bits_per_raw_sample,profile:stream_side_data")
+            add(
+                "stream=width,height,sample_aspect_ratio,pix_fmt,color_transfer,color_primaries," +
+                    "bits_per_raw_sample,profile:stream_side_data",
+            )
             add("-of")
             add("default=noprint_wrappers=1")
             add(acquiredInputValue)
@@ -320,14 +352,54 @@ internal object SceneFfmpegArguments {
         return String.format(Locale.ROOT, "%.6f", this).trimEnd('0').trimEnd('.')
     }
 
-    internal const val FRAME_FILTER =
-        "fps=8,scale=w='min(640,iw)':h='min(640,ih)':force_original_aspect_ratio=decrease:force_divisible_by=16,setsar=1"
-    internal const val FRAME_RATE = 8.0
+    internal fun frameFilter(
+        contentSize: SceneVideoDimensions,
+        outputSize: SceneVideoDimensions,
+    ): String {
+        require(
+            outputSize.width in SCENE_PIXEL_ALIGNMENT..SCENE_MAX_OUTPUT_DIMENSION &&
+                outputSize.height in SCENE_PIXEL_ALIGNMENT..SCENE_MAX_OUTPUT_DIMENSION &&
+                outputSize.width % SCENE_PIXEL_ALIGNMENT == 0 &&
+                outputSize.height % SCENE_PIXEL_ALIGNMENT == 0 &&
+                outputSize.width % SCENE_MEDIACODEC_CANVAS_ALIGNMENT == 0 &&
+                outputSize.height % SCENE_MEDIACODEC_CANVAS_ALIGNMENT == 0,
+        ) {
+            "Scene output size must be 16-pixel aligned and no larger than $SCENE_MAX_OUTPUT_DIMENSION"
+        }
+        require(
+            contentSize.width in SCENE_PIXEL_ALIGNMENT..outputSize.width &&
+                contentSize.height in SCENE_PIXEL_ALIGNMENT..outputSize.height &&
+                contentSize.width % SCENE_PIXEL_ALIGNMENT == 0 &&
+                contentSize.height % SCENE_PIXEL_ALIGNMENT == 0,
+        ) {
+            "Scene content size must be even and fit inside the output"
+        }
+        return buildList {
+            add("fps=8")
+            add("scale=w=${contentSize.width}:h=${contentSize.height}")
+            add("setsar=1")
+            if (contentSize != outputSize) {
+                val horizontalGap = outputSize.width - contentSize.width
+                val verticalGap = outputSize.height - contentSize.height
+                add(
+                    "pad=w=${outputSize.width}:h=${outputSize.height}:" +
+                        "x=${horizontalGap.centeredChromaOffset()}:" +
+                        "y=${verticalGap.centeredChromaOffset()}:color=black",
+                )
+            }
+        }.joinToString(separator = ",")
+    }
+
+    private fun Int.centeredChromaOffset(): Int {
+        return (this / 2).let { center -> center - (center % SCENE_PIXEL_ALIGNMENT) }
+    }
+
+    internal const val FRAME_RATE = SCENE_FRAME_RATE
     internal const val MAX_FRAME_COUNT = 80
     private const val REMOTE_PROTOCOLS = "http,https,tls,tcp,crypto"
     private const val REMOTE_IO_TIMEOUT_MICROSECONDS = "15000000"
     internal const val ALLOWED_INPUT_DECODERS =
-        "aac,ac3,alac,av1,dca,eac3,ffv1,flac,h263,h264,hevc,libdav1d,mjpeg,mp3,mp3float,mpeg1video," +
-            "mpeg2video,mpeg4,opus,pcm_f32le,pcm_s16le,pcm_s24le,pcm_s32le,png,prores,theora,truehd," +
-            "vorbis,vp8,vp9"
+        "aac,ac3,alac,av1,dca,eac3,ffv1,flac,h263,h264,hevc,libdav1d,mjpeg,mov_text,mp3,mp3float," +
+            "mpeg1video,mpeg2video,mpeg4,opus,pcm_f32le,pcm_s16le,pcm_s24le,pcm_s32le,png,prores," +
+            "theora,truehd,vorbis,vp8,vp9"
 }

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AndroidSceneCaptureServiceTest.kt
@@ -4,7 +4,17 @@ import android.graphics.Bitmap
 import chimahon.anki.AnkiScreenshotPreparation
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -18,11 +28,11 @@ class AndroidSceneCaptureServiceTest {
     lateinit var tempDirectory: File
 
     @Test
-    fun `successful capture uses exact bounded AVIF command`() = runTest {
+    fun `successful capture encodes directly to animated AVIF in one command`() = runTest {
         val executor = RecordingExecutor(writeOutput = true)
         val service = service(
             executor = executor,
-            validate = { AnimatedAvifInfo(320, 180, 24, 3_000) },
+            validate = { AnimatedAvifInfo(320, 192, 24, 3_000) },
         )
 
         val result = service.prepare(request())
@@ -30,27 +40,156 @@ class AndroidSceneCaptureServiceTest {
         val animated = result as AnkiScreenshotPreparation.Animated
         assertEquals("avif", animated.animation.extension)
         assertTrue(animated.animation.preferredBaseName.startsWith("chimahon_scene_"))
+        assertEquals(1, executor.ffmpegArguments.size)
         assertArrayEquals(
-            expectedAvifArguments(animated.animation.file.absolutePath),
-            executor.ffmpegArguments,
+            expectedAv1Arguments(animated.animation.file.absolutePath),
+            executor.ffmpegArguments[0],
         )
         animated.animation.file.delete()
     }
 
     @Test
-    fun `missing compatible AV1 encoder falls back before native work`() = runTest {
+    fun `missing compatible AV1 encoder falls back before encode`() = runTest {
         val executor = RecordingExecutor(writeOutput = true)
         val service = service(
             executor = executor,
-            av1EncoderName = { null },
+            av1Encoder = { null },
         )
 
         val result = service.prepare(request())
 
         assertTrue(result is AnkiScreenshotPreparation.Failed)
-        assertEquals(0, executor.probeCalls)
+        assertEquals(1, executor.probeCalls)
         assertEquals(0, executor.ffmpegCalls)
         assertFalse(tempDirectory.resolve("scene").exists())
+    }
+
+    @Test
+    fun `capture selects an encoder for probed dimensions and applies its exact output`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        var selectedFor: SceneVideoDimensions? = null
+        val service = service(
+            executor = executor,
+            validate = { AnimatedAvifInfo(320, 192, 24, 3_000) },
+            av1Encoder = { source ->
+                selectedFor = source
+                Av1EncoderSelection(
+                    name = TEST_AV1_ENCODER_NAME,
+                    contentSize = SceneVideoDimensions(width = 320, height = 180),
+                    outputSize = SceneVideoDimensions(width = 320, height = 192),
+                )
+            },
+        )
+
+        val result = service.prepare(request())
+
+        assertTrue(result is AnkiScreenshotPreparation.Animated)
+        assertEquals(SceneVideoDimensions(width = 320, height = 180), selectedFor)
+        val encodeArguments = executor.ffmpegArguments.first().toList()
+        assertEquals(
+            SceneFfmpegArguments.frameFilter(
+                contentSize = SceneVideoDimensions(width = 320, height = 180),
+                outputSize = SceneVideoDimensions(width = 320, height = 192),
+            ),
+            encodeArguments[encodeArguments.indexOf("-vf") + 1],
+        )
+        (result as AnkiScreenshotPreparation.Animated).animation.file.delete()
+    }
+
+    @Test
+    fun `capture rejects output dimensions that differ from the codec selection`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        val service = service(
+            executor = executor,
+            validate = { AnimatedAvifInfo(320, 180, 24, 3_000) },
+            av1Encoder = {
+                Av1EncoderSelection(
+                    name = TEST_AV1_ENCODER_NAME,
+                    contentSize = SceneVideoDimensions(width = 320, height = 180),
+                    outputSize = SceneVideoDimensions(width = 320, height = 192),
+                )
+            },
+        )
+
+        val result = service.prepare(request())
+
+        assertTrue(result is AnkiScreenshotPreparation.Failed)
+        assertTrue(tempDirectory.resolve("scene").listFiles().isNullOrEmpty())
+    }
+
+    @Test
+    fun `cancellation while returning a completed capture deletes the undelivered output`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true)
+        val callerJob = Job(currentCoroutineContext()[Job])
+        val service = service(
+            executor = executor,
+            validate = {
+                callerJob.cancel()
+                AnimatedAvifInfo(320, 192, 24, 3_000)
+            },
+        )
+
+        var cancelled = false
+        try {
+            withContext(callerJob) {
+                service.prepare(request())
+            }
+        } catch (_: CancellationException) {
+            cancelled = true
+        }
+
+        assertTrue(cancelled)
+        assertTrue(tempDirectory.resolve("scene").listFiles().isNullOrEmpty())
+    }
+
+    @Test
+    fun `probe argument failure closes its input lease and fails closed`() = runTest {
+        var closeCalls = 0
+        val service = service(
+            executor = RecordingExecutor(writeOutput = true),
+            inputAcquirer = SceneInputAcquirer { input ->
+                object : SceneInputLease {
+                    override val ffmpegValue = input.value
+                    override val tlsCaFile: String? = null
+
+                    override fun close() {
+                        closeCalls++
+                    }
+                }
+            },
+        )
+
+        val result = runCatching { service.prepare(request()) }
+
+        assertEquals(1, closeCalls)
+        assertTrue(result.getOrNull() is AnkiScreenshotPreparation.Failed)
+    }
+
+    @Test
+    fun `encode argument failure closes both acquired input leases`() = runTest {
+        var acquisitions = 0
+        var closeCalls = 0
+        val service = service(
+            executor = RecordingExecutor(writeOutput = true),
+            inputAcquirer = SceneInputAcquirer { input ->
+                acquisitions++
+                object : SceneInputLease {
+                    override val ffmpegValue = input.value
+                    override val tlsCaFile = if (acquisitions == 1) "/files/cacert.pem" else null
+
+                    override fun close() {
+                        closeCalls++
+                    }
+                }
+            },
+        )
+
+        val result = service.prepare(request())
+
+        assertTrue(result is AnkiScreenshotPreparation.Failed)
+        assertEquals(2, acquisitions)
+        assertEquals(2, closeCalls)
+        assertTrue(tempDirectory.resolve("scene").listFiles().isNullOrEmpty())
     }
 
     @Test
@@ -68,26 +207,64 @@ class AndroidSceneCaptureServiceTest {
         assertTrue(sceneDirectory.listFiles().isNullOrEmpty())
     }
 
+    @Test
+    fun `cancellation reaches native encode and defers file cleanup until native return`() = runTest {
+        val executor = RecordingExecutor(writeOutput = true, suspendEncode = true)
+        val service = service(executor = executor)
+        val preparation = launch { service.prepare(request()) }
+        withContext(Dispatchers.Default) {
+            withTimeout(5_000) { executor.encodeStarted.await() }
+        }
+        val output = File(executor.ffmpegArguments.last().last())
+
+        preparation.cancelAndJoin()
+        withContext(Dispatchers.Default) {
+            withTimeout(5_000) { executor.cancellationObserved.await() }
+        }
+
+        assertTrue(output.isFile)
+
+        executor.finishNative()
+
+        assertFalse(output.exists())
+    }
+
     private fun service(
         executor: RecordingExecutor,
-        validate: (File) -> AnimatedAvifInfo? = {
-            AnimatedAvifInfo(320, 180, 24, 3_000)
+        inputAcquirer: SceneInputAcquirer = SceneInputAcquirer { input ->
+            object : SceneInputLease {
+                override val ffmpegValue = input.value
+                override val tlsCaFile = "/files/cacert.pem"
+
+                override fun close() = Unit
+            }
         },
-        av1EncoderName: () -> String? = { TEST_AV1_ENCODER_NAME },
+        validate: (File) -> AnimatedAvifInfo? = {
+            AnimatedAvifInfo(320, 192, 24, 3_000)
+        },
+        av1Encoder: (SceneVideoDimensions) -> Av1EncoderSelection? = { source ->
+            selectAv1Encoder(
+                source = source,
+                candidates = sequenceOf(
+                    Av1EncoderCandidate(
+                        name = TEST_AV1_ENCODER_NAME,
+                        supportsPlanarYuv420 = true,
+                        supportsConstantQuality = true,
+                        supportsTargetQuality = true,
+                        widthAlignment = 2,
+                        heightAlignment = 2,
+                        supportsSizeAndRate = { _, _ -> true },
+                    ),
+                ),
+            )
+        },
     ): AndroidSceneCaptureService {
         return AndroidSceneCaptureService.forTests(
             sceneDirectory = tempDirectory.resolve("scene"),
-            inputAcquirer = SceneInputAcquirer { input ->
-                object : SceneInputLease {
-                    override val ffmpegValue = input.value
-                    override val tlsCaFile = "/files/cacert.pem"
-
-                    override fun close() = Unit
-                }
-            },
+            inputAcquirer = inputAcquirer,
             commandExecutor = executor,
             validate = validate,
-            av1EncoderName = av1EncoderName,
+            av1Encoder = av1Encoder,
         )
     }
 
@@ -110,7 +287,7 @@ class AndroidSceneCaptureServiceTest {
         )
     }
 
-    private fun expectedAvifArguments(output: String): Array<String> {
+    private fun expectedAv1Arguments(output: String): Array<String> {
         return arrayOf(
             "-codec_whitelist",
             SceneFfmpegArguments.ALLOWED_INPUT_DECODERS,
@@ -136,7 +313,10 @@ class AndroidSceneCaptureServiceTest {
             "-t",
             "3",
             "-vf",
-            SceneFfmpegArguments.FRAME_FILTER,
+            SceneFfmpegArguments.frameFilter(
+                contentSize = SceneVideoDimensions(width = 320, height = 180),
+                outputSize = SceneVideoDimensions(width = 320, height = 192),
+            ),
             "-frames:v",
             "80",
             "-c:v",
@@ -162,21 +342,35 @@ class AndroidSceneCaptureServiceTest {
 
     private class RecordingExecutor(
         private val writeOutput: Boolean,
+        private val suspendEncode: Boolean = false,
     ) : SceneCommandExecutor {
         var probeCalls = 0
         var ffmpegCalls = 0
-        var ffmpegArguments: Array<String> = emptyArray()
+        val ffmpegArguments = mutableListOf<Array<String>>()
+        val encodeStarted = CompletableDeferred<Unit>()
+        val cancellationObserved = CompletableDeferred<Unit>()
+        private lateinit var onEncodeFinished: () -> Unit
 
         override suspend fun executeFfmpeg(
             arguments: Array<String>,
             onNativeFinished: () -> Unit,
         ): SceneCommandResult {
-            return try {
-                ffmpegCalls++
-                ffmpegArguments = arguments
-                if (writeOutput) {
-                    File(arguments.last()).writeBytes(byteArrayOf(1, 2, 3))
+            ffmpegCalls++
+            ffmpegArguments += arguments
+            val output = File(arguments.last())
+            if (writeOutput) {
+                output.writeBytes(byteArrayOf(1, 2, 3))
+            }
+            if (suspendEncode && output.extension == "avif") {
+                onEncodeFinished = onNativeFinished
+                encodeStarted.complete(Unit)
+                return suspendCancellableCoroutine { continuation ->
+                    continuation.invokeOnCancellation {
+                        cancellationObserved.complete(Unit)
+                    }
                 }
+            }
+            return try {
                 SceneCommandResult.Success()
             } finally {
                 onNativeFinished()
@@ -190,11 +384,16 @@ class AndroidSceneCaptureServiceTest {
             return try {
                 probeCalls++
                 SceneCommandResult.Success(
-                    "pix_fmt=yuv420p\ncolor_transfer=bt709\ncolor_primaries=bt709\nbits_per_raw_sample=8",
+                    "width=320\nheight=180\npix_fmt=yuv420p\ncolor_transfer=bt709\n" +
+                        "color_primaries=bt709\nbits_per_raw_sample=8",
                 )
             } finally {
                 onNativeFinished()
             }
+        }
+
+        fun finishNative() {
+            onEncodeFinished()
         }
     }
 

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidatorTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/AnimatedAvifValidatorTest.kt
@@ -55,6 +55,15 @@ class AnimatedAvifValidatorTest {
         assertNull(validate(avif(mediaBytes = 3)))
     }
 
+    @Test
+    fun `requires the first AV1 sample to be a sync sample`() {
+        assertNull(validate(avif(syncSamples = listOf(2))))
+        assertEquals(
+            AnimatedAvifInfo(width = 64, height = 48, frameCount = 4, totalDurationMillis = 500),
+            validate(avif(syncSamples = listOf(1, 3))),
+        )
+    }
+
     private fun avif(
         majorBrand: String = "avis",
         brands: List<String> = listOf("avif", "MA1B"),
@@ -65,6 +74,7 @@ class AnimatedAvifValidatorTest {
         frameDuration: Int = 1_000,
         sampleSizes: List<Int> = List(frames) { 1 },
         mediaBytes: Int = sampleSizes.sum(),
+        syncSamples: List<Int>? = null,
     ): ByteArray {
         val fileType = majorBrand.ascii() + ByteArray(4) + brands.fold(byteArrayOf()) { bytes, brand -> bytes + brand.ascii() }
         val sampleEntry = box(
@@ -84,6 +94,12 @@ class AnimatedAvifValidatorTest {
             writeUInt32(8, sampleSizes.size)
             sampleSizes.forEachIndexed { index, size -> writeUInt32(12 + index * 4, size) }
         }
+        val syncSampleTable = syncSamples?.let { samples ->
+            ByteArray(8 + samples.size * 4).apply {
+                writeUInt32(4, samples.size)
+                samples.forEachIndexed { index, sample -> writeUInt32(8 + index * 4, sample) }
+            }
+        }
         val mediaHeader = ByteArray(24).apply {
             writeUInt32(12, 8_000)
             writeUInt32(16, frames * frameDuration)
@@ -91,7 +107,8 @@ class AnimatedAvifValidatorTest {
         val sampleTable =
             box("stsd", sampleDescription) +
                 box("stts", sampleTiming) +
-                box("stsz", sampleSizeTable)
+                box("stsz", sampleSizeTable) +
+                (syncSampleTable?.let { box("stss", it) } ?: byteArrayOf())
         val movie = box(
             "moov",
             box(

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneAv1EncoderSelectorTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneAv1EncoderSelectorTest.kt
@@ -1,0 +1,303 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SceneAv1EncoderSelectorTest {
+    @Test
+    fun `landscape input pads the MediaCodec canvas to sixteen pixels`() {
+        val checkedSizes = mutableListOf<SceneVideoDimensions>()
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 320, height = 180),
+            candidates = sequenceOf(
+                candidate { size, _ ->
+                    checkedSizes += size
+                    size == SceneVideoDimensions(width = 320, height = 192)
+                },
+            ),
+        )
+
+        assertEquals(
+            Av1EncoderSelection(
+                name = ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 320, height = 180),
+                outputSize = SceneVideoDimensions(width = 320, height = 192),
+            ),
+            selection,
+        )
+        assertEquals(listOf(SceneVideoDimensions(width = 320, height = 192)), checkedSizes)
+    }
+
+    @Test
+    fun `square input lowers its cap until it fits the codec block budget`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 640, height = 640),
+            candidates = sequenceOf(
+                candidate { size, _ ->
+                    size.width.ceilDiv(16) * size.height.ceilDiv(16) <= 1_350
+                },
+            ),
+        )
+
+        assertEquals(
+            Av1EncoderSelection(
+                name = ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 576, height = 576),
+                outputSize = SceneVideoDimensions(width = 576, height = 576),
+            ),
+            selection,
+        )
+    }
+
+    @Test
+    fun `common sixteen by nine sources select the exact same output geometry`() {
+        listOf(
+            SceneVideoDimensions(width = 640, height = 360),
+            SceneVideoDimensions(width = 1248, height = 702),
+        ).forEach { source ->
+            assertEquals(
+                SceneVideoDimensions(width = 640, height = 368),
+                selectAv1Encoder(
+                    source = source,
+                    candidates = sequenceOf(candidate()),
+                )?.outputSize,
+            )
+        }
+    }
+
+    @Test
+    fun `portrait input lowers both dimensions until the codec block budget fits`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 536, height = 640),
+            candidates = sequenceOf(
+                candidate { size, _ ->
+                    size.width.ceilDiv(16) * size.height.ceilDiv(16) <= 1_350
+                },
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 528, height = 640), selection?.outputSize)
+    }
+
+    @Test
+    fun `codec alignment expands the canvas instead of squashing the source`() {
+        val checkedSizes = mutableListOf<SceneVideoDimensions>()
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 320, height = 180),
+            candidates = sequenceOf(
+                candidate(
+                    widthAlignment = 16,
+                    heightAlignment = 16,
+                    supportsSizeAndRate = { size, _ ->
+                        checkedSizes += size
+                        true
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 320, height = 180), selection?.contentSize)
+        assertEquals(SceneVideoDimensions(width = 320, height = 192), selection?.outputSize)
+        assertEquals(listOf(SceneVideoDimensions(width = 320, height = 192)), checkedSizes)
+    }
+
+    @Test
+    fun `codec minimum dimensions expand only the canvas`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 32, height = 18),
+            candidates = sequenceOf(
+                candidate(
+                    minimumWidth = 64,
+                    minimumHeight = 64,
+                    supportsSizeAndRate = { size, _ ->
+                        size.width >= 64 && size.height >= 64
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 32, height = 18), selection?.contentSize)
+        assertEquals(SceneVideoDimensions(width = 64, height = 64), selection?.outputSize)
+    }
+
+    @Test
+    fun `conditional codec dimensions add padding instead of reducing content`() {
+        val checkedSizes = mutableListOf<SceneVideoDimensions>()
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 64, height = 64),
+            candidates = sequenceOf(
+                candidate(
+                    supportedWidthsForHeight = { height ->
+                        if (height == 64) 128..640 else null
+                    },
+                    supportsSizeAndRate = { size, _ ->
+                        checkedSizes += size
+                        size == SceneVideoDimensions(width = 128, height = 64)
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 64, height = 64), selection?.contentSize)
+        assertEquals(SceneVideoDimensions(width = 128, height = 64), selection?.outputSize)
+        assertEquals(listOf(SceneVideoDimensions(width = 128, height = 64)), checkedSizes)
+    }
+
+    @Test
+    fun `conditional codec range checks wider canvases until the frame rate is supported`() {
+        val checkedSizes = mutableListOf<SceneVideoDimensions>()
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 64, height = 64),
+            candidates = sequenceOf(
+                candidate(
+                    widthAlignment = 64,
+                    heightAlignment = 64,
+                    supportedWidthsForHeight = { height ->
+                        if (height == 64) 64..128 else null
+                    },
+                    supportsSizeAndRate = { size, _ ->
+                        checkedSizes += size
+                        size == SceneVideoDimensions(width = 128, height = 64)
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 64, height = 64), selection?.contentSize)
+        assertEquals(SceneVideoDimensions(width = 128, height = 64), selection?.outputSize)
+        assertEquals(
+            listOf(
+                SceneVideoDimensions(width = 64, height = 64),
+                SceneVideoDimensions(width = 128, height = 64),
+            ),
+            checkedSizes,
+        )
+    }
+
+    @Test
+    fun `invalid conditional height query does not reject a later padded canvas`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 64, height = 64),
+            candidates = sequenceOf(
+                candidate(
+                    widthAlignment = 64,
+                    heightAlignment = 64,
+                    supportedWidthsForHeight = { height ->
+                        if (height == 64) {
+                            throw IllegalArgumentException("unsupported height")
+                        }
+                        if (height == 128) 64..64 else null
+                    },
+                    supportsSizeAndRate = { size, _ ->
+                        size == SceneVideoDimensions(width = 64, height = 128)
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 64, height = 64), selection?.contentSize)
+        assertEquals(SceneVideoDimensions(width = 64, height = 128), selection?.outputSize)
+    }
+
+    @Test
+    fun `highest resolution wins across compatible encoders`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 640, height = 360),
+            candidates = sequenceOf(
+                candidate(
+                    name = "limited.encoder",
+                    supportsSizeAndRate = { size, _ -> size.width <= 320 },
+                ),
+                candidate(name = "full.encoder"),
+            ),
+        )
+
+        assertEquals("full.encoder", selection?.name)
+        assertEquals(SceneVideoDimensions(width = 640, height = 360), selection?.contentSize)
+    }
+
+    @Test
+    fun `selection never exceeds the production output bound`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 1_600, height = 900),
+            candidates = sequenceOf(candidate()),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 640, height = 368), selection?.outputSize)
+    }
+
+    @Test
+    fun `narrow inputs reduce the long edge instead of visibly changing aspect`() {
+        val selection = selectAv1Encoder(
+            source = SceneVideoDimensions(width = 3, height = 640),
+            candidates = sequenceOf(candidate()),
+        )
+
+        assertEquals(SceneVideoDimensions(width = 2, height = 426), selection?.contentSize)
+        assertNull(
+            selectAv1Encoder(
+                source = SceneVideoDimensions(width = 1, height = 640),
+                candidates = sequenceOf(candidate()),
+            ),
+        )
+        assertNull(
+            selectAv1Encoder(
+                source = SceneVideoDimensions(width = Int.MAX_VALUE, height = 1),
+                candidates = sequenceOf(candidate()),
+            ),
+        )
+    }
+
+    @Test
+    fun `required MediaCodec format and quality capabilities remain enforced`() {
+        val unsupported = sequenceOf(
+            candidate(supportsPlanarYuv420 = false),
+            candidate(supportsConstantQuality = false),
+            candidate(supportsTargetQuality = false),
+        )
+
+        assertNull(
+            selectAv1Encoder(
+                source = SceneVideoDimensions(width = 1920, height = 1080),
+                candidates = unsupported,
+            ),
+        )
+    }
+
+    private fun candidate(
+        name: String = ENCODER_NAME,
+        supportsPlanarYuv420: Boolean = true,
+        supportsConstantQuality: Boolean = true,
+        supportsTargetQuality: Boolean = true,
+        widthAlignment: Int = 2,
+        heightAlignment: Int = 2,
+        minimumWidth: Int = 2,
+        minimumHeight: Int = 2,
+        maximumWidth: Int = Int.MAX_VALUE,
+        maximumHeight: Int = Int.MAX_VALUE,
+        supportedWidthsForHeight: (Int) -> IntRange? = {
+            minimumWidth..maximumWidth
+        },
+        supportsSizeAndRate: (SceneVideoDimensions, Double) -> Boolean = { _, _ -> true },
+    ) = Av1EncoderCandidate(
+        name = name,
+        supportsPlanarYuv420 = supportsPlanarYuv420,
+        supportsConstantQuality = supportsConstantQuality,
+        supportsTargetQuality = supportsTargetQuality,
+        widthAlignment = widthAlignment,
+        heightAlignment = heightAlignment,
+        minimumWidth = minimumWidth,
+        minimumHeight = minimumHeight,
+        maximumWidth = maximumWidth,
+        maximumHeight = maximumHeight,
+        supportedWidthsForHeight = supportedWidthsForHeight,
+        supportsSizeAndRate = supportsSizeAndRate,
+    )
+
+    private fun Int.ceilDiv(divisor: Int): Int = (this + divisor - 1) / divisor
+
+    private companion object {
+        const val ENCODER_NAME = "c2.android.av1.encoder"
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbeTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMediaProbeTest.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.ui.player.scene
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -21,12 +23,21 @@ class SceneMediaProbeTest {
     }
 
     @Test
-    fun `ten bit and HDR video are rejected`() {
+    fun `ten bit SDR video is safe`() {
         listOf(
             "pix_fmt=yuv420p10le\ncolor_transfer=bt709",
+            "pix_fmt=yuv420p\nbits_per_raw_sample=10",
+            "pix_fmt=yuv420p10le\nprofile=Main 10",
+        ).forEach { output ->
+            assertTrue(SceneMediaProbe.inspect(output))
+        }
+    }
+
+    @Test
+    fun `HDR video is rejected`() {
+        listOf(
             "pix_fmt=yuv420p\ncolor_transfer=smpte2084",
             "pix_fmt=yuv420p\ncolor_primaries=bt2020",
-            "pix_fmt=yuv420p\nbits_per_raw_sample=10",
         ).forEach { output ->
             assertFalse(SceneMediaProbe.inspect(output))
         }
@@ -41,6 +52,74 @@ class SceneMediaProbeTest {
         ).forEach { output ->
             assertFalse(SceneMediaProbe.inspect(output))
         }
+    }
+
+    @Test
+    fun `video inspection returns dimensions after display rotation`() {
+        assertEquals(
+            SceneVideoDimensions(width = 320, height = 180),
+            SceneMediaProbe.inspectVideo(
+                "width=320\nheight=180\npix_fmt=yuv420p\ncolor_transfer=bt709",
+            ),
+        )
+        assertEquals(
+            SceneVideoDimensions(width = 1080, height = 1920),
+            SceneMediaProbe.inspectVideo(
+                "width=1920\nheight=1080\npix_fmt=yuv420p\ncolor_transfer=bt709\nrotation=90",
+            ),
+        )
+    }
+
+    @Test
+    fun `video inspection accepts only orthogonal display rotation`() {
+        listOf(-90, 90, 270, 450).forEach { rotation ->
+            assertEquals(
+                SceneVideoDimensions(width = 180, height = 320),
+                SceneMediaProbe.inspectVideo(
+                    "width=320\nheight=180\npix_fmt=yuv420p\nrotation=$rotation",
+                ),
+            )
+        }
+        assertEquals(
+            SceneVideoDimensions(width = 320, height = 180),
+            SceneMediaProbe.inspectVideo(
+                "width=320\nheight=180\npix_fmt=yuv420p\nrotation=180",
+            ),
+        )
+        assertNull(
+            SceneMediaProbe.inspectVideo(
+                "width=320\nheight=180\npix_fmt=yuv420p\nrotation=45",
+            ),
+        )
+    }
+
+    @Test
+    fun `video inspection applies sample aspect ratio before display rotation`() {
+        assertEquals(
+            SceneVideoDimensions(width = 768, height = 576),
+            SceneMediaProbe.inspectVideo(
+                "width=720\nheight=576\nsample_aspect_ratio=16:15\n" +
+                    "pix_fmt=yuv420p\ncolor_transfer=bt709",
+            ),
+        )
+        assertEquals(
+            SceneVideoDimensions(width = 576, height = 768),
+            SceneMediaProbe.inspectVideo(
+                "width=720\nheight=576\nsample_aspect_ratio=16:15\n" +
+                    "pix_fmt=yuv420p\ncolor_transfer=bt709\nrotation=90",
+            ),
+        )
+    }
+
+    @Test
+    fun `video inspection requires safe positive dimensions`() {
+        assertNull(SceneMediaProbe.inspectVideo("pix_fmt=yuv420p"))
+        assertNull(SceneMediaProbe.inspectVideo("width=0\nheight=180\npix_fmt=yuv420p"))
+        assertNull(
+            SceneMediaProbe.inspectVideo(
+                "width=320\nheight=180\npix_fmt=yuv420p\ncolor_transfer=smpte2084",
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMiningLogTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneMiningLogTest.kt
@@ -1,0 +1,110 @@
+package eu.kanade.tachiyomi.ui.player.scene
+
+import logcat.LogPriority
+import logcat.LogcatLogger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SceneMiningLogTest {
+    private class RecordingLogger : LogcatLogger {
+        val entries = mutableListOf<Triple<LogPriority, String, String>>()
+
+        override fun isLoggable(priority: LogPriority) = true
+
+        override fun log(priority: LogPriority, tag: String, message: String) {
+            entries += Triple(priority, tag, message)
+        }
+    }
+
+    private val logger = RecordingLogger()
+
+    @AfterEach
+    fun tearDown() {
+        if (LogcatLogger.isInstalled) LogcatLogger.uninstall()
+    }
+
+    /**
+     * A previous build emitted the calling class as the tag and `[SceneMining]` as a message
+     * prefix, which made `adb logcat -s SceneMining` return nothing at all and read as though the
+     * instrumentation had never fired.
+     */
+    @Test
+    fun `scene logs are tagged so a tag-only logcat filter finds them`() {
+        LogcatLogger.install(logger)
+
+        sceneLog { "prepare: starting" }
+
+        val (priority, tag, message) = logger.entries.single()
+        assertEquals(SCENE_LOG_TAG, tag)
+        // Release-derived builds install a logger with an INFO floor and would drop DEBUG.
+        assertEquals(LogPriority.INFO, priority)
+        assertTrue(message.endsWith("prepare: starting"), message)
+        // The caller is still identifiable now that it no longer occupies the tag.
+        assertTrue(message.startsWith("SceneMiningLogTest: "), message)
+    }
+
+    @Test
+    fun `scene logs append the throwable so a swallowed cause survives`() {
+        LogcatLogger.install(logger)
+
+        sceneLog(throwable = IllegalStateException("boom")) { "prepare: threw" }
+
+        val message = logger.entries.single().third
+        assertTrue(message.contains("prepare: threw"), message)
+        assertTrue(message.contains("IllegalStateException"), message)
+        assertTrue(message.contains("boom"), message)
+    }
+
+    @Test
+    fun `remote values keep only scheme and host`() {
+        assertEquals(
+            "https://media.example/<redacted>",
+            redactSceneValue("https://media.example/a/b.mkv?token=super-secret&x-amz-signature=abc"),
+        )
+        // The scheme is echoed as written, so an uppercase input stays uppercase.
+        assertEquals(
+            "HTTP://media.example/<redacted>",
+            redactSceneValue("HTTP://media.example/a/b.mkv"),
+        )
+        assertEquals("<blank>", redactSceneValue(null))
+        assertEquals("<blank>", redactSceneValue("  "))
+    }
+
+    @Test
+    fun `local paths and content uris stay readable`() {
+        assertEquals("/video/episode.mkv", redactSceneValue("/video/episode.mkv"))
+        assertEquals(
+            "content://media/external/video/1",
+            redactSceneValue("content://media/external/video/1"),
+        )
+    }
+
+    @Test
+    fun `ffmpeg output keeps its diagnostics but loses embedded credentials`() {
+        val redacted = redactSceneLogLine(
+            "https://media.example/ep.mkv?token=secret: Server returned 403 Forbidden",
+        )
+
+        assertEquals(
+            "https://media.example/<redacted> Server returned 403 Forbidden",
+            redacted,
+        )
+        assertFalse(redacted.contains("secret"))
+    }
+
+    @Test
+    fun `every url on a multi line report is redacted`() {
+        val redacted = redactSceneLogLine(
+            """
+            [tls @ 0x1] error opening https://a.example/x?sig=one
+            [http @ 0x2] retry https://b.example/y?sig=two failed
+            """.trimIndent(),
+        )
+
+        assertFalse(redacted.contains("sig="))
+        assertEquals(2, Regex("<redacted>").findAll(redacted).count())
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInputTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/scene/SceneVideoInputTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -62,14 +63,16 @@ class SceneVideoInputTest {
     }
 
     @Test
-    fun `AVIF command has the single bounded native recipe`() {
+    fun `AV1 encode muxes MediaCodec output directly into animated AVIF`() {
         val input = supportedInput()
-        val arguments = SceneFfmpegArguments.animatedAvif(
+        val arguments = SceneFfmpegArguments.animatedAvifMediaCodec(
             input = input,
             acquiredInputValue = "https://media.example/video.mp4",
             range = SceneTimeRange(1.25, 11.25),
             outputFile = "/cache/output.avif",
             encoderName = TEST_AV1_ENCODER_NAME,
+            contentSize = SceneVideoDimensions(width = 640, height = 360),
+            outputSize = SceneVideoDimensions(width = 640, height = 368),
             tlsCaFile = "/files/cacert.pem",
         ).toList()
 
@@ -104,9 +107,51 @@ class SceneVideoInputTest {
             ),
         )
         assertEquals(1, arguments.count { it == "-c:v" })
-        assertEquals(SceneFfmpegArguments.FRAME_FILTER, arguments[arguments.indexOf("-vf") + 1])
-        assertTrue(SceneFfmpegArguments.FRAME_FILTER.contains("force_divisible_by=16"))
-        assertFalse(arguments.any { it.contains("webp", ignoreCase = true) })
+        assertEquals(
+            "fps=8,scale=w=640:h=360,setsar=1,pad=w=640:h=368:x=0:y=4:color=black",
+            arguments[arguments.indexOf("-vf") + 1],
+        )
+        assertEquals("/cache/output.avif", arguments.last())
+    }
+
+    @Test
+    fun `AV1 encode pads aspect preserving content into the codec canvas`() {
+        val arguments = SceneFfmpegArguments.animatedAvifMediaCodec(
+            input = supportedInput(),
+            acquiredInputValue = "https://media.example/video.mp4",
+            range = SceneTimeRange(1.25, 11.25),
+            outputFile = "/cache/output.avif",
+            encoderName = TEST_AV1_ENCODER_NAME,
+            contentSize = SceneVideoDimensions(width = 320, height = 180),
+            outputSize = SceneVideoDimensions(width = 320, height = 192),
+            tlsCaFile = "/files/cacert.pem",
+        ).toList()
+
+        assertEquals(
+            "fps=8,scale=w=320:h=180,setsar=1,pad=w=320:h=192:x=0:y=6:color=black",
+            arguments[arguments.indexOf("-vf") + 1],
+        )
+    }
+
+    @Test
+    fun `AV1 padding uses explicit chroma aligned offsets`() {
+        assertEquals(
+            "fps=8,scale=w=318:h=178,setsar=1,pad=w=320:h=192:x=0:y=6:color=black",
+            SceneFfmpegArguments.frameFilter(
+                contentSize = SceneVideoDimensions(width = 318, height = 178),
+                outputSize = SceneVideoDimensions(width = 320, height = 192),
+            ),
+        )
+    }
+
+    @Test
+    fun `AV1 filter rejects a canvas that is not sixteen pixel aligned`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SceneFfmpegArguments.frameFilter(
+                contentSize = SceneVideoDimensions(width = 320, height = 180),
+                outputSize = SceneVideoDimensions(width = 320, height = 180),
+            )
+        }
     }
 
     @Test
@@ -115,12 +160,14 @@ class SceneVideoInputTest {
         val range = SceneTimeRange(1.25, 2.25)
         val caFile = "/files/cacert.pem"
         val commands = listOf(
-            SceneFfmpegArguments.animatedAvif(
+            SceneFfmpegArguments.animatedAvifMediaCodec(
                 input = input,
                 acquiredInputValue = input.value,
                 range = range,
                 outputFile = "/cache/scene.avif",
                 encoderName = TEST_AV1_ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 640, height = 360),
+                outputSize = SceneVideoDimensions(width = 640, height = 368),
                 tlsCaFile = caFile,
             ),
             SceneFfmpegArguments.videoProbe(input, input.value, caFile),
@@ -139,6 +186,67 @@ class SceneVideoInputTest {
     }
 
     @Test
+    fun `embedded MP4 subtitles do not block scene probe or encode`() {
+        val input = supportedInput()
+        val commands = listOf(
+            SceneFfmpegArguments.videoProbe(input, input.value, "/files/cacert.pem"),
+            SceneFfmpegArguments.animatedAvifMediaCodec(
+                input = input,
+                acquiredInputValue = input.value,
+                range = SceneTimeRange(1.25, 2.25),
+                outputFile = "/cache/scene.avif",
+                encoderName = TEST_AV1_ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 640, height = 360),
+                outputSize = SceneVideoDimensions(width = 640, height = 368),
+                tlsCaFile = "/files/cacert.pem",
+            ),
+        )
+
+        commands.forEach { command ->
+            val whitelist = command[command.indexOf("-codec_whitelist") + 1].split(',')
+            assertTrue("mov_text" in whitelist, "mov_text missing from $whitelist")
+        }
+    }
+
+    /**
+     * SAF documents reach FFmpeg as FFmpegKit's `saf:<id>.<ext>` pseudo-URL, because reopening a
+     * `/proc/self/fd/N` path re-checks permissions against the real file and loses the SAF grant.
+     * `-protocol_whitelist` would filter that scheme out, so it must stay confined to remote input.
+     */
+    @Test
+    fun `content uri commands pass a saf value through without restricting protocols`() {
+        val input = SceneVideoInputSpec(
+            value = "content://com.android.externalstorage.documents/tree/primary%3AAnime",
+            kind = SceneVideoInputKind.CONTENT_URI,
+            headers = emptyList(),
+        )
+        val safValue = "saf:37.mp4"
+        val range = SceneTimeRange(1.25, 2.25)
+        val commands = listOf(
+            SceneFfmpegArguments.animatedAvifMediaCodec(
+                input = input,
+                acquiredInputValue = safValue,
+                range = range,
+                outputFile = "/cache/scene.avif",
+                encoderName = TEST_AV1_ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 640, height = 360),
+                outputSize = SceneVideoDimensions(width = 640, height = 368),
+            ),
+            SceneFfmpegArguments.videoProbe(input, safValue),
+            SceneFfmpegArguments.audioProbe(input, safValue),
+            SceneFfmpegArguments.sentenceAudio(input, safValue, range, "/cache/audio.m4a"),
+        )
+
+        commands.forEach { command ->
+            val arguments = command.toList()
+            assertTrue(safValue in arguments, "saf value missing from $arguments")
+            assertFalse("-protocol_whitelist" in arguments, "saf scheme would be filtered out")
+            // The content uri itself must never reach ffmpeg -- it is not an openable path.
+            assertFalse(arguments.any { it.startsWith("content://") }, arguments.toString())
+        }
+    }
+
+    @Test
     fun `sentence audio maps the frozen selected stream`() {
         val input = supportedInput().copy(videoStreamIndex = 2, audioStreamIndex = 3)
         val range = SceneTimeRange(1.25, 2.25)
@@ -147,12 +255,14 @@ class SceneVideoInputTest {
             .sentenceAudio(input, input.value, range, "/cache/audio.m4a", caFile)
             .toList()
         val video = SceneFfmpegArguments
-            .animatedAvif(
+            .animatedAvifMediaCodec(
                 input = input,
                 acquiredInputValue = input.value,
                 range = range,
                 outputFile = "/cache/scene.avif",
                 encoderName = TEST_AV1_ENCODER_NAME,
+                contentSize = SceneVideoDimensions(width = 640, height = 360),
+                outputSize = SceneVideoDimensions(width = 640, height = 368),
                 tlsCaFile = caFile,
             )
             .toList()


### PR DESCRIPTION
> [!IMPORTANT]
> **Ready for code review; device validation remains a merge gate.** Local Kotlin compilation and focused scene tests pass, but JVM tests mock the native executor and cannot prove vendor MediaCodec behavior. Unsupported or failed animation generation deliberately returns the already-captured still image.

## The problem

Animated Anki scene capture worked on the device and media shape it was first built around, but the implementation made assumptions that Android's codec API does not guarantee:

- choose the first advertised AV1 encoder;
- ask it for one fixed 640×640 shape;
- assume the source's coded width/height are its display geometry;
- assume 8-bit input and a simple YUV420 layout;
- treat command success as proof that the AVIF is decodable from frame zero;
- allow native cancellation and Kotlin cleanup to race each other;
- silently fall back when any of those gates fail.

Real devices vary in alignment, minimum/maximum dimensions, block budgets, conditional width ranges, rate support, color formats, CQ support, and vendor behavior. Real media also carries rotation, sample-aspect ratio, 10-bit SDR, HDR metadata, embedded subtitle streams, SAF inputs, and remote URLs.

The result was not one isolated bug. Depending on device/input, capture could select an unusable encoder, distort portrait or anamorphic video, request unsupported dimensions, produce an AVIF with an invalid first frame, fail on a harmless subtitle stream, lose cancellation, leak/delete files at the wrong time, or simply return a still with no useful diagnostic.

## Concrete failures that drove the design

These were not hypothetical codec-matrix concerns:

- **Samsung Galaxy S24 Ultra / SAF input:** ffprobe received `/proc/self/fd/497`, reopened it by path, lost the SAF grant, and failed with `Permission denied` before MediaCodec ran. The fix is FFmpegKit's native `saf:` protocol rather than reopening a FUSE-backed descriptor path. [Diagnosis](https://github.com/bee-san/chimahon/issues/17#issuecomment-5140488273)
- **Lenovo TB132FU / capability gate:** its only AV1 encoder rejected the synthetic `640×640 @ 8 fps` check, so capture returned in roughly 13 ms even though the actual 16:9 source could be encoded at `640×360`. Source-aware selection later produced a validated 32-frame, four-second looping AVIF. [Failure](https://github.com/bee-san/chimahon/issues/17#issuecomment-5140945401) · [follow-up pass](https://github.com/bee-san/chimahon/issues/17#issuecomment-5142526155)
- **Samsung Galaxy S24 Ultra / subtitled MP4:** stream discovery rejected a normal H.264/AAC MP4 because its embedded `mov_text` stream was missing from the bounded decoder whitelist. The subtitle was not output, but libavformat still initialized it while probing. Adding `mov_text` allowed the same input to produce animated AVIF and sentence audio. [Diagnosis and follow-up](https://github.com/bee-san/chimahon/issues/17#issuecomment-5143060749)
- **HiBy M500:** a predecessor validation build produced two independently named, valid 32-frame AVIFs and visibly looped the second in AnkiDroid. [Device result](https://github.com/bee-san/chimahon/issues/17#issuecomment-5143703608)

These runs establish the actual failure modes and validate predecessor integrated builds. They are **not** exact-head coverage of this standalone upstream PR; that is why the vendor matrix remains open below.

## Approaches tried before this one

### Fixed 640×640 capability check

This was simple, but it asked the wrong question. An encoder may support a useful portrait or landscape canvas while rejecting 640×640, or advertise 640×640 while imposing alignment/rate/conditional-range constraints elsewhere. Forcing visible content into that square also risks distortion.

**Why rejected:** codec capability is a constraint-solving problem, not a single `isSizeSupported(640, 640)` check.

### First advertised AV1 encoder

Codec enumeration order is not a quality or compatibility guarantee. The first encoder may lack planar YUV420, constant-quality mode, a usable quality range, 8 fps support, or enough resolution for the source while a later candidate works.

**Why rejected:** it turns vendor ordering into application behavior and misses valid alternatives.

### Normalize raw AV1 OBUs in Kotlin, then remux in a second FFmpeg pass

An earlier implementation wrote an intermediate AV1 stream, normalized OBUs in Kotlin, and remuxed that file into AVIF.

**Why rejected:** it duplicated AV1 syntax handling outside FFmpeg, added a second native session and temporary file, complicated cancellation/ownership, and still could not safely repair MediaCodec's internal GOP/reference state. The native invariants are handled by the narrowly patched dependency in #99 instead.

### Accept any file that FFmpeg reports as successful

A non-empty file and zero exit code do not prove a valid animated AVIF. Container boxes can point outside the file, sample sizes can disagree, timing can be unusable, and frame 1 may not be independently decodable.

**Why rejected:** animation is optional; failing closed to the still image is safer than handing corrupt media to Anki.

### Retry broadly or permit every input

Blind retries repeat deterministic codec/container failures. Passing extension arguments, credentials, DRM/transient sources, or unrestricted remote protocols into FFmpeg expands both the failure and security surface.

**Why rejected:** select capabilities before encoding and reject unsafe inputs before native execution.

## Why this solution

The final path is **probe → select → encode once → validate → deliver or fall back**.

### 1. Freeze and inspect the request

The request carries the resolved scene timing and a stable video-input description. Capture rejects missing/changed state rather than guessing at a different stream or time range.

ffprobe extracts the facts needed for encoding:

- coded width and height;
- sample-aspect ratio;
- display rotation;
- pixel format and bit depth;
- color primaries and transfer function;
- selected video stream.

Invalid dimensions, protected/HDR/BT.2020 content, unsafe sources, and unusable probe output fail before an output file is committed. 8-bit and 10-bit **SDR** input are accepted; 10-bit input is converted to `yuv420p`, not advertised as preserved 10-bit output.

### 2. Evaluate every usable hardware AV1 encoder

`SceneAv1EncoderSelector` examines each MediaCodec AV1 candidate for:

- encoder status and hardware suitability;
- planar YUV420 support;
- constant-quality mode and target quality;
- width/height alignment;
- size/rate and conditional width constraints at 8 fps;
- a canvas bounded to 640×640.

Display geometry is derived from coded dimensions, SAR, and rotation. Visible content is scaled without intentional distortion and then black-padded into a supported 16-pixel-aligned canvas. Candidate ranking first preserves content resolution, then avoids an unnecessarily large canvas.

This separates **content size** from **encoder canvas size**—the key distinction the fixed-square approach lacked.

### 3. Use one native encode/mux command

The selected stream is sampled at 8 fps, scaled/padded, converted to `yuv420p`, encoded with the chosen `av1_mediacodec` encoder, and muxed directly into looping AVIF.

The two-pass Kotlin OBU/remux pipeline is gone. #99 supplies the native parser/MediaCodec reset/configuration/first-keyframe fixes required for this direct path.

The command remains bounded:

- maximum 10 seconds / 80 frames;
- maximum 640 pixels per dimension;
- 10 MiB output limit;
- restricted decoders and protocols;
- TLS verification and bounded remote I/O;
- `mov_text` allowed so an embedded MP4 subtitle track does not invalidate otherwise safe video.

### 4. Validate before ownership transfer

A successful native return is necessary but not sufficient. `AnimatedAvifValidator` checks the output's:

- AVIF brands and AV1 configuration;
- dimensions and frame count;
- duration/timing tables;
- sample tables, sample sizes, and media-data bounds;
- first-sample sync evidence when `stss` is present.

If command construction, probing, encoding, validation, or delivery fails, partial output is removed and the caller keeps the still-image fallback.

### 5. Make cancellation and cleanup native-aware

Kotlin cancellation does not mean native FFmpeg has already stopped. The implementation therefore separates Kotlin ownership from native-use leases:

- cancellation is rethrown rather than converted into an ordinary failure;
- running native work is cancelled and awaited before descriptors/files are released;
- invalid and partial output is deleted;
- a validated file remains owned by the capture operation until delivery succeeds;
- cancellation after validation but before delivery cannot orphan the file.

### 6. Produce useful diagnostics without leaking inputs

The original path had many early returns and almost no explanation; one device test could return a still without revealing which gate fired.

Tagged `SceneMining` logs now cover request rejection, probe output, encoder selection, native failure, validation, cancellation, and cleanup. Remote paths and embedded URLs are reduced/redacted, and FFmpegKit's own unredacted logcat output remains suppressed.

## Input policy

The path supports seekable local inputs and constrained public HTTP(S)/HLS sources. It intentionally rejects or falls back for:

- DRM/protected media;
- HDR transfer functions and BT.2020 primaries;
- DASH, torrents/transient, or nonseekable sources;
- extension-provided FFmpeg arguments;
- credential-bearing URLs and sensitive signed/auth query keys;
- non-allowlisted headers;
- devices with no qualifying hardware AV1 encoder.

Those are explicit safety/portability decisions, not accidental unsupported cases.

## Scope

This PR includes MediaCodec selection, geometry, probe/command construction, capture ownership, AVIF validation, safe input handling, redacted diagnostics, and focused tests.

It deliberately excludes:

- the patched native dependency itself (#99);
- the optional worker-process/AIDL boundary (#100);
- player surface, PiP, config, and progress-overlay changes (#102).

## Verification

Verified at exact head `f0624257e6237e7fd796f08104f9e4ac4086abbf`:

- `./gradlew :app:compileDebugKotlin` — **BUILD SUCCESSFUL**
- focused `eu.kanade.tachiyomi.ui.player.scene.*` tests — **69 passed, 0 failed, 0 errors, 0 skipped**
- all changed scene files pass scoped Spotless checks
- `git diff --check` passes

The focused test task initially encountered an unrelated baseline test-compile defect: `ReaderOcrSourceTest` omits the now-required `mokuroAvailable` argument. The same mismatch exists on upstream `main`; it was temporarily supplied only in the isolated verification worktree, then reverted. No such change is in this PR.

Upstream PR CI currently stops earlier at repository-wide Spotless failures in untouched `presentation-core` code, so the red check does not represent a compile/test failure in this diff.

## What the tests cover

Focused coverage exercises:

- landscape, portrait, square, narrow, odd/minimum-size, alignment, conditional-range, and competing-encoder selection;
- SAR/rotation geometry and exact scale/pad filters;
- 8/10-bit SDR acceptance and HDR/protected-media rejection;
- one-command AVIF arguments and decoder/protocol restrictions;
- AVIF brands, bounds, dimensions, timing, sample sizes, payload, and first-sync validation;
- success, unavailable encoder, dimension mismatch, argument failure, partial-output deletion, cancellation during native work, and undelivered-output cleanup;
- tagged/redacted diagnostics.

## Remaining device work

- [ ] Qualcomm, MediaTek, Exynos, and Tensor MediaCodec implementations where available
- [ ] devices with no AV1 encoder (must keep the still fallback)
- [ ] rotated, anamorphic/SAR, odd-sized, portrait, landscape, square, 8-bit SDR, and 10-bit SDR media
- [ ] local files, SAF providers, public HTTPS MP4, and public HLS
- [ ] frame-zero decode, looping, duration, aspect ratio, padding, and Anki import
- [ ] cancellation during probe/encode and cancellation after validation
- [ ] malformed output, native failure, and repeated captures
- [ ] confirm rejected credentialed/HDR/DRM/transient inputs fail closed without leaking paths

This PR is the selected design because it asks the platform what it can encode, preserves display geometry, performs one bounded native operation, validates the artifact before delivery, and treats animation as optional. It does not claim universal vendor compatibility until the device matrix is complete.
