### PR TITLE
fix(player): harden player lifecycle behavior

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
@@ -20,6 +20,7 @@ package eu.kanade.tachiyomi.ui.player
 import android.content.Context
 import android.os.Build
 import android.os.Environment
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
@@ -51,15 +52,42 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet) : BaseMPVView(c
     var isExiting = false
     var surfaceReady = false
         private set
+    private val playbackLoadGate = SurfacePlaybackLoadGate { url ->
+        if (isExiting) {
+            false
+        } else {
+            MPVLib.command(arrayOf("loadfile", url, "replace"))
+            true
+        }
+    }
 
     override fun surfaceCreated(holder: SurfaceHolder) {
         super.surfaceCreated(holder)
         surfaceReady = true
+        playbackLoadGate.onSurfaceCreated()
     }
 
     override fun surfaceDestroyed(holder: SurfaceHolder) {
+        playbackLoadGate.onSurfaceDestroyed()
         surfaceReady = false
         super.surfaceDestroyed(holder)
+    }
+
+    fun loadFileWhenSurfaceReady(url: String) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            playbackLoadGate.load(url)
+        } else {
+            post { playbackLoadGate.load(url) }
+        }
+    }
+
+    fun retryPendingLoad() {
+        playbackLoadGate.retryPending()
+    }
+
+    fun destroyPlayer() {
+        playbackLoadGate.close()
+        destroy()
     }
 
     private fun getPropertyInt(property: String): Int? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/MpvConfigDirectoryResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/MpvConfigDirectoryResolver.kt
@@ -1,0 +1,17 @@
+package eu.kanade.tachiyomi.ui.player
+
+internal fun resolveMpvConfigDirectory(
+    internalConfigDirectory: String,
+    useExternalConfigDirectory: Boolean,
+    externalConfigDirectory: () -> String?,
+    onExternalFailure: (Exception) -> Unit = {},
+): String {
+    if (!useExternalConfigDirectory) return internalConfigDirectory
+
+    return try {
+        externalConfigDirectory()?.takeIf { it.isNotBlank() } ?: internalConfigDirectory
+    } catch (error: Exception) {
+        onExternalFailure(error)
+        internalConfigDirectory
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PictureInPictureGuard.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PictureInPictureGuard.kt
@@ -1,0 +1,21 @@
+package eu.kanade.tachiyomi.ui.player
+
+internal class PictureInPictureGuard(
+    initiallyAvailable: Boolean,
+    private val onRejected: (IllegalStateException) -> Unit = {},
+) {
+    var isAvailable = initiallyAvailable
+        private set
+
+    fun runIfAvailable(operation: () -> Boolean): Boolean {
+        if (!isAvailable) return false
+
+        return try {
+            operation()
+        } catch (error: IllegalStateException) {
+            isAvailable = false
+            onRejected(error)
+            false
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -43,6 +43,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.os.Looper
 import android.util.Rational
 import android.view.KeyEvent
 import android.view.View
@@ -142,10 +143,19 @@ class PlayerActivity : BaseActivity() {
     private var restoreAudioFocus: () -> Unit = {}
 
     private var pipRect: Rect? = null
-    val isPipSupportedAndEnabled by lazy {
-        packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
-            playerPreferences.enablePip().get()
+    private val pipGuard by lazy {
+        PictureInPictureGuard(
+            initiallyAvailable = packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
+                playerPreferences.enablePip().get(),
+            onRejected = { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Picture-in-picture disabled after framework rejection"
+                }
+            },
+        )
     }
+    val isPipSupportedAndEnabled: Boolean
+        get() = pipGuard.isAvailable
 
     private var pipReceiver: BroadcastReceiver? = null
 
@@ -396,7 +406,9 @@ class PlayerActivity : BaseActivity() {
                     castManager = castManager, // Pass the castManager instance
                     onBackPress = {
                         if (isPipSupportedAndEnabled && player.paused == false && playerPreferences.pipOnExit().get()) {
-                            enterPictureInPictureMode(createPipParams())
+                            if (!enterPictureInPictureIfAvailable()) {
+                                finish()
+                            }
                         } else {
                             finish()
                         }
@@ -525,7 +537,7 @@ class PlayerActivity : BaseActivity() {
 
         MPVLib.removeLogObserver(playerObserver)
         MPVLib.removeObserver(playerObserver)
-        player.destroy()
+        player.destroyPlayer()
         castManager.cleanup()
 
 
@@ -574,7 +586,7 @@ class PlayerActivity : BaseActivity() {
     @SuppressLint("MissingSuperCall")
     override fun onUserLeaveHint() {
         if (isPipSupportedAndEnabled && player.paused == false && playerPreferences.pipOnExit().get()) {
-            enterPictureInPictureMode()
+            enterPictureInPictureIfAvailable()
         }
         super.onUserLeaveHint()
     }
@@ -586,7 +598,9 @@ class PlayerActivity : BaseActivity() {
                 viewModel.panelShown.value == Panels.None &&
                 viewModel.dialogShown.value == Dialogs.None
             ) {
-                enterPictureInPictureMode()
+                if (!enterPictureInPictureIfAvailable()) {
+                    super.onBackPressed()
+                }
             }
         } else {
             super.onBackPressed()
@@ -595,7 +609,7 @@ class PlayerActivity : BaseActivity() {
 
     override fun onStart() {
         super.onStart()
-        setPictureInPictureParams(createPipParams())
+        updatePictureInPictureParamsIfAvailable()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.setFlags(
             WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
@@ -642,18 +656,24 @@ class PlayerActivity : BaseActivity() {
     }
 
     private fun loadPlayableUrl(url: String) {
-        MPVLib.command(arrayOf("loadfile", url, "replace"))
+        player.loadFileWhenSurfaceReady(url)
     }
 
     private fun setupPlayerMPV() {
         val logLevel = if (networkPreferences.verboseLogging().get()) "info" else "warn"
         val internalConfigDir = applicationContext.filesDir.path
 
-        val configDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()) {
-            storageManager.getMPVConfigDirectory()!!.filePath!!
-        } else {
-            internalConfigDir
-        }
+        val configDir = resolveMpvConfigDirectory(
+            internalConfigDirectory = internalConfigDir,
+            useExternalConfigDirectory = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                Environment.isExternalStorageManager(),
+            externalConfigDirectory = { storageManager.getMPVConfigDirectory()?.filePath },
+            onExternalFailure = { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to resolve external MPV config directory; using internal storage"
+                }
+            },
+        )
 
         val mpvConfFile = File("$configDir/mpv.conf")
         advancedPlayerPreferences.mpvConf().get().let { mpvConfFile.writeText(it) }
@@ -890,6 +910,7 @@ class PlayerActivity : BaseActivity() {
         }
 
         player.isExiting = false
+        player.retryPendingLoad()
         super.onResume()
 
         viewModel.currentVolume.update {
@@ -962,7 +983,7 @@ class PlayerActivity : BaseActivity() {
                 }
 
                 runCatching {
-                    setPictureInPictureParams(createPipParams())
+                    updatePictureInPictureParamsIfAvailable()
                 }
 
             }
@@ -1023,6 +1044,19 @@ class PlayerActivity : BaseActivity() {
         }
     }
 
+    internal fun updatePictureInPictureParamsIfAvailable(): Boolean {
+        return pipGuard.runIfAvailable {
+            setPictureInPictureParams(createPipParams())
+            true
+        }
+    }
+
+    internal fun enterPictureInPictureIfAvailable(): Boolean {
+        return pipGuard.runIfAvailable {
+            enterPictureInPictureMode(createPipParams())
+        }
+    }
+
     fun createPipParams(): PictureInPictureParams {
         val builder = PictureInPictureParams.Builder()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -1065,7 +1099,7 @@ class PlayerActivity : BaseActivity() {
                 pipReceiver = null
             }
         } else {
-            setPictureInPictureParams(createPipParams())
+            updatePictureInPictureParamsIfAvailable()
             viewModel.hideControls()
             viewModel.hideSeekBar()
             viewModel.isBrightnessSliderShown.update { false }
@@ -1081,7 +1115,7 @@ class PlayerActivity : BaseActivity() {
                         PIP_PREVIOUS -> viewModel.changeEpisode(true)
                         PIP_SKIP -> viewModel.seekBy(10)
                     }
-                    setPictureInPictureParams(createPipParams())
+                    updatePictureInPictureParamsIfAvailable()
                 }
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -1341,6 +1375,10 @@ class PlayerActivity : BaseActivity() {
     }
 
     fun setVideo(video: Video?, position: Long? = null) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            runOnUiThread { setVideo(video, position) }
+            return
+        }
         if (player.isExiting) return
         if (video == null) return
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1446,7 +1446,7 @@ class PlayerViewModel @JvmOverloads constructor(
         activity.player.paused = true
         _paused.update { true }
         runCatching {
-            activity.setPictureInPictureParams(activity.createPipParams())
+            activity.updatePictureInPictureParamsIfAvailable()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/SurfacePlaybackLoadGate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/SurfacePlaybackLoadGate.kt
@@ -1,0 +1,45 @@
+package eu.kanade.tachiyomi.ui.player
+
+internal class SurfacePlaybackLoadGate(
+    private val loadNow: (String) -> Boolean,
+) {
+    private var isSurfaceReady = false
+    private var isClosed = false
+    private var pendingUrl: String? = null
+
+    fun load(url: String) {
+        if (isClosed) return
+
+        if (isSurfaceReady && loadNow(url)) {
+            pendingUrl = null
+        } else {
+            pendingUrl = url
+        }
+    }
+
+    fun onSurfaceCreated() {
+        if (isClosed) return
+
+        isSurfaceReady = true
+        retryPending()
+    }
+
+    fun retryPending() {
+        if (isClosed || !isSurfaceReady) return
+
+        val url = pendingUrl ?: return
+        if (loadNow(url)) {
+            pendingUrl = null
+        }
+    }
+
+    fun onSurfaceDestroyed() {
+        isSurfaceReady = false
+    }
+
+    fun close() {
+        isClosed = true
+        isSurfaceReady = false
+        pendingUrl = null
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -644,7 +644,7 @@ fun PlayerControls(
                         isPipAvailable = activity.isPipSupportedAndEnabled,
                         onPipClick = {
                             if (!viewModel.isLoadingEpisode.value) {
-                                activity.enterPictureInPictureMode(activity.createPipParams())
+                                activity.enterPictureInPictureIfAvailable()
                             }
                         },
                         onAspectClick = {

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/MpvConfigDirectoryResolverTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/MpvConfigDirectoryResolverTest.kt
@@ -1,0 +1,79 @@
+package eu.kanade.tachiyomi.ui.player
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class MpvConfigDirectoryResolverTest {
+
+    @Test
+    fun `external config directory is used when it is available`() {
+        assertEquals(
+            "/storage/emulated/0/chimaFork/mpv",
+            resolveMpvConfigDirectory(
+                internalConfigDirectory = "/data/user/0/app.chimahon.dev/files",
+                useExternalConfigDirectory = true,
+                externalConfigDirectory = { "/storage/emulated/0/chimaFork/mpv" },
+            ),
+        )
+    }
+
+    @Test
+    fun `missing external directory falls back to internal storage`() {
+        assertEquals(
+            "/data/user/0/app.chimahon.dev/files",
+            resolveMpvConfigDirectory(
+                internalConfigDirectory = "/data/user/0/app.chimahon.dev/files",
+                useExternalConfigDirectory = true,
+                externalConfigDirectory = { null },
+            ),
+        )
+    }
+
+    @Test
+    fun `blank external path falls back to internal storage`() {
+        assertEquals(
+            "/data/user/0/app.chimahon.dev/files",
+            resolveMpvConfigDirectory(
+                internalConfigDirectory = "/data/user/0/app.chimahon.dev/files",
+                useExternalConfigDirectory = true,
+                externalConfigDirectory = { " " },
+            ),
+        )
+    }
+
+    @Test
+    fun `external lookup failure falls back and reports the cause`() {
+        val failure = SecurityException("Persisted URI grant is missing")
+        var reportedFailure: Exception? = null
+
+        assertEquals(
+            "/data/user/0/app.chimahon.dev/files",
+            resolveMpvConfigDirectory(
+                internalConfigDirectory = "/data/user/0/app.chimahon.dev/files",
+                useExternalConfigDirectory = true,
+                externalConfigDirectory = { throw failure },
+                onExternalFailure = { reportedFailure = it },
+            ),
+        )
+        assertSame(failure, reportedFailure)
+    }
+
+    @Test
+    fun `external directory is not queried without all files access`() {
+        var lookupCount = 0
+
+        assertEquals(
+            "/data/user/0/app.chimahon.dev/files",
+            resolveMpvConfigDirectory(
+                internalConfigDirectory = "/data/user/0/app.chimahon.dev/files",
+                useExternalConfigDirectory = false,
+                externalConfigDirectory = {
+                    lookupCount++
+                    "/storage/emulated/0/chimaFork/mpv"
+                },
+            ),
+        )
+        assertEquals(0, lookupCount)
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PictureInPictureGuardTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PictureInPictureGuardTest.kt
@@ -1,0 +1,89 @@
+package eu.kanade.tachiyomi.ui.player
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PictureInPictureGuardTest {
+
+    @Test
+    fun `unavailable picture in picture skips framework calls`() {
+        var calls = 0
+        val guard = PictureInPictureGuard(initiallyAvailable = false)
+
+        val completed = guard.runIfAvailable {
+            calls++
+            true
+        }
+
+        assertFalse(completed)
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `available picture in picture runs framework calls`() {
+        var calls = 0
+        val guard = PictureInPictureGuard(initiallyAvailable = true)
+
+        val completed = guard.runIfAvailable {
+            calls++
+            true
+        }
+
+        assertTrue(completed)
+        assertTrue(guard.isAvailable)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `framework rejection disables later picture in picture calls`() {
+        val rejection = IllegalStateException("Device doesn't support picture-in-picture mode")
+        var reportedFailure: IllegalStateException? = null
+        var calls = 0
+        val guard = PictureInPictureGuard(
+            initiallyAvailable = true,
+            onRejected = { reportedFailure = it },
+        )
+
+        val firstCompleted = guard.runIfAvailable {
+            calls++
+            throw rejection
+        }
+        val secondCompleted = guard.runIfAvailable {
+            calls++
+            true
+        }
+
+        assertFalse(firstCompleted)
+        assertFalse(secondCompleted)
+        assertFalse(guard.isAvailable)
+        assertSame(rejection, reportedFailure)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `framework false result is preserved without disabling later calls`() {
+        val guard = PictureInPictureGuard(initiallyAvailable = true)
+
+        val completed = guard.runIfAvailable { false }
+
+        assertFalse(completed)
+        assertTrue(guard.isAvailable)
+    }
+
+    @Test
+    fun `unexpected failures are not hidden`() {
+        val failure = IllegalArgumentException("Invalid picture-in-picture parameters")
+        val guard = PictureInPictureGuard(initiallyAvailable = true)
+
+        val thrown = assertThrows(IllegalArgumentException::class.java) {
+            guard.runIfAvailable { throw failure }
+        }
+
+        assertSame(failure, thrown)
+        assertTrue(guard.isAvailable)
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/SurfacePlaybackLoadGateTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/SurfacePlaybackLoadGateTest.kt
@@ -1,0 +1,114 @@
+package eu.kanade.tachiyomi.ui.player
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SurfacePlaybackLoadGateTest {
+
+    @Test
+    fun `cold start defers playback until the surface exists`() {
+        val loaded = mutableListOf<String>()
+        val gate = SurfacePlaybackLoadGate {
+            loaded += it
+            true
+        }
+
+        gate.load("content://episode")
+
+        assertTrue(loaded.isEmpty())
+
+        gate.onSurfaceCreated()
+
+        assertEquals(listOf("content://episode"), loaded)
+    }
+
+    @Test
+    fun `latest pending load replaces an older request`() {
+        val loaded = mutableListOf<String>()
+        val gate = SurfacePlaybackLoadGate {
+            loaded += it
+            true
+        }
+
+        gate.load("content://old")
+        gate.load("content://new")
+        gate.onSurfaceCreated()
+
+        assertEquals(listOf("content://new"), loaded)
+    }
+
+    @Test
+    fun `surface recreation defers new playback until reattached`() {
+        val loaded = mutableListOf<String>()
+        val gate = SurfacePlaybackLoadGate {
+            loaded += it
+            true
+        }
+
+        gate.onSurfaceCreated()
+        gate.load("content://first")
+        gate.onSurfaceDestroyed()
+        gate.load("content://second")
+
+        assertEquals(listOf("content://first"), loaded)
+
+        gate.onSurfaceCreated()
+
+        assertEquals(listOf("content://first", "content://second"), loaded)
+    }
+
+    @Test
+    fun `surface recreation without a pending request does not reload`() {
+        val loaded = mutableListOf<String>()
+        val gate = SurfacePlaybackLoadGate {
+            loaded += it
+            true
+        }
+
+        gate.onSurfaceCreated()
+        gate.load("content://episode")
+        gate.onSurfaceDestroyed()
+        gate.onSurfaceCreated()
+
+        assertEquals(listOf("content://episode"), loaded)
+    }
+
+    @Test
+    fun `closing the gate drops pending and future loads`() {
+        val loaded = mutableListOf<String>()
+        val gate = SurfacePlaybackLoadGate {
+            loaded += it
+            true
+        }
+
+        gate.load("content://pending")
+        gate.close()
+        gate.onSurfaceCreated()
+        gate.load("content://late")
+
+        assertTrue(loaded.isEmpty())
+    }
+
+    @Test
+    fun `rejected surface load remains pending until playback resumes`() {
+        val loaded = mutableListOf<String>()
+        var canLoad = false
+        val gate = SurfacePlaybackLoadGate {
+            if (canLoad) {
+                loaded += it
+            }
+            canLoad
+        }
+
+        gate.onSurfaceCreated()
+        gate.load("content://episode")
+
+        assertTrue(loaded.isEmpty())
+
+        canLoad = true
+        gate.retryPending()
+
+        assertEquals(listOf("content://episode"), loaded)
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Ready for code review; device validation remains before merge.** These fixes make lifecycle decisions explicit and unit-testable, but player surfaces and picture-in-picture remain framework/device behavior that JVM tests cannot fully prove.

## The problem

Animated scene testing exposed several player failures that were adjacent to capture but not caused by the AVIF container code:

1. **Playback could issue `loadfile` before MPV had a surface, during surface recreation, or while teardown was in progress.**
   Depending on timing, a cold start or episode change could be lost, run against a destroyed player, or leave the UI and native player disagreeing about the current video.

2. **`setVideo()` could be called off the main thread.**
   It touches Activity/player state, so relying on every upstream caller to arrive on the UI thread leaves a race at the boundary.

3. **External MPV config resolution assumed storage state could not change.**
   `getMPVConfigDirectory()!!.filePath!!` could fail when a configured directory was missing, blank, revoked, or threw during storage lookup—even though the internal config directory was a valid fallback.

4. **Feature detection did not make picture-in-picture calls safe.**
   Android can still reject `setPictureInPictureParams()` or `enterPictureInPictureMode()` with `IllegalStateException` because of current Activity/framework state. The previous code repeatedly called the framework after such a rejection.

5. **Scene generation used a modal dialog.**
   The dialog obscured the player and made the difference between “still cancellable” and “already committing” awkward. It was too heavy for optional background media preparation.

These issues were split from the MediaCodec/FFmpeg changes so they can be reviewed and merged independently.

## Why the obvious fixes were not enough

### “Call `loadfile` and let MPV queue it”

There were two earlier behaviors, each solving only half the problem:

- falling back to `player.playFile()` avoided the missing-surface case but could bypass the MPV `start` position already configured for resume;
- replacing that with unconditional `loadfile <url> replace` preserved start-position behavior but reintroduced the surface race.

Leaving `loadfile` to native timing can run across `surfaceCreated`, `surfaceDestroyed`, resume, and player destruction. A delayed callback can also load an obsolete episode after a newer request.

**Chosen instead:** retain the required `loadfile ... replace` semantics while keeping only the latest pending URL in a small surface-aware gate. Flush it when a surface becomes ready or the Activity resumes; close the gate before destroying MPV so no later retry can reach a dead player.

### “Post a retry with a delay”

A timer guesses when the surface will exist, can outlive the Activity, and introduces ordering races between episode changes.

**Chosen instead:** react to the actual surface lifecycle and keep deterministic latest-request-wins semantics.

### “The PiP preference and feature flag are true, so the call is safe”

Those checks describe capability, not current framework state. Catching every exception would hide programming errors, while retrying after `IllegalStateException` repeats a rejected operation.

**Chosen instead:** a `PictureInPictureGuard` catches only the framework's `IllegalStateException`, logs it, disables subsequent PiP attempts for that Activity, and uses the normal finish/back path. Unexpected exception types are not swallowed.

### “Keep asserting the external config path”

External storage permissions and providers are mutable runtime state. Crashing the player because an optional config location disappeared is worse than using the app's internal config.

**Chosen instead:** a resolver accepts only a nonblank external path and otherwise returns the internal directory. Exceptions are logged and fallback remains deterministic.

### “Keep the modal progress dialog”

The operation has two phases: preparation can be cancelled, but commit should not pretend cancellation is still safe. A modal window also blocks context the user may want to see.

**Chosen instead:** a compact top overlay with a polite accessibility live region. It shows the cancel action only before the commit boundary and consumes taps only inside the overlay.

## The selected design

### Surface-aware playback gate

`SurfacePlaybackLoadGate` is a small state machine with four facts: surface readiness, closed state, one pending URL, and a `loadNow` callback.

- before a surface: retain the URL;
- on surface creation/resume: retry it;
- on a newer request: replace the old pending URL;
- on surface destruction: stop immediate loads but retain pending state;
- on player destruction: close and clear everything;
- if `loadNow` reports failure: keep the latest URL for a later retry.

`AniyomiMPVView.loadFileWhenSurfaceReady()` also posts to the main looper when necessary. This keeps ordering and native player access on the UI thread.

### Main-thread video boundary

`PlayerActivity.setVideo()` checks the current looper and redispatches itself through `runOnUiThread` before touching player or Activity state. The guard sits at the mutating boundary rather than depending on every caller.

### PiP rejection guard

All PiP parameter updates and entry attempts go through one guard. After an `IllegalStateException`, PiP becomes unavailable for the rest of that Activity instance; back/finish behavior continues normally instead of repeatedly invoking a framework path that already failed.

### MPV config fallback

The player prefers the external config only when requested and successfully resolved to a nonblank path. Null, blank, missing, or exceptional lookups use the internal app directory and record the external failure.

### Non-modal scene progress

The new top overlay:

- leaves the player visible;
- respects safe drawing insets;
- exposes progress through an accessibility live region;
- has a 48 dp cancel target during the cancellable phase;
- removes the cancel action once commit begins;
- prevents taps on the overlay from leaking through to player controls.

## Scope

This PR includes only player and UI lifecycle hardening:

- surface/load sequencing;
- main-thread dispatch for video changes;
- PiP rejection behavior;
- MPV config-directory fallback;
- scene-progress overlay behavior.

It deliberately excludes:

- FFmpegKit dependency/native fixes (#99);
- scene worker-process isolation (#100);
- MediaCodec probing, AVIF generation, validation, and diagnostics (#101).

## Verification

- One commit directly on upstream `main`.
- `git diff --check` passes.
- `./gradlew :app:compileDebugKotlin` passes.
- Focused unit coverage was added for:
  - load before surface creation;
  - latest pending URL replacement;
  - retry after failed load;
  - surface recreation and close/destroy behavior;
  - PiP disabled/unavailable, successful entry, framework rejection, and no retry after rejection;
  - internal config selection plus null, blank, and throwing external lookups.
- Upstream PR CI currently stops at repository-wide Spotless failures in untouched `presentation-core` baseline code before build/tests.

## Remaining device checks

- [ ] cold player startup before surface creation
- [ ] rapid episode changes while the surface is created/recreated
- [ ] background/resume with a pending load
- [ ] Activity destruction with queued/off-main callbacks
- [ ] PiP supported, unsupported, user-disabled, and framework-rejected states across Android versions
- [ ] revoked/missing external MPV config permissions
- [ ] scene preparation cancellation versus non-cancellable commit
- [ ] overlay insets, accessibility announcement, rotation, and player-control interaction

This approach was selected because it replaces timing guesses and scattered exception handling with small stateful boundaries that encode the actual lifecycle rules and can be tested independently.
