### PR TITLE
fix(player): allow YouTube export audio

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureService.kt
@@ -81,18 +81,47 @@ internal class SentenceAudioCaptureService(
     }
 
     private suspend fun resolveInput(snapshot: SentenceAudioInputSnapshot, input: SentenceAudioInputSpec): Resolution {
-        val first = resolveOne(input)
-        if (first !is Resolution.Unavailable || input.origin != SentenceAudioInputOrigin.ORIGINAL_VIDEO || !first.failure.isPlayableFallbackRetryable()) {
-            return first
+        var current = resolveOne(input)
+        if (current is Resolution.Ready) {
+            return current
         }
+        val currentFailure = (current as? Resolution.Unavailable)?.failure ?: AnkiSentenceAudioFailure.SOURCE_UNAVAILABLE
+
+        if (input.origin == SentenceAudioInputOrigin.EXTERNAL_AUDIO) {
+            if (input.audioStreamIndex != null) {
+                val unindexedExternal = input.copy(audioStreamIndex = null)
+                val retryExternal = resolveOne(unindexedExternal)
+                if (retryExternal is Resolution.Ready) return retryExternal
+                if (retryExternal is Resolution.Unavailable) current = retryExternal
+            }
+
+            val originalFallback = SentenceAudioInputResolver.resolveOriginalVideoSpec(snapshot)
+                ?.copy(audioStreamIndex = null)
+            if (originalFallback != null && originalFallback.value != input.value) {
+                val fallbackFailure = (current as? Resolution.Unavailable)?.failure ?: currentFailure
+                record(SentenceAudioDiagnosticStage.FALLBACK_DECISION, input, SentenceAudioDiagnosticFallback.ATTEMPTED, fallbackFailure)
+                val second = resolveOne(originalFallback)
+                if (second is Resolution.Ready) return second
+                if (second is Resolution.Unavailable) current = second
+            }
+
+            return current
+        }
+
+        if (current is Resolution.Unavailable && !current.failure.isPlayableFallbackRetryable()) {
+            return current
+        }
+
+        val activeFailure = (current as? Resolution.Unavailable)?.failure ?: currentFailure
+
         return when (val fallback = SentenceAudioInputResolver.resolvePlayableFallback(snapshot, input)) {
             is SentenceAudioPlayableFallbackResolution.Available -> {
-                record(SentenceAudioDiagnosticStage.FALLBACK_DECISION, input, SentenceAudioDiagnosticFallback.ATTEMPTED, first.failure)
+                record(SentenceAudioDiagnosticStage.FALLBACK_DECISION, input, SentenceAudioDiagnosticFallback.ATTEMPTED, activeFailure)
                 resolveOne(fallback.input)
             }
-            SentenceAudioPlayableFallbackResolution.Missing -> unavailableResolution(first.failure, input, AnkiSentenceAudioPlayableFallback.MISSING)
-            SentenceAudioPlayableFallbackResolution.SameAsOriginal -> unavailableResolution(first.failure, input, AnkiSentenceAudioPlayableFallback.SAME_AS_ORIGINAL)
-            SentenceAudioPlayableFallbackResolution.Unavailable -> unavailableResolution(first.failure, input, AnkiSentenceAudioPlayableFallback.UNAVAILABLE)
+            SentenceAudioPlayableFallbackResolution.Missing -> unavailableResolution(activeFailure, input, AnkiSentenceAudioPlayableFallback.MISSING)
+            SentenceAudioPlayableFallbackResolution.SameAsOriginal -> unavailableResolution(activeFailure, input, AnkiSentenceAudioPlayableFallback.SAME_AS_ORIGINAL)
+            SentenceAudioPlayableFallbackResolution.Unavailable -> unavailableResolution(activeFailure, input, AnkiSentenceAudioPlayableFallback.UNAVAILABLE)
         }
     }
 
@@ -143,7 +172,7 @@ internal class SentenceAudioCaptureService(
             ProbeResult.Failed -> Resolution.Unavailable(AnkiSentenceAudioFailure.AUDIO_PROBE_FAILED, input.diagnostic())
             is ProbeResult.Success -> when {
                 SentenceAudioMediaProbe.audioStreams(discovery.output).isNotEmpty() -> Resolution.Unavailable(AnkiSentenceAudioFailure.AUDIO_CODEC_RESTRICTED, input.diagnostic())
-                input.kind == SentenceAudioInputKind.REMOTE_HTTP && input.origin == SentenceAudioInputOrigin.ORIGINAL_VIDEO && input.audioStreamIndex != null -> Resolution.Ready(input)
+                input.kind == SentenceAudioInputKind.REMOTE_HTTP && input.audioStreamIndex != null -> Resolution.Ready(input)
                 else -> Resolution.Unavailable(AnkiSentenceAudioFailure.AUDIO_STREAMS_NOT_FOUND, input.diagnostic())
             }
         }
@@ -182,6 +211,22 @@ internal class SentenceAudioCaptureService(
     }
 
     private suspend fun extract(input: SentenceAudioInputSpec, range: ClosedFloatingPointRange<Double>): AnkiSentenceAudioPreparation {
+        val primary = executeOnce(input, range)
+        if (primary is AnkiSentenceAudioPreparation.Ready) return primary
+
+        if (primary is AnkiSentenceAudioPreparation.Unavailable &&
+            primary.failure == AnkiSentenceAudioFailure.EXTRACTION_STREAM_MAPPING_FAILED &&
+            input.audioStreamIndex != null
+        ) {
+            val fallbackInput = input.copy(audioStreamIndex = null)
+            val retry = executeOnce(fallbackInput, range)
+            if (retry is AnkiSentenceAudioPreparation.Ready) return retry
+        }
+
+        return primary
+    }
+
+    private suspend fun executeOnce(input: SentenceAudioInputSpec, range: ClosedFloatingPointRange<Double>): AnkiSentenceAudioPreparation {
         val lease = inputAcquirer.acquire(input) ?: return unavailable(AnkiSentenceAudioFailure.SOURCE_UNAVAILABLE, input, SentenceAudioDiagnosticStage.AUDIO_EXTRACTION)
         val output = File(cacheDirectory, "chimahon_sentence_audio_${System.nanoTime()}.m4a")
         val inputCleanup = NativeCleanup(lease::close)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureService.kt
@@ -90,7 +90,7 @@ internal class SentenceAudioCaptureService(
         if (input.origin == SentenceAudioInputOrigin.EXTERNAL_AUDIO) {
             if (input.audioStreamIndex != null) {
                 val unindexedExternal = input.copy(audioStreamIndex = null)
-                val retryExternal = resolveOne(unindexedExternal)
+                val retryExternal = resolveInventory(unindexedExternal)
                 if (retryExternal is Resolution.Ready) return retryExternal
                 if (retryExternal is Resolution.Unavailable) current = retryExternal
             }
@@ -218,9 +218,11 @@ internal class SentenceAudioCaptureService(
             primary.failure == AnkiSentenceAudioFailure.EXTRACTION_STREAM_MAPPING_FAILED &&
             input.audioStreamIndex != null
         ) {
-            val fallbackInput = input.copy(audioStreamIndex = null)
-            val retry = executeOnce(fallbackInput, range)
-            if (retry is AnkiSentenceAudioPreparation.Ready) return retry
+            val inventory = resolveInventory(input.copy(audioStreamIndex = null))
+            if (inventory is Resolution.Ready) {
+                val retry = executeOnce(inventory.input, range)
+                if (retry is AnkiSentenceAudioPreparation.Ready) return retry
+            }
         }
 
         return primary

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnostics.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnostics.kt
@@ -53,7 +53,7 @@ internal object SentenceAudioDiagnosticJournal {
     const val maxLogBytes = 64 * 1024
     private const val maxNativeDiagnosticChars = 32 * 1024
     private val urlPattern = Regex("""(?i)\b(?:https?|file)://[^\s"'<>]+""")
-    private val sensitiveQueryPattern = Regex("""(?i)\b(access_token|api_key|auth|authorization|credential|credentials|key|policy|signature|signed|sig|token|x-amz-[^=\s]+|x-goog-[^=\s]+)=([^&\s]+)""")
+    private val sensitiveQueryPattern = Regex("""(?i)\b(access_token|api_key|auth|authorization|credential|credentials|key|policy|signature|signed|sig|lsig|token|x-amz-[^=\s]+|x-goog-[^=\s]+)=([^&\s]+)""")
     private val sensitiveHeaderPattern = Regex("""(?im)^((?:authorization|cookie|referer|origin|user-agent|accept(?:-[a-z-]+)?|cache-control|pragma|proxy-authorization|x-[a-z0-9-]+)\s*:\s*).*$""")
     private val localPathPattern = Regex("""(?i)(?:[a-z]:\\|/(?:data|storage|sdcard|mnt|cache|files)/)[^\s"'<>]+""")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnostics.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnostics.kt
@@ -36,7 +36,12 @@ internal object SentenceAudioDiagnosticJournal {
     }
     fun render(event: SentenceAudioDiagnosticEvent): String = buildString {
         appendLine("recorded_at_utc=${System.currentTimeMillis()}"); appendLine("stage=${event.stage.name}")
-        event.input?.let { appendLine("input_source=${it.origin.name}"); appendLine("input_kind=${it.kind.name}"); appendLine("audio_stream_index=${it.audioStreamIndex ?: "none"}") }
+        event.input?.let {
+            appendLine("input_source=${it.origin.name}")
+            appendLine("input_kind=${it.kind.name}")
+            appendLine("audio_stream_index=${it.audioStreamIndex ?: "none"}")
+            appendLine("input_value_sanitized=${SentenceAudioInputResolver.sanitizeForLog(it.value)}")
+        }
         appendLine("fallback=${event.fallback.name}"); event.failure?.let { appendLine("failure=${it.name}") }; event.result?.let { appendResult(it) }; event.exceptionType?.let { appendLine("exception_type=$it") }; appendLine("---")
     }
     private fun StringBuilder.appendResult(result: SentenceAudioCommandResult) = when (result) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
@@ -132,11 +132,16 @@ internal object SentenceAudioInputResolver {
             SentenceAudioInputKind.REMOTE_HTTP -> validateRemoteInput(normalized.first, snapshot.headers) ?: return null
             SentenceAudioInputKind.LOCAL_FILE, SentenceAudioInputKind.CONTENT_URI -> emptyList()
         }
+        val audioStreamIndex = if (origin == SentenceAudioInputOrigin.EXTERNAL_AUDIO || !snapshot.selectedAudioIsExternal) {
+            snapshot.selectedAudioFfmpegIndex?.takeIf { it >= 0 }
+        } else {
+            null
+        }
         return SentenceAudioInputSpec(
             value = normalized.first,
             kind = normalized.second,
             headers = headers,
-            audioStreamIndex = snapshot.selectedAudioFfmpegIndex?.takeIf { it >= 0 },
+            audioStreamIndex = audioStreamIndex,
             origin = origin,
         )
     }
@@ -144,7 +149,8 @@ internal object SentenceAudioInputResolver {
     private fun validateRemoteInput(value: String, headers: List<Pair<String, String>>): List<Pair<String, String>>? {
         val uri = runCatching { URI(value) }.getOrNull() ?: return null
         val host = uri.host?.lowercase(Locale.ROOT)
-        if (!uri.userInfo.isNullOrBlank() || host.isNullOrBlank() || hasRejectedValidationQuery(uri.rawQuery.orEmpty(), host)) return null
+        val scheme = uri.scheme?.lowercase(Locale.ROOT)
+        if (!uri.userInfo.isNullOrBlank() || host.isNullOrBlank() || hasRejectedValidationQuery(uri.rawQuery.orEmpty(), host, scheme)) return null
         return headers.takeIf { it.all(::isAllowedHeader) }
     }
 
@@ -163,12 +169,12 @@ internal object SentenceAudioInputResolver {
             value.none { it == '\u0000' || it == '\r' || it == '\n' || (it.code < 0x20 && it != '\t') }
     }
 
-    private fun hasRejectedValidationQuery(query: String, host: String): Boolean = query.split('&').any { parameter ->
+    private fun hasRejectedValidationQuery(query: String, host: String, scheme: String?): Boolean = query.split('&').any { parameter ->
         if (parameter.isBlank()) return@any false
         val name = runCatching { URLDecoder.decode(parameter.substringBefore('='), StandardCharsets.UTF_8.name()).lowercase(Locale.ROOT) }.getOrNull()
             ?: return true
         name in rejectedValidationQueryNames ||
-            (name in signedMediaQueryNames && !host.isYouTubeVideoCdn()) ||
+            (name in signedMediaQueryNames && (scheme != "https" || !host.isYouTubeVideoCdn())) ||
             sensitiveQueryPrefixes.any(name::startsWith)
     }
 
@@ -203,8 +209,8 @@ internal object SentenceAudioInputResolver {
 
     private val allowedHttpHeaders = setOf("user-agent", "accept", "accept-encoding", "accept-language", "cache-control", "origin", "pragma", "referer")
     private val rejectedValidationQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "token")
-    private val signedMediaQueryNames = setOf("signature", "signed", "sig")
-    private val sensitiveLogQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "signature", "signed", "sig", "token")
+    private val signedMediaQueryNames = setOf("signature", "signed", "sig", "lsig")
+    private val sensitiveLogQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "signature", "signed", "sig", "lsig", "token")
     private val sensitiveQueryPrefixes = setOf("x-amz-", "x-goog-")
     private val transientSchemes = setOf("blob", "data", "fd", "fdclose", "edl", "memory", "lavf", "ytdl")
     private const val maxHeaderValueLength = 8_192

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
@@ -107,10 +107,18 @@ internal object SentenceAudioInputResolver {
         if (snapshot.seekable != true || snapshot.ffmpegStreamArgs.isNotEmpty() || snapshot.ffmpegVideoArgs.isNotEmpty()) {
             return SentenceAudioInputResolution.Unavailable(AnkiSentenceAudioFailure.SOURCE_UNAVAILABLE)
         }
-        return resolveValue(snapshot.selectedExternalAudioValue ?: snapshot.originalVideoValue, snapshot, SentenceAudioInputOrigin.EXTERNAL_AUDIO)
-            ?.let(SentenceAudioInputResolution::Available)
-            ?: SentenceAudioInputResolution.Unavailable(AnkiSentenceAudioFailure.SOURCE_UNAVAILABLE)
+        val externalValue = snapshot.selectedExternalAudioValue?.takeIf(String::isNotBlank)
+        if (externalValue != null) {
+            val externalSpec = resolveValue(externalValue, snapshot, SentenceAudioInputOrigin.EXTERNAL_AUDIO)
+            if (externalSpec != null) {
+                return SentenceAudioInputResolution.Available(externalSpec)
+            }
+        }
+        return resolveOriginalVideo(snapshot)
     }
+
+    fun resolveOriginalVideoSpec(snapshot: SentenceAudioInputSnapshot): SentenceAudioInputSpec? =
+        (resolveOriginalVideo(snapshot) as? SentenceAudioInputResolution.Available)?.input
 
     private fun resolveValue(
         value: String?,
@@ -135,7 +143,8 @@ internal object SentenceAudioInputResolver {
 
     private fun validateRemoteInput(value: String, headers: List<Pair<String, String>>): List<Pair<String, String>>? {
         val uri = runCatching { URI(value) }.getOrNull() ?: return null
-        if (!uri.userInfo.isNullOrBlank() || uri.host.isNullOrBlank() || hasRejectedValidationQuery(uri.rawQuery.orEmpty())) return null
+        val host = uri.host?.lowercase(Locale.ROOT)
+        if (!uri.userInfo.isNullOrBlank() || host.isNullOrBlank() || hasRejectedValidationQuery(uri.rawQuery.orEmpty(), host)) return null
         return headers.takeIf { it.all(::isAllowedHeader) }
     }
 
@@ -154,12 +163,16 @@ internal object SentenceAudioInputResolver {
             value.none { it == '\u0000' || it == '\r' || it == '\n' || (it.code < 0x20 && it != '\t') }
     }
 
-    private fun hasRejectedValidationQuery(query: String): Boolean = query.split('&').any { parameter ->
+    private fun hasRejectedValidationQuery(query: String, host: String): Boolean = query.split('&').any { parameter ->
         if (parameter.isBlank()) return@any false
         val name = runCatching { URLDecoder.decode(parameter.substringBefore('='), StandardCharsets.UTF_8.name()).lowercase(Locale.ROOT) }.getOrNull()
             ?: return true
-        name in rejectedValidationQueryNames || sensitiveQueryPrefixes.any(name::startsWith)
+        name in rejectedValidationQueryNames ||
+            (name in signedMediaQueryNames && !host.isYouTubeVideoCdn()) ||
+            sensitiveQueryPrefixes.any(name::startsWith)
     }
+
+    private fun String.isYouTubeVideoCdn() = this == "googlevideo.com" || endsWith(".googlevideo.com")
 
     fun sanitizeForLog(url: String): String {
         if (url.isBlank()) return url
@@ -190,6 +203,7 @@ internal object SentenceAudioInputResolver {
 
     private val allowedHttpHeaders = setOf("user-agent", "accept", "accept-encoding", "accept-language", "cache-control", "origin", "pragma", "referer")
     private val rejectedValidationQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "token")
+    private val signedMediaQueryNames = setOf("signature", "signed", "sig")
     private val sensitiveLogQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "signature", "signed", "sig", "token")
     private val sensitiveQueryPrefixes = setOf("x-amz-", "x-goog-")
     private val transientSchemes = setOf("blob", "data", "fd", "fdclose", "edl", "memory", "lavf", "ytdl")
@@ -208,7 +222,7 @@ internal object SentenceAudioFfmpegArguments {
     }.toTypedArray()
     private fun MutableList<String>.addInputOptions(input: SentenceAudioInputSpec, tlsCaFile: String?, restrict: Boolean = true) {
         if (restrict) { add("-codec_whitelist"); add(ALLOWED_INPUT_DECODERS) }
-        if (input.kind == SentenceAudioInputKind.REMOTE_HTTP) { require(!tlsCaFile.isNullOrBlank()); add("-protocol_whitelist"); add("http,https,tls,tcp,crypto"); add("-rw_timeout"); add("15000000") }
+        if (input.kind == SentenceAudioInputKind.REMOTE_HTTP) { require(!tlsCaFile.isNullOrBlank()); add("-protocol_whitelist"); add("http,https,tls,tcp,crypto,hls,applehttp,concat"); add("-rw_timeout"); add("15000000") }
         if (input.headers.isNotEmpty()) { add("-headers"); add(input.headers.joinToString("") { "${it.first}: ${it.second}\r\n" }) }
     }
     private fun Double.seconds() = String.format(Locale.ROOT, "%.6f", this).trimEnd('0').trimEnd('.')

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInput.kt
@@ -135,7 +135,7 @@ internal object SentenceAudioInputResolver {
 
     private fun validateRemoteInput(value: String, headers: List<Pair<String, String>>): List<Pair<String, String>>? {
         val uri = runCatching { URI(value) }.getOrNull() ?: return null
-        if (!uri.userInfo.isNullOrBlank() || uri.host.isNullOrBlank() || hasSensitiveQuery(uri.rawQuery.orEmpty())) return null
+        if (!uri.userInfo.isNullOrBlank() || uri.host.isNullOrBlank() || hasRejectedValidationQuery(uri.rawQuery.orEmpty())) return null
         return headers.takeIf { it.all(::isAllowedHeader) }
     }
 
@@ -154,10 +154,32 @@ internal object SentenceAudioInputResolver {
             value.none { it == '\u0000' || it == '\r' || it == '\n' || (it.code < 0x20 && it != '\t') }
     }
 
-    private fun hasSensitiveQuery(query: String): Boolean = query.split('&').any { parameter ->
+    private fun hasRejectedValidationQuery(query: String): Boolean = query.split('&').any { parameter ->
+        if (parameter.isBlank()) return@any false
         val name = runCatching { URLDecoder.decode(parameter.substringBefore('='), StandardCharsets.UTF_8.name()).lowercase(Locale.ROOT) }.getOrNull()
             ?: return true
-        name in sensitiveQueryNames || sensitiveQueryPrefixes.any(name::startsWith)
+        name in rejectedValidationQueryNames || sensitiveQueryPrefixes.any(name::startsWith)
+    }
+
+    fun sanitizeForLog(url: String): String {
+        if (url.isBlank()) return url
+        val queryStart = url.indexOf('?')
+        val pathPart = if (queryStart >= 0) url.substring(0, queryStart) else url
+        val queryPart = if (queryStart >= 0) url.substring(queryStart + 1) else null
+
+        val redactedQuery = queryPart?.split('&')?.joinToString("&") { param ->
+            val key = param.substringBefore('=')
+            val decodedKey = runCatching {
+                URLDecoder.decode(key, StandardCharsets.UTF_8.name()).lowercase(Locale.ROOT)
+            }.getOrDefault(key.lowercase(Locale.ROOT))
+            if (decodedKey in sensitiveLogQueryNames || sensitiveQueryPrefixes.any(decodedKey::startsWith)) {
+                "$key=[REDACTED]"
+            } else {
+                param
+            }
+        }
+
+        return if (redactedQuery != null) "$pathPart?$redactedQuery" else pathPart
     }
 
     private fun isDash(value: String) = value.substringBefore('?').endsWith(".mpd", ignoreCase = true) || value.startsWith("dash://", ignoreCase = true)
@@ -167,7 +189,8 @@ internal object SentenceAudioInputResolver {
     }
 
     private val allowedHttpHeaders = setOf("user-agent", "accept", "accept-encoding", "accept-language", "cache-control", "origin", "pragma", "referer")
-    private val sensitiveQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "signature", "signed", "sig", "token")
+    private val rejectedValidationQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "token")
+    private val sensitiveLogQueryNames = setOf("access_token", "api_key", "auth", "authorization", "credential", "credentials", "key", "policy", "signature", "signed", "sig", "token")
     private val sensitiveQueryPrefixes = setOf("x-amz-", "x-goog-")
     private val transientSchemes = setOf("blob", "data", "fd", "fdclose", "edl", "memory", "lavf", "ytdl")
     private const val maxHeaderValueLength = 8_192

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureServiceTest.kt
@@ -68,9 +68,10 @@ class SentenceAudioCaptureServiceTest {
     }
 
     @Test
-    fun `retries unindexed extraction after stream mapping failure`() = runTest {
+    fun `retries unindexed extraction after stream mapping failure only when single audio stream exists`() = runTest {
         val executor = FakeExecutor(
             selected = listOf(SentenceAudioCommandResult.Success(selectedAudio)),
+            all = listOf(SentenceAudioCommandResult.Success("[STREAM]\nindex=0\ncodec_type=audio\n[/STREAM]")),
             ffmpeg = listOf(
                 SentenceAudioCommandResult.FfmpegFailed(SentenceAudioFfmpegFailure.STREAM_MAPPING),
                 SentenceAudioCommandResult.Success(),
@@ -80,7 +81,21 @@ class SentenceAudioCaptureServiceTest {
         assertType<AnkiSentenceAudioPreparation.Ready>(result)
         assertEquals(2, executor.ffmpegCalls)
         assertTrue(executor.ffmpegArguments[0].contains("0:2"))
-        assertTrue(executor.ffmpegArguments[1].contains("0:a:0"))
+        assertTrue(executor.ffmpegArguments[1].contains("0:0"))
+    }
+
+    @Test
+    fun `does not retry unindexed extraction after stream mapping failure when multiple audio streams exist`() = runTest {
+        val executor = FakeExecutor(
+            selected = listOf(SentenceAudioCommandResult.Success(selectedAudio)),
+            all = listOf(SentenceAudioCommandResult.Success("[STREAM]\nindex=1\ncodec_type=audio\n[/STREAM]\n[STREAM]\nindex=2\ncodec_type=audio\n[/STREAM]")),
+            ffmpeg = listOf(
+                SentenceAudioCommandResult.FfmpegFailed(SentenceAudioFfmpegFailure.STREAM_MAPPING),
+            ),
+        )
+        val result = service(executor).prepare(request(index = 2))
+        assertFailure(AnkiSentenceAudioFailure.EXTRACTION_STREAM_MAPPING_FAILED, result)
+        assertEquals(1, executor.ffmpegCalls)
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioCaptureServiceTest.kt
@@ -45,23 +45,42 @@ class SentenceAudioCaptureServiceTest {
     }
 
     @Test
-    fun `does not retry external audio after its probe fails`() = runTest {
-        val executor = FakeExecutor(selected = listOf(SentenceAudioCommandResult.Failed))
-        val result = service(executor).prepare(request(external = true, externalValue = "https://media.example/audio.m4a", playable = "https://media.example/playable.mp4"))
-        assertFailure(AnkiSentenceAudioFailure.AUDIO_PROBE_FAILED, result)
-        assertEquals(1, executor.probeInputs.size)
+    fun `falls back to original video when external audio probe fails`() = runTest {
+        val executor = FakeExecutor(
+            selected = listOf(SentenceAudioCommandResult.Failed, SentenceAudioCommandResult.Failed, SentenceAudioCommandResult.Success(selectedAudio)),
+        )
+        val result = service(executor).prepare(request(index = 8, external = true, externalValue = "https://media.example/audio.m4a", playable = "https://media.example/playable.mp4"))
+        assertType<AnkiSentenceAudioPreparation.Ready>(result)
+        assertEquals(listOf("https://media.example/audio.m4a", "https://media.example/audio.m4a", "https://media.example/original.mp4"), executor.probeInputs)
+        assertEquals(listOf("8", "a:0", "a:0"), executor.probeSelectors)
     }
 
     @Test
     fun `does not retry playable input after extraction failure`() = runTest {
         val executor = FakeExecutor(
             selected = listOf(SentenceAudioCommandResult.Success(selectedAudio)),
-            ffmpeg = SentenceAudioCommandResult.FfmpegFailed(SentenceAudioFfmpegFailure.SOURCE_READ),
+            ffmpeg = listOf(SentenceAudioCommandResult.FfmpegFailed(SentenceAudioFfmpegFailure.SOURCE_READ)),
         )
         val result = service(executor).prepare(request(playable = "https://media.example/playable.mp4"))
         assertFailure(AnkiSentenceAudioFailure.EXTRACTION_SOURCE_READ_FAILED, result)
         assertEquals(1, executor.probeInputs.size)
         assertEquals(1, executor.ffmpegCalls)
+    }
+
+    @Test
+    fun `retries unindexed extraction after stream mapping failure`() = runTest {
+        val executor = FakeExecutor(
+            selected = listOf(SentenceAudioCommandResult.Success(selectedAudio)),
+            ffmpeg = listOf(
+                SentenceAudioCommandResult.FfmpegFailed(SentenceAudioFfmpegFailure.STREAM_MAPPING),
+                SentenceAudioCommandResult.Success(),
+            ),
+        )
+        val result = service(executor).prepare(request(index = 2))
+        assertType<AnkiSentenceAudioPreparation.Ready>(result)
+        assertEquals(2, executor.ffmpegCalls)
+        assertTrue(executor.ffmpegArguments[0].contains("0:2"))
+        assertTrue(executor.ffmpegArguments[1].contains("0:a:0"))
     }
 
     @Test
@@ -102,6 +121,27 @@ class SentenceAudioCaptureServiceTest {
         val executor = FakeExecutor(selected = listOf(SentenceAudioCommandResult.Success("codec_type=video")), all = listOf(SentenceAudioCommandResult.Success("")), discovery = listOf(SentenceAudioCommandResult.Success("")))
         assertType<AnkiSentenceAudioPreparation.Ready>(service(executor).prepare(request(index = 7)))
         assertTrue(executor.ffmpegArguments.single().contains("0:7"))
+    }
+
+    @Test
+    fun `attempts frozen external audio index after empty probes`() = runTest {
+        val executor = FakeExecutor(
+            selected = listOf(SentenceAudioCommandResult.Success("")),
+            all = listOf(SentenceAudioCommandResult.Success("")),
+            discovery = listOf(SentenceAudioCommandResult.Success("")),
+        )
+
+        val result = service(executor).prepare(
+            request(
+                index = 0,
+                external = true,
+                externalValue = "https://media.example/external-audio.webm",
+            ),
+        )
+
+        assertType<AnkiSentenceAudioPreparation.Ready>(result)
+        assertEquals(listOf("https://media.example/external-audio.webm"), executor.probeInputs.distinct())
+        assertTrue(executor.ffmpegArguments.single().contains("0:0"))
     }
 
     @Test
@@ -150,16 +190,17 @@ class SentenceAudioCaptureServiceTest {
         selected: List<SentenceAudioCommandResult> = listOf(SentenceAudioCommandResult.Success(selectedAudio)),
         private val all: List<SentenceAudioCommandResult> = listOf(SentenceAudioCommandResult.Success("")),
         private val discovery: List<SentenceAudioCommandResult> = listOf(SentenceAudioCommandResult.Success("")),
-        private val ffmpeg: SentenceAudioCommandResult = SentenceAudioCommandResult.Success(),
+        ffmpeg: List<SentenceAudioCommandResult> = listOf(SentenceAudioCommandResult.Success()),
         private val writeOutput: Boolean = true,
         private val neverFinish: Boolean = false,
     ) : SentenceAudioCommandExecutor {
         private val selectedQueue = ArrayDeque(selected)
         private val allQueue = ArrayDeque(all)
         private val discoveryQueue = ArrayDeque(discovery)
-        val probeInputs = mutableListOf<String>(); val ffmpegArguments = mutableListOf<List<String>>(); var ffmpegCalls = 0; var allProbeCalls = 0
+        private val ffmpegQueue = ArrayDeque(ffmpeg)
+        val probeInputs = mutableListOf<String>(); val probeSelectors = mutableListOf<String>(); val ffmpegArguments = mutableListOf<List<String>>(); var ffmpegCalls = 0; var allProbeCalls = 0
         override suspend fun executeFfprobe(arguments: Array<String>, onNativeFinished: () -> Unit): SentenceAudioCommandResult {
-            probeInputs += arguments.last(); val selector = arguments[arguments.indexOf("-select_streams") + 1]
+            probeInputs += arguments.last(); val selector = arguments[arguments.indexOf("-select_streams") + 1]; probeSelectors += selector
             val result = when (selector) { "a" -> if ("-codec_whitelist" in arguments) { allProbeCalls++; allQueue.removeFirstOrNull() ?: SentenceAudioCommandResult.Failed } else discoveryQueue.removeFirstOrNull() ?: SentenceAudioCommandResult.Failed; else -> selectedQueue.removeFirstOrNull() ?: SentenceAudioCommandResult.Failed }
             onNativeFinished(); return result
         }
@@ -168,8 +209,9 @@ class SentenceAudioCaptureServiceTest {
             if (neverFinish) return suspendCancellableCoroutine { continuation ->
                 continuation.invokeOnCancellation { onNativeFinished() }
             }
-            if (ffmpeg is SentenceAudioCommandResult.Success && writeOutput) File(arguments.last()).writeBytes(byteArrayOf(1, 2, 3))
-            onNativeFinished(); return ffmpeg
+            val result = ffmpegQueue.removeFirstOrNull() ?: SentenceAudioCommandResult.Failed
+            if (result is SentenceAudioCommandResult.Success && writeOutput) File(arguments.last()).writeBytes(byteArrayOf(1, 2, 3))
+            onNativeFinished(); return result
         }
     }
     private class BlockingExecutor : SentenceAudioCommandExecutor {

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnosticsTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioDiagnosticsTest.kt
@@ -21,6 +21,8 @@ class SentenceAudioDiagnosticsTest {
         val raw = """
             https://example.test/video.m3u8?token=secret
             Authorization: Bearer secret-value
+            lsig=secret-lsig-token
+            sig=secret-sig-token
             /data/user/0/app.chimahon.dev/cache/source.mp4
             C:\\Users\\teera\\AppData\\Local\\cache\\source.mp4
         """.trimIndent()
@@ -29,9 +31,13 @@ class SentenceAudioDiagnosticsTest {
 
         assertTrue(redacted.contains("<redacted-url>"))
         assertTrue(redacted.contains("Authorization: <redacted>"))
+        assertTrue(redacted.contains("lsig=<redacted>"))
+        assertTrue(redacted.contains("sig=<redacted>"))
         assertTrue(redacted.contains("<redacted-path>"))
         assertFalse(redacted.contains("example.test"))
         assertFalse(redacted.contains("secret"))
+        assertFalse(redacted.contains("secret-lsig-token"))
+        assertFalse(redacted.contains("secret-sig-token"))
         assertFalse(redacted.contains("source.mp4"))
         assertFalse(redacted.contains("C:\\Users"))
     }

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
@@ -36,20 +36,27 @@ class SentenceAudioInputTest {
     }
 
     @Test
-    fun `media URL signature parameters are supported only for YouTube CDN`() {
-        val input = resolve(snapshot("https://googlevideo.com/videoplayback?expire=123&sig=signatureValue&id=abc"))
-        assertNotNull(input)
-        assertEquals(SentenceAudioInputKind.REMOTE_HTTP, input?.kind)
+    fun `media URL signature parameters like sig and lsig are supported only for HTTPS YouTube CDN`() {
+        val inputSig = resolve(snapshot("https://googlevideo.com/videoplayback?expire=123&sig=signatureValue&id=abc"))
+        val inputLsig = resolve(snapshot("https://googlevideo.com/videoplayback?expire=123&lsig=signatureValue&id=abc"))
+        assertNotNull(inputSig)
+        assertNotNull(inputLsig)
+        assertEquals(SentenceAudioInputKind.REMOTE_HTTP, inputSig?.kind)
+        assertEquals(SentenceAudioInputKind.REMOTE_HTTP, inputLsig?.kind)
+        assertNull(resolve(snapshot("http://googlevideo.com/videoplayback?expire=123&sig=signatureValue&id=abc")))
+        assertNull(resolve(snapshot("http://googlevideo.com/videoplayback?expire=123&lsig=signatureValue&id=abc")))
         assertNull(resolve(snapshot("https://media.example/video.mp4?sig=signatureValue")))
     }
 
     @Test
-    fun `sanitizeForLog redacts sensitive tokens and preserves path`() {
-        val url = "https://googlevideo.com/videoplayback?expire=123&sig=secretKey123&id=abc"
+    fun `sanitizeForLog redacts sensitive tokens including sig and lsig and preserves path`() {
+        val url = "https://googlevideo.com/videoplayback?expire=123&sig=secretKey123&lsig=secretLsig456&id=abc"
         val sanitized = SentenceAudioInputResolver.sanitizeForLog(url)
         assertTrue(sanitized.contains("expire=123"))
         assertTrue(sanitized.contains("sig=[REDACTED]"))
+        assertTrue(sanitized.contains("lsig=[REDACTED]"))
         assertFalse(sanitized.contains("secretKey123"))
+        assertFalse(sanitized.contains("secretLsig456"))
     }
 
     @Test
@@ -69,7 +76,9 @@ class SentenceAudioInputTest {
         assertEquals(SentenceAudioInputOrigin.ORIGINAL_VIDEO, requireNotNull(resolve(snapshot("/video/original.mkv", playableValue = "/video/playable.mkv"))).origin)
         assertEquals(SentenceAudioInputOrigin.PLAYABLE_VIDEO, requireNotNull(resolve(snapshot("", playableValue = "/video/playable.mkv"))).origin)
         assertEquals(SentenceAudioInputOrigin.EXTERNAL_AUDIO, requireNotNull(resolve(snapshot("/video/original.mkv", selectedAudioIsExternal = true, selectedExternalAudioValue = "/audio/external.m4a"))).origin)
-        assertEquals(SentenceAudioInputOrigin.ORIGINAL_VIDEO, requireNotNull(resolve(snapshot("/video/original.mkv", selectedAudioIsExternal = true, selectedExternalAudioValue = null))).origin)
+        val fallbackSpec = requireNotNull(resolve(snapshot("/video/original.mkv", selectedAudioIsExternal = true, selectedExternalAudioValue = null, selectedAudioFfmpegIndex = 2)))
+        assertEquals(SentenceAudioInputOrigin.ORIGINAL_VIDEO, fallbackSpec.origin)
+        assertNull(fallbackSpec.audioStreamIndex)
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
@@ -36,10 +36,11 @@ class SentenceAudioInputTest {
     }
 
     @Test
-    fun `media URL signature parameters like sig are supported`() {
+    fun `media URL signature parameters are supported only for YouTube CDN`() {
         val input = resolve(snapshot("https://googlevideo.com/videoplayback?expire=123&sig=signatureValue&id=abc"))
         assertNotNull(input)
         assertEquals(SentenceAudioInputKind.REMOTE_HTTP, input?.kind)
+        assertNull(resolve(snapshot("https://media.example/video.mp4?sig=signatureValue")))
     }
 
     @Test
@@ -67,7 +68,8 @@ class SentenceAudioInputTest {
     fun `resolved inputs retain whether export uses original playable or external audio`() {
         assertEquals(SentenceAudioInputOrigin.ORIGINAL_VIDEO, requireNotNull(resolve(snapshot("/video/original.mkv", playableValue = "/video/playable.mkv"))).origin)
         assertEquals(SentenceAudioInputOrigin.PLAYABLE_VIDEO, requireNotNull(resolve(snapshot("", playableValue = "/video/playable.mkv"))).origin)
-        assertEquals(SentenceAudioInputOrigin.EXTERNAL_AUDIO, requireNotNull(resolve(snapshot("/audio/episode.m4a", selectedAudioIsExternal = true))).origin)
+        assertEquals(SentenceAudioInputOrigin.EXTERNAL_AUDIO, requireNotNull(resolve(snapshot("/video/original.mkv", selectedAudioIsExternal = true, selectedExternalAudioValue = "/audio/external.m4a"))).origin)
+        assertEquals(SentenceAudioInputOrigin.ORIGINAL_VIDEO, requireNotNull(resolve(snapshot("/video/original.mkv", selectedAudioIsExternal = true, selectedExternalAudioValue = null))).origin)
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/sentenceaudio/SentenceAudioInputTest.kt
@@ -26,14 +26,29 @@ class SentenceAudioInputTest {
     }
 
     @Test
-    fun `sensitive request metadata and signed URLs are rejected`() {
+    fun `sensitive request metadata and credential query parameters are rejected`() {
         listOf(
             snapshot("https://media.example/video.mp4", headers = listOf("Authorization" to "Bearer secret")),
             snapshot("https://media.example/video.mp4?access_token=secret"),
-            snapshot("https://media.example/video.mp4?signature=secret"),
-            snapshot("https://media.example/video.mp4?x-amz-signature=secret"),
+            snapshot("https://media.example/video.mp4?api_key=secret"),
             snapshot("https://user:password@media.example/video.mp4"),
         ).forEach { assertNull(resolve(it)) }
+    }
+
+    @Test
+    fun `media URL signature parameters like sig are supported`() {
+        val input = resolve(snapshot("https://googlevideo.com/videoplayback?expire=123&sig=signatureValue&id=abc"))
+        assertNotNull(input)
+        assertEquals(SentenceAudioInputKind.REMOTE_HTTP, input?.kind)
+    }
+
+    @Test
+    fun `sanitizeForLog redacts sensitive tokens and preserves path`() {
+        val url = "https://googlevideo.com/videoplayback?expire=123&sig=secretKey123&id=abc"
+        val sanitized = SentenceAudioInputResolver.sanitizeForLog(url)
+        assertTrue(sanitized.contains("expire=123"))
+        assertTrue(sanitized.contains("sig=[REDACTED]"))
+        assertFalse(sanitized.contains("secretKey123"))
     }
 
     @Test


### PR DESCRIPTION
## Problem
When mining sentence audio from YouTube videos using the YouTube Extension, card creation succeeded for stills and text but failed for sentence audio, producing the warning notification: *"The selected video source could not be read for sentence audio. The card was created without it."*

In addition, diagnostic reporting lacked explicit rejection reason details in UI Toast notifications when input validation failed prior to probe execution.

## Result
- **YouTube Extension Sentence Audio**: Sentence audio mining now works seamlessly for YouTube extension videos and media CDN streams signed with `sig=` parameters.
- **Clear Failure Feedback**: In the event of a video source rejection, Toast notifications now display the specific rejection detail.


This PR builds upon https://github.com/sohilsayed/chimahon/pull/96
