### PR TITLE
fix(player): append millisecond values to controls hide delay preference options

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsPlayerScreen.kt
@@ -1,4 +1,4 @@
-﻿package eu.kanade.presentation.more.settings.screen.player
+package eu.kanade.presentation.more.settings.screen.player
 
 import android.os.Build
 import androidx.compose.runtime.Composable
@@ -193,7 +193,7 @@ object PlayerSettingsPlayerScreen : SearchableSettings {
                     preference = hideTime,
                     title = stringResource(MR.strings.pref_player_time_to_disappear),
                     entries = listOf(500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000).associateWith {
-                        stringResource(MR.strings.pref_player_time_to_disappear_summary, it)
+                        "${stringResource(MR.strings.pref_player_time_to_disappear_summary)} ${it} ms"
                     }.toPersistentMap(),
                 ),
                 Preference.PreferenceItem.SliderPreference(


### PR DESCRIPTION
## Problem
In Player Settings > Player > Display > Controls hide delay, opening the duration selector dialog rendered 10 identical options displaying "Time before controls are hidden" instead of showing the time value for each entry (e.g., 500 ms, 1000 ms, 4000 ms). 

## Result
Each option in the "Controls hide delay" selection dialog now clearly displays the summary text along with its duration value in milliseconds (e.g., "Time before controls are hidden 4000 ms") and updates the preference subtitle correctly upon selection.
