### PR TITLE
fix(reader): persist Google Lens OCR results

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
@@ -99,6 +99,11 @@ class OcrCacheManager(
         }
     }
 
+    private fun hasNormalOcrPages(cacheFile: UniFile?): Boolean {
+        if (cacheFile?.exists() != true) return false
+        return readOcrData(cacheFile)?.pages?.isNotEmpty() == true
+    }
+
     /**
      * Save OCR blocks for a single page to the chapter's OCR cache file.
      */
@@ -172,25 +177,22 @@ class OcrCacheManager(
         chapter: Chapter,
         source: Source,
     ): Boolean = withContext(Dispatchers.IO) {
-        val chapterLocation = findChapterLocation(manga, chapter, source)
-        val isDownloaded = isChapterDownloaded(manga, chapter, source)
+        mutex.withLock {
+            val chapterLocation = findChapterLocation(manga, chapter, source)
+            val isDownloaded = isChapterDownloaded(manga, chapter, source)
 
-        val hasDownloadCache = if (chapterLocation != null && isDownloaded) {
-            when (chapterLocation) {
-                is ChapterLocation.Directory -> {
-                    chapterLocation.dir.findFile(OCR_CACHE_FILE)?.exists() == true
+            val downloadCacheFile = if (chapterLocation != null && isDownloaded) {
+                when (chapterLocation) {
+                    is ChapterLocation.Directory -> chapterLocation.dir.findFile(OCR_CACHE_FILE)
+                    is ChapterLocation.Cbz -> findSidecarFile(chapterLocation.file)
                 }
-                is ChapterLocation.Cbz -> {
-                    findSidecarFile(chapterLocation.file)?.exists() == true
-                }
+            } else {
+                null
             }
-        } else {
-            false
+
+            hasNormalOcrPages(downloadCacheFile) ||
+                hasNormalOcrPages(UniFile.fromFile(getInternalCacheFile(manga, chapter, source)))
         }
-
-        val hasInternalCache = getInternalCacheFile(manga, chapter, source).exists()
-
-        hasDownloadCache || hasInternalCache
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
@@ -109,6 +109,7 @@ class OcrCacheManager(
         pageIndex: Int,
         blocks: List<OcrTextBlock>,
         language: String,
+        cacheVariant: String? = null,
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
             val chapterLocation = findChapterLocation(manga, chapter, source)
@@ -118,15 +119,15 @@ class OcrCacheManager(
                 isDownloaded && chapterLocation != null -> {
                     when (chapterLocation) {
                         is ChapterLocation.Directory -> {
-                            saveToDirectory(chapterLocation.dir, pageIndex, blocks, language)
+                            saveToDirectory(chapterLocation.dir, pageIndex, blocks, language, cacheVariant)
                         }
                         is ChapterLocation.Cbz -> {
-                            saveToCbz(chapterLocation.file, pageIndex, blocks, language)
+                            saveToCbz(chapterLocation.file, pageIndex, blocks, language, cacheVariant)
                         }
                     }
                 }
                 else -> {
-                    saveToInternal(manga, chapter, source, pageIndex, blocks, language)
+                    saveToInternal(manga, chapter, source, pageIndex, blocks, language, cacheVariant)
                 }
             }
         }
@@ -140,6 +141,7 @@ class OcrCacheManager(
         chapter: Chapter,
         source: Source,
         pageIndex: Int,
+        cacheVariant: String? = null,
     ): List<OcrTextBlock>? = withContext(Dispatchers.IO) {
         mutex.withLock {
             val chapterLocation = findChapterLocation(manga, chapter, source)
@@ -147,8 +149,8 @@ class OcrCacheManager(
 
             val downloadBlocks = if (chapterLocation != null && isDownloaded) {
                 when (chapterLocation) {
-                    is ChapterLocation.Directory -> loadFromDirectory(chapterLocation.dir, pageIndex)
-                    is ChapterLocation.Cbz -> loadFromCbz(chapterLocation.file, pageIndex)
+                    is ChapterLocation.Directory -> loadFromDirectory(chapterLocation.dir, pageIndex, cacheVariant)
+                    is ChapterLocation.Cbz -> loadFromCbz(chapterLocation.file, pageIndex, cacheVariant)
                 }
             } else {
                 null
@@ -158,7 +160,7 @@ class OcrCacheManager(
                 return@withLock downloadBlocks
             }
 
-            loadFromInternal(manga, chapter, source, pageIndex)
+            loadFromInternal(manga, chapter, source, pageIndex, cacheVariant)
         }
     }
 
@@ -308,7 +310,13 @@ class OcrCacheManager(
     /**
      * Save OCR data to a directory-based chapter.
      */
-    private fun saveToDirectory(dir: UniFile, pageIndex: Int, blocks: List<OcrTextBlock>, language: String) {
+    private fun saveToDirectory(
+        dir: UniFile,
+        pageIndex: Int,
+        blocks: List<OcrTextBlock>,
+        language: String,
+        cacheVariant: String?,
+    ) {
         val cacheFile = dir.findFile(OCR_CACHE_FILE) ?: dir.createFile(OCR_CACHE_FILE)
         if (cacheFile == null) {
             logcat(LogPriority.ERROR) { "OcrCache: Failed to create cache file in directory" }
@@ -317,21 +325,20 @@ class OcrCacheManager(
 
         val chapterData = readOcrData(cacheFile) ?: return
 
-        val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
+        val pageData = OcrPageData(
             blocks = blocks.map { it.toBlockData() },
             language = language,
             version = CURRENT_VERSION,
         )
 
-        val newData = chapterData.copy(pages = updatedPages)
+        val newData = chapterData.withPage(pageIndex, pageData, cacheVariant)
         atomicWrite(cacheFile, json.encodeToString(newData))
     }
 
     /**
      * Load OCR data from a directory-based chapter.
      */
-    private fun loadFromDirectory(dir: UniFile, pageIndex: Int): List<OcrTextBlock>? {
+    private fun loadFromDirectory(dir: UniFile, pageIndex: Int, cacheVariant: String?): List<OcrTextBlock>? {
         val cacheFile = dir.findFile(OCR_CACHE_FILE) ?: return null
 
         return try {
@@ -341,7 +348,7 @@ class OcrCacheManager(
                 return null
             }
             val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
+            chapterData.page(pageIndex, cacheVariant)?.blocks?.map { it.toTextBlock() }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from directory" }
             null
@@ -366,7 +373,13 @@ class OcrCacheManager(
     /**
      * Save OCR data to a CBZ sidecar file.
      */
-    private fun saveToCbz(cbzFile: UniFile, pageIndex: Int, blocks: List<OcrTextBlock>, language: String) {
+    private fun saveToCbz(
+        cbzFile: UniFile,
+        pageIndex: Int,
+        blocks: List<OcrTextBlock>,
+        language: String,
+        cacheVariant: String?,
+    ) {
         val sidecarFile = getSidecarFile(cbzFile)
         if (sidecarFile == null) {
             logcat(LogPriority.ERROR) { "OcrCache: Failed to create sidecar file for CBZ" }
@@ -375,21 +388,20 @@ class OcrCacheManager(
 
         val chapterData = readOcrData(sidecarFile) ?: return
 
-        val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
+        val pageData = OcrPageData(
             blocks = blocks.map { it.toBlockData() },
             language = language,
             version = CURRENT_VERSION,
         )
 
-        val newData = chapterData.copy(pages = updatedPages)
+        val newData = chapterData.withPage(pageIndex, pageData, cacheVariant)
         atomicWrite(sidecarFile, json.encodeToString(newData))
     }
 
     /**
      * Load OCR data from a CBZ sidecar file.
      */
-    private fun loadFromCbz(cbzFile: UniFile, pageIndex: Int): List<OcrTextBlock>? {
+    private fun loadFromCbz(cbzFile: UniFile, pageIndex: Int, cacheVariant: String?): List<OcrTextBlock>? {
         val sidecarFile = findSidecarFile(cbzFile) ?: return null
 
         return try {
@@ -399,7 +411,7 @@ class OcrCacheManager(
                 return null
             }
             val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
+            chapterData.page(pageIndex, cacheVariant)?.blocks?.map { it.toTextBlock() }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from CBZ sidecar" }
             null
@@ -441,6 +453,7 @@ class OcrCacheManager(
         pageIndex: Int,
         blocks: List<OcrTextBlock>,
         language: String,
+        cacheVariant: String?,
     ) {
         val cacheFile = getInternalCacheFile(manga, chapter, source)
 
@@ -450,14 +463,13 @@ class OcrCacheManager(
             OcrChapterData(pages = emptyMap(), version = CURRENT_VERSION)
         }
 
-        val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
+        val pageData = OcrPageData(
             blocks = blocks.map { it.toBlockData() },
             language = language,
             version = CURRENT_VERSION,
         )
 
-        val newData = chapterData.copy(pages = updatedPages)
+        val newData = chapterData.withPage(pageIndex, pageData, cacheVariant)
         try {
             cacheFile.writeText(json.encodeToString(newData))
         } catch (e: Exception) {
@@ -473,6 +485,7 @@ class OcrCacheManager(
         chapter: Chapter,
         source: Source,
         pageIndex: Int,
+        cacheVariant: String?,
     ): List<OcrTextBlock>? {
         val cacheFile = getInternalCacheFile(manga, chapter, source)
         if (!cacheFile.exists()) {
@@ -486,7 +499,7 @@ class OcrCacheManager(
                 return null
             }
             val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
+            chapterData.page(pageIndex, cacheVariant)?.blocks?.map { it.toTextBlock() }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from internal storage" }
             null
@@ -555,5 +568,21 @@ class OcrCacheManager(
 @Serializable
 data class OcrChapterData(
     val pages: Map<Int, OcrPageData>,
+    val variants: Map<String, Map<Int, OcrPageData>> = emptyMap(),
     val version: Int = 2,
 )
+
+private fun OcrChapterData.page(pageIndex: Int, cacheVariant: String?): OcrPageData? {
+    return if (cacheVariant == null) pages[pageIndex] else variants[cacheVariant]?.get(pageIndex)
+}
+
+private fun OcrChapterData.withPage(
+    pageIndex: Int,
+    pageData: OcrPageData,
+    cacheVariant: String?,
+): OcrChapterData {
+    if (cacheVariant == null) return copy(pages = pages + (pageIndex to pageData))
+
+    val variantPages = variants[cacheVariant].orEmpty() + (pageIndex to pageData)
+    return copy(variants = variants + (cacheVariant to variantPages))
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -2529,6 +2529,11 @@ class ReaderViewModel @JvmOverloads constructor(
                 blocks
             }
 
+            ocrCacheMutex.withLock {
+                ocrCache[cacheKey] = finalBlocks
+                trimOcrCacheLocked()
+            }
+
             savePersistentOcrBlocks(
                 ocrSource = ocrSource,
                 manga = manga,
@@ -2552,11 +2557,6 @@ class ReaderViewModel @JvmOverloads constructor(
                 language = ocrLang.bcp47,
             )
 
-            ocrCacheMutex.withLock {
-                ocrCache[cacheKey] = finalBlocks
-                trimOcrCacheLocked()
-            }
-
             val elapsedMs = SystemClock.elapsedRealtime() - startMs
             if (elapsedMs >= 1200) {
                 logcat(LogPriority.WARN) {
@@ -2568,6 +2568,8 @@ class ReaderViewModel @JvmOverloads constructor(
                 }
             }
             finalBlocks
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val elapsedMs = SystemClock.elapsedRealtime() - startMs
             logcat(LogPriority.WARN, e) {
@@ -2587,15 +2589,23 @@ class ReaderViewModel @JvmOverloads constructor(
         language: String,
     ) {
         if (!ocrSource.persistsOcrResults) return
-        ocrCacheManager.saveOcrBlocks(
-            manga = manga,
-            chapter = chapter,
-            source = source,
-            pageIndex = pageIndex,
-            blocks = blocks,
-            language = language,
-            cacheVariant = ocrSource.persistentCacheVariant,
-        )
+        try {
+            ocrCacheManager.saveOcrBlocks(
+                manga = manga,
+                chapter = chapter,
+                source = source,
+                pageIndex = pageIndex,
+                blocks = blocks,
+                language = language,
+                cacheVariant = ocrSource.persistentCacheVariant,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) {
+                "OCR cache write failed: chapter=${chapter.id} page=$pageIndex source=$ocrSource"
+            }
+        }
     }
 
     private fun trimOcrCacheLocked() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1735,7 +1735,7 @@ class ReaderViewModel @JvmOverloads constructor(
             }
         }
 
-        if (ocrSource.usesPersistentCache) {
+        if (ocrSource.persistsOcrResults) {
             loadCachedOcrBlocks(page, ocrSource)?.let { cached ->
                 return cached
             }
@@ -1776,7 +1776,7 @@ class ReaderViewModel @JvmOverloads constructor(
             ocrCache[cacheKey]?.let { return it }
         }
 
-        return if (ocrSource.usesPersistentCache) {
+        return if (ocrSource.persistsOcrResults) {
             loadCachedOcrBlocks(page, ocrSource).orEmpty()
         } else {
             emptyList()
@@ -1793,7 +1793,13 @@ class ReaderViewModel @JvmOverloads constructor(
         val mangaSource = sourceManager.getOrStub(manga.source)
         val cacheKey = OcrCacheKey(chapterId = chapterId, pageIndex = page.index, ocrSource = ocrSource)
 
-        val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, mangaSource, page.index)
+        val diskBlocks = ocrCacheManager.loadOcrBlocks(
+            manga = manga,
+            chapter = domainChapter,
+            source = mangaSource,
+            pageIndex = page.index,
+            cacheVariant = ocrSource.persistentCacheVariant,
+        )
             ?.takeIf { it.isNotEmpty() }
             ?.map { it.toViewerBlock() }
             ?: return null
@@ -2422,8 +2428,14 @@ class ReaderViewModel @JvmOverloads constructor(
 
         if (ocrSource == ReaderOcrSource.MOKURO) return emptyList()
 
-        if (ocrSource.usesPersistentCache) {
-            val diskBlocks = ocrCacheManager.loadOcrBlocks(manga, domainChapter, source, page.index)
+        if (ocrSource.persistsOcrResults) {
+            val diskBlocks = ocrCacheManager.loadOcrBlocks(
+                manga = manga,
+                chapter = domainChapter,
+                source = source,
+                pageIndex = page.index,
+                cacheVariant = ocrSource.persistentCacheVariant,
+            )
             if (diskBlocks != null && diskBlocks.isNotEmpty()) {
                 ocrCacheMutex.withLock {
                     ocrCache[cacheKey] = diskBlocks.map { it.toViewerBlock() }
@@ -2574,8 +2586,16 @@ class ReaderViewModel @JvmOverloads constructor(
         blocks: List<chimahon.ocr.OcrTextBlock>,
         language: String,
     ) {
-        if (!ocrSource.usesPersistentCache) return
-        ocrCacheManager.saveOcrBlocks(manga, chapter, source, pageIndex, blocks, language)
+        if (!ocrSource.persistsOcrResults) return
+        ocrCacheManager.saveOcrBlocks(
+            manga = manga,
+            chapter = chapter,
+            source = source,
+            pageIndex = pageIndex,
+            blocks = blocks,
+            language = language,
+            cacheVariant = ocrSource.persistentCacheVariant,
+        )
     }
 
     private fun trimOcrCacheLocked() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderOcrSource.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.ocr.OcrEngineType
 enum class ReaderOcrSource(
     val usesMokuro: Boolean,
     val usesPersistentCache: Boolean,
+    val persistentCacheVariant: String? = null,
     val recognitionEngine: OcrEngineType?,
 ) {
     AUTOMATIC(
@@ -20,6 +21,7 @@ enum class ReaderOcrSource(
     GOOGLE_LENS(
         usesMokuro = false,
         usesPersistentCache = false,
+        persistentCacheVariant = "google_lens",
         recognitionEngine = OcrEngineType.CLOUD,
     ),
     LOCAL(
@@ -28,6 +30,9 @@ enum class ReaderOcrSource(
         recognitionEngine = OcrEngineType.LOCAL,
     ),
     ;
+
+    val persistsOcrResults: Boolean
+        get() = usesPersistentCache || persistentCacheVariant != null
 
     companion object {
         fun availableSources(localOcrAvailable: Boolean, mokuroAvailable: Boolean): List<ReaderOcrSource> {


### PR DESCRIPTION
## Summary

- persist successful Google Lens reader OCR results to the existing chapter cache
- store Lens results in a separate `google_lens` variant so Automatic OCR cache data remains unchanged
- only treat default `pages` entries as normal chapter OCR readiness
- read the Lens variant before invoking Lens again, allowing cached OCR to load offline
- keep recognised blocks in memory when persistence fails while preserving coroutine cancellation

## Root cause

Google Lens is an explicit reader source with persistent caching disabled to avoid cross-source cache collisions. Its results therefore survived only in the ViewModel memory cache; after that cache was lost, the reader called the Lens network endpoint again.

Adding a Lens variant also exposed two edge cases: readiness used cache-file existence instead of inspecting normal page data, and a storage exception occurred before successful recognised blocks were put into the memory cache.

## Verification

- `./gradlew assembleDebug`
- existing `OcrManagerTest` and `ReaderOcrSourceTest`: 9 passed
- full unit suite: 100 passed; one unrelated existing player-audio test failed and also fails in isolation

No test files are included in this PR.

## CI note

The upstream `spotlessCheck` currently fails before the build on two unchanged `data` module files. This branch does not modify either file, and the same baseline failure occurred on the preceding upstream PR build.