### PR TITLE
perf(ocr): parse the chapter cache file once, not once per page

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,14 @@ android {
         includeInBundle = Config.includeDependencyInfo
     }
 
+    testOptions {
+        unitTests {
+            // Unit tests exercise UniFile-backed cache files, whose raw-file
+            // implementation calls trivial framework statics (TextUtils, Log).
+            isReturnDefaultValues = true
+        }
+    }
+
     buildFeatures {
         viewBinding = true
         buildConfig = true
@@ -241,7 +249,6 @@ dependencies {
     implementation(androidx.paging.compose)
 
     implementation(libs.bundles.sqlite)
-
 
     implementation(kotlinx.reflect)
     implementation(kotlinx.immutables)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -268,6 +268,8 @@ class DownloadCache(
                 }
             }
         }
+
+        notifyChanges()
     }
 
     // SY <--
@@ -536,4 +538,3 @@ private class MangaDirectory(
     val dir: UniFile?,
     var chapterDirs: MutableSet<String> = mutableSetOf(),
 )
-

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
@@ -48,6 +48,86 @@ class OcrCacheManager(
         private const val TMP_SUFFIX = ".tmp"
         private const val CURRENT_VERSION = 2
         private const val INTERNAL_OCR_DIR = "ocr_cache"
+        private const val MEMO_MAX_CHAPTERS = 4
+    }
+
+    // ========== In-memory chapter memo ==========
+    //
+    // The on-disk format stores a whole chapter per file, so a naive per-page read
+    // re-resolves the chapter location (SAF IPC round trips) and re-parses every
+    // page's blocks just to return one page - O(pages^2) work across a chapter.
+    // Since this class is the single reader/writer of the OCR cache files, a small
+    // memo of the parsed chapters is coherent by construction and turns every read
+    // after the first (including misses for pages with no OCR data yet) into an
+    // in-memory map lookup. All memo access is guarded by [mutex].
+
+    private data class ChapterKey(val sourceId: Long, val mangaId: Long, val chapterId: Long)
+
+    /**
+     * Parsed view of a chapter's OCR cache across both storage locations.
+     *
+     * [downloadData]/[internalData] are null when the backing file exists but is
+     * unreadable, so the save path keeps refusing to overwrite corrupt files.
+     */
+    private class MemoizedChapter(
+        val location: ChapterLocation?,
+        val isDownloaded: Boolean,
+        val downloadData: OcrChapterData?,
+        val internalData: OcrChapterData?,
+    )
+
+    private val chapterMemo = object : LinkedHashMap<ChapterKey, MemoizedChapter>(
+        MEMO_MAX_CHAPTERS,
+        0.75f,
+        true,
+    ) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<ChapterKey, MemoizedChapter>,
+        ): Boolean = size > MEMO_MAX_CHAPTERS
+    }
+
+    private fun memoKey(manga: Manga, chapter: Chapter, source: Source): ChapterKey {
+        return ChapterKey(sourceId = source.id, mangaId = manga.id, chapterId = chapter.id)
+    }
+
+    private fun emptyChapterData() = OcrChapterData(pages = emptyMap(), version = CURRENT_VERSION)
+
+    /**
+     * Get the memoized parse of a chapter's OCR cache, loading and memoizing it
+     * on first access. Must be called with [mutex] held.
+     */
+    private fun getOrLoadChapterLocked(manga: Manga, chapter: Chapter, source: Source): MemoizedChapter {
+        val key = memoKey(manga, chapter, source)
+        chapterMemo[key]?.let { return it }
+
+        val location = findChapterLocation(manga, chapter, source)
+        val isDownloaded = isChapterDownloaded(manga, chapter, source)
+
+        val downloadData = if (location != null && isDownloaded) {
+            when (location) {
+                is ChapterLocation.Directory -> readChapterData(location.dir.findFile(OCR_CACHE_FILE))
+                is ChapterLocation.Cbz -> readChapterData(findSidecarFile(location.file))
+            }
+        } else {
+            emptyChapterData()
+        }
+
+        val internalFile = getInternalCacheFile(manga, chapter, source)
+        val internalData = if (internalFile.exists()) {
+            UniFile.fromFile(internalFile)?.let { readOcrData(it) }
+        } else {
+            emptyChapterData()
+        }
+
+        val memoized = MemoizedChapter(location, isDownloaded, downloadData, internalData)
+        chapterMemo[key] = memoized
+        return memoized
+    }
+
+    /** Parse a whole cache file: absent file -> empty data, unreadable file -> null. */
+    private fun readChapterData(file: UniFile?): OcrChapterData? {
+        if (file == null) return emptyChapterData()
+        return readOcrData(file)
     }
 
     /**
@@ -101,6 +181,10 @@ class OcrCacheManager(
 
     /**
      * Save OCR blocks for a single page to the chapter's OCR cache file.
+     *
+     * The read-modify-write base comes from the chapter memo when it was built
+     * against the same target file, so per-page saves don't re-read and re-parse
+     * the whole chapter file; the memo is refreshed with the written data.
      */
     suspend fun saveOcrBlocks(
         manga: Manga,
@@ -111,29 +195,102 @@ class OcrCacheManager(
         language: String,
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
+            val key = memoKey(manga, chapter, source)
+            val memo = chapterMemo[key]
+
+            // Always re-resolve the write target so a chapter downloaded or
+            // removed mid-session is picked up; the memo is refreshed below.
             val chapterLocation = findChapterLocation(manga, chapter, source)
             val isDownloaded = isChapterDownloaded(manga, chapter, source)
 
-            when {
-                isDownloaded && chapterLocation != null -> {
-                    when (chapterLocation) {
-                        is ChapterLocation.Directory -> {
-                            saveToDirectory(chapterLocation.dir, pageIndex, blocks, language)
-                        }
-                        is ChapterLocation.Cbz -> {
-                            saveToCbz(chapterLocation.file, pageIndex, blocks, language)
-                        }
+            val newPage = OcrPageData(
+                blocks = blocks.map { it.toBlockData() },
+                language = language,
+                version = CURRENT_VERSION,
+            )
+
+            try {
+                if (isDownloaded && chapterLocation != null) {
+                    // Reuse the memoized parse as the read-modify-write base only
+                    // when it was built against this exact target file.
+                    val knownData = if (
+                        memo != null &&
+                        memo.isDownloaded &&
+                        memo.location?.uriString() == chapterLocation.uriString()
+                    ) {
+                        memo.downloadData
+                    } else {
+                        null
                     }
+                    val written = when (chapterLocation) {
+                        is ChapterLocation.Directory ->
+                            saveToDirectory(chapterLocation.dir, pageIndex, newPage, knownData)
+                        is ChapterLocation.Cbz ->
+                            saveToCbz(chapterLocation.file, pageIndex, newPage, knownData)
+                    }
+                    refreshMemoAfterSave(key, chapterLocation, isDownloaded, written, wroteToDownload = true)
+                } else {
+                    val written = saveToInternal(manga, chapter, source, pageIndex, newPage, memo?.internalData)
+                    refreshMemoAfterSave(key, chapterLocation, isDownloaded, written, wroteToDownload = false)
                 }
-                else -> {
-                    saveToInternal(manga, chapter, source, pageIndex, blocks, language)
-                }
+            } catch (e: Exception) {
+                // Disk state is uncertain after a failed write; drop the memo so
+                // the next read re-parses whatever is actually on disk.
+                chapterMemo.remove(key)
+                throw e
             }
         }
     }
 
     /**
+     * Refresh the chapter memo after a save attempt. [written] is the full
+     * chapter data now on disk for the written side, or null when the save was
+     * aborted. Only an existing memo entry is updated in place; building one
+     * from scratch is left to the next read so both sides always come from a
+     * real parse.
+     */
+    private fun refreshMemoAfterSave(
+        key: ChapterKey,
+        location: ChapterLocation?,
+        isDownloaded: Boolean,
+        written: OcrChapterData?,
+        wroteToDownload: Boolean,
+    ) {
+        if (written == null) {
+            chapterMemo.remove(key)
+            return
+        }
+        val old = chapterMemo[key] ?: return
+
+        chapterMemo[key] = if (wroteToDownload) {
+            MemoizedChapter(
+                location = location,
+                isDownloaded = isDownloaded,
+                downloadData = written,
+                // The internal cache path is fixed by ids, so its parse stays valid.
+                internalData = old.internalData,
+            )
+        } else {
+            // Keep the memoized download-side parse only if it still describes the
+            // freshly resolved target; otherwise fall back to the same
+            // "not downloaded" default the load path uses.
+            val downloadStillValid = old.isDownloaded == isDownloaded &&
+                old.location?.uriString() == location?.uriString()
+            MemoizedChapter(
+                location = location,
+                isDownloaded = isDownloaded,
+                downloadData = if (downloadStillValid) old.downloadData else emptyChapterData(),
+                internalData = written,
+            )
+        }
+    }
+
+    /**
      * Load OCR blocks for a single page from cache.
+     *
+     * The first read of a chapter resolves its location and parses each cache
+     * file once; subsequent reads (including misses for pages that have no OCR
+     * data yet) are served from the in-memory chapter memo.
      */
     suspend fun loadOcrBlocks(
         manga: Manga,
@@ -142,23 +299,10 @@ class OcrCacheManager(
         pageIndex: Int,
     ): List<OcrTextBlock>? = withContext(Dispatchers.IO) {
         mutex.withLock {
-            val chapterLocation = findChapterLocation(manga, chapter, source)
-            val isDownloaded = isChapterDownloaded(manga, chapter, source)
-
-            val downloadBlocks = if (chapterLocation != null && isDownloaded) {
-                when (chapterLocation) {
-                    is ChapterLocation.Directory -> loadFromDirectory(chapterLocation.dir, pageIndex)
-                    is ChapterLocation.Cbz -> loadFromCbz(chapterLocation.file, pageIndex)
-                }
-            } else {
-                null
-            }
-
-            if (downloadBlocks != null) {
-                return@withLock downloadBlocks
-            }
-
-            loadFromInternal(manga, chapter, source, pageIndex)
+            val memo = getOrLoadChapterLocked(manga, chapter, source)
+            val pageData = memo.downloadData?.pages?.get(pageIndex)
+                ?: memo.internalData?.pages?.get(pageIndex)
+            pageData?.blocks?.map { it.toTextBlock() }
         }
     }
 
@@ -200,6 +344,8 @@ class OcrCacheManager(
         source: Source,
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
+            chapterMemo.remove(memoKey(manga, chapter, source))
+
             val chapterLocation = findChapterLocation(manga, chapter, source)
             val isDownloaded = isChapterDownloaded(manga, chapter, source)
 
@@ -226,6 +372,8 @@ class OcrCacheManager(
         source: Source,
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
+            chapterMemo.keys.removeAll { it.sourceId == source.id && it.mangaId == manga.id }
+
             val mangaDir = downloadProvider.findMangaDir(manga.ogTitle, source)
             mangaDir?.listFiles()?.forEach { chapterEntry ->
                 when {
@@ -265,6 +413,7 @@ class OcrCacheManager(
      */
     suspend fun clear() = withContext(Dispatchers.IO) {
         mutex.withLock {
+            chapterMemo.clear()
             getInternalOcrDir().deleteRecursively()
         }
     }
@@ -284,6 +433,11 @@ class OcrCacheManager(
     private sealed class ChapterLocation {
         data class Directory(val dir: UniFile) : ChapterLocation()
         data class Cbz(val file: UniFile) : ChapterLocation()
+
+        fun uriString(): String = when (this) {
+            is Directory -> dir.uri.toString()
+            is Cbz -> file.uri.toString()
+        }
     }
 
     private fun findChapterLocation(manga: Manga, chapter: Chapter, source: Source): ChapterLocation? {
@@ -307,45 +461,28 @@ class OcrCacheManager(
 
     /**
      * Save OCR data to a directory-based chapter.
+     * Returns the full chapter data now on disk, or null if the save was aborted.
      */
-    private fun saveToDirectory(dir: UniFile, pageIndex: Int, blocks: List<OcrTextBlock>, language: String) {
+    private fun saveToDirectory(
+        dir: UniFile,
+        pageIndex: Int,
+        newPage: OcrPageData,
+        knownData: OcrChapterData?,
+    ): OcrChapterData? {
         val cacheFile = dir.findFile(OCR_CACHE_FILE) ?: dir.createFile(OCR_CACHE_FILE)
         if (cacheFile == null) {
             logcat(LogPriority.ERROR) { "OcrCache: Failed to create cache file in directory" }
-            return
+            return null
         }
 
-        val chapterData = readOcrData(cacheFile) ?: return
+        val chapterData = knownData ?: readOcrData(cacheFile) ?: return null
 
         val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
-            blocks = blocks.map { it.toBlockData() },
-            language = language,
-            version = CURRENT_VERSION,
-        )
+        updatedPages[pageIndex] = newPage
 
         val newData = chapterData.copy(pages = updatedPages)
         atomicWrite(cacheFile, json.encodeToString(newData))
-    }
-
-    /**
-     * Load OCR data from a directory-based chapter.
-     */
-    private fun loadFromDirectory(dir: UniFile, pageIndex: Int): List<OcrTextBlock>? {
-        val cacheFile = dir.findFile(OCR_CACHE_FILE) ?: return null
-
-        return try {
-            val content = cacheFile.openInputStream().bufferedReader().use { it.readText() }
-            if (content.isBlank()) {
-                logcat(LogPriority.WARN) { "OcrCache: Directory cache file is empty" }
-                return null
-            }
-            val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from directory" }
-            null
-        }
+        return newData
     }
 
     /**
@@ -365,45 +502,28 @@ class OcrCacheManager(
 
     /**
      * Save OCR data to a CBZ sidecar file.
+     * Returns the full chapter data now on disk, or null if the save was aborted.
      */
-    private fun saveToCbz(cbzFile: UniFile, pageIndex: Int, blocks: List<OcrTextBlock>, language: String) {
+    private fun saveToCbz(
+        cbzFile: UniFile,
+        pageIndex: Int,
+        newPage: OcrPageData,
+        knownData: OcrChapterData?,
+    ): OcrChapterData? {
         val sidecarFile = getSidecarFile(cbzFile)
         if (sidecarFile == null) {
             logcat(LogPriority.ERROR) { "OcrCache: Failed to create sidecar file for CBZ" }
-            return
+            return null
         }
 
-        val chapterData = readOcrData(sidecarFile) ?: return
+        val chapterData = knownData ?: readOcrData(sidecarFile) ?: return null
 
         val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
-            blocks = blocks.map { it.toBlockData() },
-            language = language,
-            version = CURRENT_VERSION,
-        )
+        updatedPages[pageIndex] = newPage
 
         val newData = chapterData.copy(pages = updatedPages)
         atomicWrite(sidecarFile, json.encodeToString(newData))
-    }
-
-    /**
-     * Load OCR data from a CBZ sidecar file.
-     */
-    private fun loadFromCbz(cbzFile: UniFile, pageIndex: Int): List<OcrTextBlock>? {
-        val sidecarFile = findSidecarFile(cbzFile) ?: return null
-
-        return try {
-            val content = sidecarFile.openInputStream().bufferedReader().use { it.readText() }
-            if (content.isBlank()) {
-                logcat(LogPriority.WARN) { "OcrCache: CBZ sidecar file is empty" }
-                return null
-            }
-            val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from CBZ sidecar" }
-            null
-        }
+        return newData
     }
 
     /**
@@ -433,62 +553,34 @@ class OcrCacheManager(
 
     /**
      * Save OCR data to internal storage (for online chapters).
+     * Returns the full chapter data now on disk, or null if the save failed.
      */
     private fun saveToInternal(
         manga: Manga,
         chapter: Chapter,
         source: Source,
         pageIndex: Int,
-        blocks: List<OcrTextBlock>,
-        language: String,
-    ) {
+        newPage: OcrPageData,
+        knownData: OcrChapterData?,
+    ): OcrChapterData? {
         val cacheFile = getInternalCacheFile(manga, chapter, source)
 
-        val chapterData = if (cacheFile.exists()) {
-            readOcrData(com.hippo.unifile.UniFile.fromFile(cacheFile) ?: return) ?: return
+        val chapterData = knownData ?: if (cacheFile.exists()) {
+            val uniFile = UniFile.fromFile(cacheFile) ?: return null
+            readOcrData(uniFile) ?: return null
         } else {
-            OcrChapterData(pages = emptyMap(), version = CURRENT_VERSION)
+            emptyChapterData()
         }
 
         val updatedPages = chapterData.pages.toMutableMap()
-        updatedPages[pageIndex] = OcrPageData(
-            blocks = blocks.map { it.toBlockData() },
-            language = language,
-            version = CURRENT_VERSION,
-        )
+        updatedPages[pageIndex] = newPage
 
         val newData = chapterData.copy(pages = updatedPages)
-        try {
+        return try {
             cacheFile.writeText(json.encodeToString(newData))
+            newData
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "OcrCache: Failed to save to internal storage" }
-        }
-    }
-
-    /**
-     * Load OCR data from internal storage (for online chapters).
-     */
-    private fun loadFromInternal(
-        manga: Manga,
-        chapter: Chapter,
-        source: Source,
-        pageIndex: Int,
-    ): List<OcrTextBlock>? {
-        val cacheFile = getInternalCacheFile(manga, chapter, source)
-        if (!cacheFile.exists()) {
-            return null
-        }
-
-        return try {
-            val content = cacheFile.readText()
-            if (content.isBlank()) {
-                logcat(LogPriority.WARN) { "OcrCache: Internal cache file is empty" }
-                return null
-            }
-            val chapterData = json.decodeFromString<OcrChapterData>(content)
-            chapterData.pages[pageIndex]?.blocks?.map { it.toTextBlock() }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) { "OcrCache: Failed to load from internal storage" }
             null
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
@@ -5,10 +5,15 @@ import android.text.format.Formatter
 import chimahon.ocr.OcrBlockData
 import chimahon.ocr.OcrPageData
 import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -39,6 +44,8 @@ class OcrCacheManager(
     private val json: Json,
     private val downloadManager: DownloadManager = Injekt.get(),
     private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val downloadCache: DownloadCache = Injekt.get(),
+    invalidationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
     private val mutex = Mutex()
 
@@ -56,10 +63,27 @@ class OcrCacheManager(
     // The on-disk format stores a whole chapter per file, so a naive per-page read
     // re-resolves the chapter location (SAF IPC round trips) and re-parses every
     // page's blocks just to return one page - O(pages^2) work across a chapter.
-    // Since this class is the single reader/writer of the OCR cache files, a small
-    // memo of the parsed chapters is coherent by construction and turns every read
-    // after the first (including misses for pages with no OCR data yet) into an
-    // in-memory map lookup. All memo access is guarded by [mutex].
+    // The memo keeps that parse so every read after the first (including misses
+    // for pages with no OCR data yet) is an in-memory map lookup.
+    //
+    // Coherence model, per storage side:
+    //  - Internal storage ({filesDir}/ocr_cache) is app-private and only this
+    //    class reads or writes it, so the memoized parse of that side cannot go
+    //    stale while the entry exists.
+    //  - The download side is NOT single-writer: DownloadManager deletes chapter
+    //    directories and .ocr.json sidecars directly, Downloader creates new
+    //    chapter directories, and the user can mutate the downloads tree from
+    //    outside the app entirely. The memo therefore subscribes to
+    //    [DownloadCache.changes] and drops every entry whenever the downloads
+    //    index reports a mutation (download completed, chapter/manga deleted,
+    //    rename, cache renew). App-initiated changes invalidate immediately;
+    //    external changes are picked up when DownloadCache renews - the same
+    //    staleness bound the rest of the app accepts for download state.
+    //
+    // Callers that turn cache state into persisted decisions (the OCR queue's
+    // "already processed?" checks) must not trust the memo at all; they use
+    // [getCachedPageIndexes], which always re-reads disk. All memo access is
+    // guarded by [mutex].
 
     private data class ChapterKey(val sourceId: Long, val mangaId: Long, val chapterId: Long)
 
@@ -86,6 +110,22 @@ class OcrCacheManager(
         ): Boolean = size > MEMO_MAX_CHAPTERS
     }
 
+    init {
+        // Downloaded chapters can be deleted, re-downloaded, or renamed without
+        // this class being involved; any change to the downloads index makes the
+        // memoized download-side parses untrustworthy. The memo holds at most
+        // MEMO_MAX_CHAPTERS entries, so clearing it wholesale is cheap and the
+        // next read simply re-parses from disk.
+        downloadCache.changes
+            .onEach { invalidateMemo() }
+            .launchIn(invalidationScope)
+    }
+
+    /** Drop every memoized chapter so the next read re-parses from disk. */
+    private suspend fun invalidateMemo() {
+        mutex.withLock { chapterMemo.clear() }
+    }
+
     private fun memoKey(manga: Manga, chapter: Chapter, source: Source): ChapterKey {
         return ChapterKey(sourceId = source.id, mangaId = manga.id, chapterId = chapter.id)
     }
@@ -100,6 +140,16 @@ class OcrCacheManager(
         val key = memoKey(manga, chapter, source)
         chapterMemo[key]?.let { return it }
 
+        val memoized = loadChapterLocked(manga, chapter, source)
+        chapterMemo[key] = memoized
+        return memoized
+    }
+
+    /**
+     * Resolve the chapter location and parse both cache files from disk,
+     * ignoring the memo. Must be called with [mutex] held.
+     */
+    private fun loadChapterLocked(manga: Manga, chapter: Chapter, source: Source): MemoizedChapter {
         val location = findChapterLocation(manga, chapter, source)
         val isDownloaded = isChapterDownloaded(manga, chapter, source)
 
@@ -119,9 +169,7 @@ class OcrCacheManager(
             emptyChapterData()
         }
 
-        val memoized = MemoizedChapter(location, isDownloaded, downloadData, internalData)
-        chapterMemo[key] = memoized
-        return memoized
+        return MemoizedChapter(location, isDownloaded, downloadData, internalData)
     }
 
     /** Parse a whole cache file: absent file -> empty data, unreadable file -> null. */
@@ -133,20 +181,30 @@ class OcrCacheManager(
     /**
      * Atomically write JSON to a file by writing to a temp file first, then renaming.
      * If interrupted mid-write, only the .tmp file is corrupted; the original is preserved.
+     *
+     * Returns true only when the data actually reached the target file. Callers
+     * must treat false as "nothing was written" - in particular, nothing may be
+     * recorded as persisted (memo or otherwise) on a false return.
      */
-    private fun atomicWrite(targetFile: UniFile, jsonString: String) {
+    private fun atomicWrite(targetFile: UniFile, jsonString: String): Boolean {
         val tmpFile = targetFile.parentFile?.createFile("${targetFile.name}$TMP_SUFFIX")
             ?: run {
                 logcat(LogPriority.ERROR) { "OcrCache: Failed to create temp file for atomic write" }
-                return
+                return false
             }
         try {
             tmpFile.openOutputStream().bufferedWriter().use {
                 it.write(jsonString)
                 it.flush()
             }
+            val targetName = targetFile.name
+            if (targetName == null) {
+                tmpFile.delete()
+                logcat(LogPriority.ERROR) { "OcrCache: target file has no name, aborting atomic write" }
+                return false
+            }
             targetFile.delete()
-            if (!tmpFile.renameTo(targetFile.name ?: return)) {
+            if (!tmpFile.renameTo(targetName)) {
                 logcat(LogPriority.WARN) { "OcrCache: rename failed, trying fallback" }
                 // Fallback: write directly (some storage backends don't support rename)
                 targetFile.openOutputStream().bufferedWriter().use {
@@ -155,6 +213,7 @@ class OcrCacheManager(
                 }
                 tmpFile.delete()
             }
+            return true
         } catch (e: Exception) {
             tmpFile.delete()
             logcat(LogPriority.ERROR, e) { "OcrCache: atomic write failed" }
@@ -216,7 +275,7 @@ class OcrCacheManager(
                     val knownData = if (
                         memo != null &&
                         memo.isDownloaded &&
-                        memo.location?.uriString() == chapterLocation.uriString()
+                        memo.location?.identity() == chapterLocation.identity()
                     ) {
                         memo.downloadData
                     } else {
@@ -275,7 +334,7 @@ class OcrCacheManager(
             // freshly resolved target; otherwise fall back to the same
             // "not downloaded" default the load path uses.
             val downloadStillValid = old.isDownloaded == isDownloaded &&
-                old.location?.uriString() == location?.uriString()
+                old.location?.identity() == location?.identity()
             MemoizedChapter(
                 location = location,
                 isDownloaded = isDownloaded,
@@ -303,6 +362,33 @@ class OcrCacheManager(
             val pageData = memo.downloadData?.pages?.get(pageIndex)
                 ?: memo.internalData?.pages?.get(pageIndex)
             pageData?.blocks?.map { it.toTextBlock() }
+        }
+    }
+
+    /**
+     * The set of page indexes with OCR data on disk right now, from a fresh
+     * location resolve and parse that bypasses the memo (the fresh parse
+     * re-primes it).
+     *
+     * The OCR queue uses this for its persisted decisions - skipping
+     * already-processed pages and judging a chapter complete - because those
+     * must reflect the actual files, never memoized state: the downloads tree
+     * can be deleted or replaced without this class being told. One call per
+     * chapter replaces the old per-page probes, so the queue stays O(pages)
+     * per chapter.
+     */
+    suspend fun getCachedPageIndexes(
+        manga: Manga,
+        chapter: Chapter,
+        source: Source,
+    ): Set<Int> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            val fresh = loadChapterLocked(manga, chapter, source)
+            chapterMemo[memoKey(manga, chapter, source)] = fresh
+            buildSet {
+                fresh.downloadData?.pages?.keys?.let(::addAll)
+                fresh.internalData?.pages?.keys?.let(::addAll)
+            }
         }
     }
 
@@ -434,10 +520,19 @@ class OcrCacheManager(
         data class Directory(val dir: UniFile) : ChapterLocation()
         data class Cbz(val file: UniFile) : ChapterLocation()
 
-        fun uriString(): String = when (this) {
-            is Directory -> dir.uri.toString()
-            is Cbz -> file.uri.toString()
-        }
+        private val target: UniFile
+            get() = when (this) {
+                is Directory -> dir
+                is Cbz -> file
+            }
+
+        /**
+         * Stable identity of the backing location, used to decide whether a
+         * memoized parse still describes the same target file. Prefers the
+         * plain file path (cheap for raw files, IPC-free for SAF documents)
+         * and falls back to the URI string.
+         */
+        fun identity(): String = target.filePath ?: target.uri.toString()
     }
 
     private fun findChapterLocation(manga: Manga, chapter: Chapter, source: Source): ChapterLocation? {
@@ -481,7 +576,7 @@ class OcrCacheManager(
         updatedPages[pageIndex] = newPage
 
         val newData = chapterData.copy(pages = updatedPages)
-        atomicWrite(cacheFile, json.encodeToString(newData))
+        if (!atomicWrite(cacheFile, json.encodeToString(newData))) return null
         return newData
     }
 
@@ -522,7 +617,7 @@ class OcrCacheManager(
         updatedPages[pageIndex] = newPage
 
         val newData = chapterData.copy(pages = updatedPages)
-        atomicWrite(sidecarFile, json.encodeToString(newData))
+        if (!atomicWrite(sidecarFile, json.encodeToString(newData))) return null
         return newData
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrManager.kt
@@ -11,8 +11,6 @@ import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
-import tachiyomi.domain.storage.service.StorageManager
-import tachiyomi.source.local.isLocal
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +33,8 @@ import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.storage.service.StorageManager
+import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import chimahon.ocr.OcrTextBlock as ChimahonOcrTextBlock
@@ -256,7 +256,7 @@ class OcrManager(
 
     suspend fun runPendingQueue(stopRequested: () -> Boolean) = kotlinx.coroutines.supervisorScope {
         val dictPrefs = Injekt.get<eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences>()
-        
+
         val prefJob = launch {
             dictPrefs.parallelOcrLimit().changes().collect {
                 triggerChannel.trySend(Unit)
@@ -266,7 +266,7 @@ class OcrManager(
         try {
             while (!stopRequested()) {
                 val parallelLimit = dictPrefs.parallelOcrLimit().get()
-                
+
                 val runnableTasks = ocrStore.getAll().filter { it.status.isRunnable() }
                 val nextTask = runnableTasks.firstOrNull { !runningJobs.containsKey(it.chapterId) }
 
@@ -501,6 +501,12 @@ class OcrManager(
                     )
                 }
 
+                // One fresh disk read for the whole chapter replaces per-page
+                // cache probes. This must come from disk, not the reader-path
+                // memo: skipping a page marks it as done without a file backing
+                // it if the memo is stale (e.g. chapter deleted + re-downloaded).
+                val alreadyCachedPages = ocrCacheManager.getCachedPageIndexes(manga, chapter, source)
+
                 for (pageIndex in 0 until pageCount) {
                     if (stopRequested()) {
                         updateStoredTask(chapterId) { current ->
@@ -513,8 +519,7 @@ class OcrManager(
                         return OcrTaskResult.CANCELLED
                     }
 
-                    val existingBlocks = ocrCacheManager.loadOcrBlocks(manga, chapter, source, pageIndex)
-                    if (existingBlocks != null) {
+                    if (pageIndex in alreadyCachedPages) {
                         logcat { "OcrManager: page $pageIndex already cached for chapter ${chapter.name}" }
                         updateStoredTask(chapterId) {
                             it.copy(
@@ -620,7 +625,7 @@ class OcrManager(
                                     vertical = it.vertical,
                                     lineGeometries = it.lineGeometries?.map { lg ->
                                         chimahon.ocr.OcrLineGeometry(lg.xmin, lg.ymin, lg.xmax, lg.ymax, lg.rotation)
-                                    }
+                                    },
                                 )
                             },
                             language = OcrLanguage.JAPANESE.bcp47,
@@ -667,13 +672,10 @@ class OcrManager(
         source: Source,
         pageCount: Int,
     ): Int {
-        var cachedPages = 0
-        for (pageIndex in 0 until pageCount) {
-            if (ocrCacheManager.loadOcrBlocks(manga, chapter, source, pageIndex) != null) {
-                cachedPages++
-            }
-        }
-        return cachedPages
+        // isOcrReady is a persisted claim that every page has OCR on disk, so
+        // this must be a fresh disk read, never a memoized one.
+        val cachedPages = ocrCacheManager.getCachedPageIndexes(manga, chapter, source)
+        return (0 until pageCount).count { it in cachedPages }
     }
 
     private fun getChapterImageProvider(

--- a/app/src/test/kotlin/chimahon/ocr/OcrCacheManagerTest.kt
+++ b/app/src/test/kotlin/chimahon/ocr/OcrCacheManagerTest.kt
@@ -1,16 +1,23 @@
 package chimahon.ocr
 
 import android.content.Context
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import tachiyomi.domain.chapter.model.Chapter
@@ -23,6 +30,9 @@ class OcrCacheManagerTest {
     lateinit var tempDir: File
 
     private val json = Json { ignoreUnknownKeys = true }
+
+    /** Stands in for [DownloadCache.changes]; tests emit to simulate downloads-index mutations. */
+    private val downloadChanges = MutableSharedFlow<Unit>()
 
     private val manga = mockk<Manga>(relaxed = true) {
         every { id } returns 2L
@@ -43,14 +53,26 @@ class OcrCacheManagerTest {
         downloadProvider: DownloadProvider = mockk {
             every { findChapterDir(any(), any(), any(), any(), any()) } returns null
         },
+        downloadManager: DownloadManager = mockk {
+            every { isChapterDownloaded(any(), any(), any(), any(), any(), any()) } returns false
+        },
     ): OcrCacheManager {
         val context = mockk<Context> {
             every { filesDir } returns tempDir
         }
-        val downloadManager = mockk<DownloadManager> {
-            every { isChapterDownloaded(any(), any(), any(), any(), any(), any()) } returns false
+        val downloadCache = mockk<DownloadCache> {
+            every { changes } returns downloadChanges
         }
-        return OcrCacheManager(context, json, downloadManager, downloadProvider)
+        return OcrCacheManager(
+            context = context,
+            json = json,
+            downloadManager = downloadManager,
+            downloadProvider = downloadProvider,
+            downloadCache = downloadCache,
+            // Unconfined so downloadChanges.emit() runs the invalidation collector
+            // inline, keeping the tests deterministic.
+            invalidationScope = CoroutineScope(Dispatchers.Unconfined),
+        )
     }
 
     private fun block(text: String) = OcrTextBlock(
@@ -66,8 +88,10 @@ class OcrCacheManagerTest {
         return File(tempDir, "ocr_cache/1/2/$chapterId.json")
     }
 
+    // ========== Internal storage (app-private, single-writer) ==========
+
     @Test
-    fun `reads after the first are served from the memo without touching disk`() = runTest {
+    fun `internal-storage reads after the first are served from the memo without touching disk`() = runTest {
         val chapter = chapter(3L)
 
         // Build the on-disk fixture with a separate manager so the manager under
@@ -84,7 +108,11 @@ class OcrCacheManagerTest {
 
         assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
 
-        // Delete the backing file: page 1 can now only come from the memo.
+        // Deleting the app-private backing file proves page 1 is answered from the
+        // memo, with no disk read. Internal storage has no writer other than
+        // OcrCacheManager itself, so this staleness cannot occur in production;
+        // the download side, which can change underneath us, is covered by the
+        // invalidation tests below.
         internalCacheFile(3L).delete()
         assertEquals(listOf(block("page1")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 1))
         assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 2))
@@ -156,5 +184,185 @@ class OcrCacheManagerTest {
         verify(exactly = 6) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
         manager.loadOcrBlocks(manga, chapter(5L), source, pageIndex = 0)
         verify(exactly = 6) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+    }
+
+    // ========== Downloaded chapters (directory and CBZ sidecar) ==========
+
+    private fun downloadedManager(
+        findChapterDir: () -> UniFile?,
+        isDownloaded: () -> Boolean,
+        downloadProvider: DownloadProvider = mockk {
+            every { findChapterDir(any(), any(), any(), any(), any()) } answers { findChapterDir() }
+        },
+    ): Pair<OcrCacheManager, DownloadProvider> {
+        val downloadManager = mockk<DownloadManager> {
+            every { isChapterDownloaded(any(), any(), any(), any(), any(), any()) } answers { isDownloaded() }
+        }
+        return newManager(downloadProvider, downloadManager) to downloadProvider
+    }
+
+    @Test
+    fun `downloaded directory chapter saves to and reads from the chapter dir`() = runTest {
+        val chapter = chapter(7L)
+        val chapterDirFile = File(tempDir, "downloads/Manga/Chapter 7").apply { mkdirs() }
+        val chapterDir = UniFile.fromFile(chapterDirFile)!!
+        val (manager, downloadProvider) = downloadedManager({ chapterDir }, { true })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("dl0")), language = "ja")
+
+        // The write landed in the chapter directory, not internal storage.
+        assertTrue(File(chapterDirFile, ".ocr_cache.json").exists())
+        assertFalse(internalCacheFile(7L).exists())
+
+        assertEquals(listOf(block("dl0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // A second save reuses the memoized parse as its read-modify-write base;
+        // a second read is a memo hit. Resolutions: save, load, save.
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 1, blocks = listOf(block("dl1")), language = "ja")
+        assertEquals(listOf(block("dl1")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 1))
+        verify(exactly = 3) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+
+        // A cold manager reads both pages back from the file itself.
+        val (coldManager, _) = downloadedManager({ chapterDir }, { true })
+        assertEquals(listOf(block("dl0")), coldManager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+        assertEquals(listOf(block("dl1")), coldManager.loadOcrBlocks(manga, chapter, source, pageIndex = 1))
+    }
+
+    @Test
+    fun `cbz chapter uses the sidecar file and never clobbers a corrupt sidecar`() = runTest {
+        val chapter = chapter(9L)
+        val mangaDirFile = File(tempDir, "downloads/Manga").apply { mkdirs() }
+        File(mangaDirFile, "Chapter 9.cbz").createNewFile()
+        val cbz = UniFile.fromFile(mangaDirFile)!!.findFile("Chapter 9.cbz")!!
+        val (manager, _) = downloadedManager({ cbz }, { true })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("cbz0")), language = "ja")
+
+        val sidecar = File(mangaDirFile, "Chapter 9.cbz.ocr.json")
+        assertTrue(sidecar.exists())
+        assertEquals(listOf(block("cbz0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // Corrupt the sidecar behind the manager's back and invalidate: reads
+        // fail soft and a save must abort rather than overwrite the file.
+        val corruptContent = "not json {{{"
+        sidecar.writeText(corruptContent)
+        downloadChanges.emit(Unit)
+
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 1, blocks = listOf(block("cbz1")), language = "ja")
+        assertEquals(corruptContent, sidecar.readText())
+    }
+
+    @Test
+    fun `download cache change invalidates the memo after chapter deletion and re-download`() = runTest {
+        val chapter = chapter(10L)
+        val chapterDirFile = File(tempDir, "downloads/Manga/Chapter 10")
+        chapterDirFile.mkdirs()
+        var currentDir: UniFile? = UniFile.fromFile(chapterDirFile)
+        var downloaded = true
+        val (manager, _) = downloadedManager({ currentDir }, { downloaded })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+        assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // DownloadManager deletes the chapter dir (and the OCR file inside it)
+        // without telling OcrCacheManager. Until the downloads index reports the
+        // change the memo may still answer - that window is the accepted bound...
+        chapterDirFile.deleteRecursively()
+        currentDir = null
+        downloaded = false
+        assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // ...and the DownloadCache change event closes it.
+        downloadChanges.emit(Unit)
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // Re-download: fresh chapter dir with no OCR data. No ghost of the old
+        // parse may survive.
+        chapterDirFile.mkdirs()
+        currentDir = UniFile.fromFile(chapterDirFile)
+        downloaded = true
+        downloadChanges.emit(Unit)
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+        assertEquals(emptySet<Int>(), manager.getCachedPageIndexes(manga, chapter, source))
+    }
+
+    @Test
+    fun `getCachedPageIndexes bypasses the memo and reflects disk truth`() = runTest {
+        val chapter = chapter(12L)
+        val chapterDirFile = File(tempDir, "downloads/Manga/Chapter 12")
+        chapterDirFile.mkdirs()
+        var currentDir: UniFile? = UniFile.fromFile(chapterDirFile)
+        var downloaded = true
+        val (manager, _) = downloadedManager({ currentDir }, { downloaded })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+        assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // The chapter dir vanishes with NO invalidation event (mid-window). The
+        // OCR queue's completeness check must still see the truth: if it trusted
+        // the memo it would skip every page and mark the chapter OCR-ready with
+        // no file on disk.
+        chapterDirFile.deleteRecursively()
+        currentDir = null
+        downloaded = false
+        assertEquals(emptySet<Int>(), manager.getCachedPageIndexes(manga, chapter, source))
+
+        // The fresh parse re-primed the memo, so the reader path agrees now too.
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+    }
+
+    @Test
+    fun `save discards the memoized base when the chapter location changes`() = runTest {
+        val chapter = chapter(11L)
+        val dirA = File(tempDir, "downloads/Manga/Chapter 11").apply { mkdirs() }
+        val dirB = File(tempDir, "downloads-new/Manga/Chapter 11").apply { mkdirs() }
+        var currentDir = dirA
+        val (manager, _) = downloadedManager({ UniFile.fromFile(currentDir) }, { true })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("a0")), language = "ja")
+        assertEquals(listOf(block("a0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // The chapter now resolves to a different location (e.g. storage moved).
+        // The save must base itself on the new file, not the memoized parse of
+        // the old one, so page 0 of the old location must not leak into it.
+        currentDir = dirB
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 1, blocks = listOf(block("b1")), language = "ja")
+
+        val dataB = json.decodeFromString<OcrChapterData>(File(dirB, ".ocr_cache.json").readText())
+        assertEquals(setOf(1), dataB.pages.keys)
+
+        // The refreshed memo describes the new location.
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+        assertEquals(listOf(block("b1")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 1))
+    }
+
+    @Test
+    fun `a save whose atomic write cannot start is not recorded as persisted`() = runTest {
+        val chapter = chapter(8L)
+        // A directory chapter whose cache file cannot get a temp sibling: the
+        // atomic write reports failure instead of silently doing nothing.
+        val cacheFile = mockk<UniFile> {
+            every { openInputStream() } answers { "".byteInputStream() }
+            every { name } returns ".ocr_cache.json"
+            every { parentFile } returns mockk {
+                every { createFile(any()) } returns null
+            }
+        }
+        val chapterDir = mockk<UniFile> {
+            every { isDirectory } returns true
+            every { filePath } returns "/downloads/Manga/Chapter 8"
+            every { findFile(".ocr_cache.json") } returns cacheFile
+        }
+        val (manager, _) = downloadedManager({ chapterDir }, { true })
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+
+        // Nothing reached disk, so nothing may be served from memory either:
+        // otherwise the page would read back fine until the process restarts,
+        // and the OCR queue would skip it forever after.
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+        assertEquals(emptySet<Int>(), manager.getCachedPageIndexes(manga, chapter, source))
+        assertFalse(internalCacheFile(8L).exists())
     }
 }

--- a/app/src/test/kotlin/chimahon/ocr/OcrCacheManagerTest.kt
+++ b/app/src/test/kotlin/chimahon/ocr/OcrCacheManagerTest.kt
@@ -1,0 +1,160 @@
+package chimahon.ocr
+
+import android.content.Context
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.source.Source
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.manga.model.Manga
+import java.io.File
+
+class OcrCacheManagerTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val manga = mockk<Manga>(relaxed = true) {
+        every { id } returns 2L
+        every { ogTitle } returns "Manga"
+    }
+    private val source = mockk<Source>(relaxed = true) {
+        every { id } returns 1L
+    }
+
+    private fun chapter(chapterId: Long) = mockk<Chapter>(relaxed = true) {
+        every { id } returns chapterId
+        every { name } returns "Chapter $chapterId"
+        every { scanlator } returns null
+        every { url } returns "/chapter/$chapterId"
+    }
+
+    private fun newManager(
+        downloadProvider: DownloadProvider = mockk {
+            every { findChapterDir(any(), any(), any(), any(), any()) } returns null
+        },
+    ): OcrCacheManager {
+        val context = mockk<Context> {
+            every { filesDir } returns tempDir
+        }
+        val downloadManager = mockk<DownloadManager> {
+            every { isChapterDownloaded(any(), any(), any(), any(), any(), any()) } returns false
+        }
+        return OcrCacheManager(context, json, downloadManager, downloadProvider)
+    }
+
+    private fun block(text: String) = OcrTextBlock(
+        xmin = 0.1f,
+        ymin = 0.2f,
+        xmax = 0.3f,
+        ymax = 0.4f,
+        lines = listOf(text),
+        vertical = true,
+    )
+
+    private fun internalCacheFile(chapterId: Long): File {
+        return File(tempDir, "ocr_cache/1/2/$chapterId.json")
+    }
+
+    @Test
+    fun `reads after the first are served from the memo without touching disk`() = runTest {
+        val chapter = chapter(3L)
+
+        // Build the on-disk fixture with a separate manager so the manager under
+        // test starts with a cold memo.
+        newManager().apply {
+            saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+            saveOcrBlocks(manga, chapter, source, pageIndex = 1, blocks = listOf(block("page1")), language = "ja")
+        }
+
+        val downloadProvider = mockk<DownloadProvider> {
+            every { findChapterDir(any(), any(), any(), any(), any()) } returns null
+        }
+        val manager = newManager(downloadProvider)
+
+        assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // Delete the backing file: page 1 can now only come from the memo.
+        internalCacheFile(3L).delete()
+        assertEquals(listOf(block("page1")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 1))
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 2))
+
+        // The chapter location was resolved once for the whole chapter, not per page.
+        verify(exactly = 1) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `save refreshes the memo and persists to disk`() = runTest {
+        val chapter = chapter(4L)
+        val manager = newManager()
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("v1")), language = "ja")
+        assertEquals(listOf(block("v1")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // Overwrite the page; the memoized entry must serve the new data.
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("v2")), language = "ja")
+        assertEquals(listOf(block("v2")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        // A fresh manager (cold memo) must read the same data back from disk.
+        assertEquals(listOf(block("v2")), newManager().loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+    }
+
+    @Test
+    fun `deleteOcrForChapter invalidates the memo`() = runTest {
+        val chapter = chapter(5L)
+        val manager = newManager()
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+        assertEquals(listOf(block("page0")), manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        manager.deleteOcrForChapter(manga, chapter, source)
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+    }
+
+    @Test
+    fun `corrupt cache file is not clobbered by a save`() = runTest {
+        val chapter = chapter(6L)
+        val corruptContent = "not json {{{"
+        internalCacheFile(6L).apply {
+            parentFile?.mkdirs()
+            writeText(corruptContent)
+        }
+
+        val manager = newManager()
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+
+        manager.saveOcrBlocks(manga, chapter, source, pageIndex = 0, blocks = listOf(block("page0")), language = "ja")
+
+        // The save must abort rather than overwrite the unreadable file.
+        assertEquals(corruptContent, internalCacheFile(6L).readText())
+        assertNull(manager.loadOcrBlocks(manga, chapter, source, pageIndex = 0))
+    }
+
+    @Test
+    fun `memo evicts least recently used chapters`() = runTest {
+        val downloadProvider = mockk<DownloadProvider> {
+            every { findChapterDir(any(), any(), any(), any(), any()) } returns null
+        }
+        val manager = newManager(downloadProvider)
+
+        // Load 5 chapters: one more than the memo holds, evicting the first.
+        (1L..5L).forEach { manager.loadOcrBlocks(manga, chapter(it), source, pageIndex = 0) }
+        verify(exactly = 5) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+
+        // Chapter 1 was evicted, so it resolves again; chapter 5 is still memoized.
+        manager.loadOcrBlocks(manga, chapter(1L), source, pageIndex = 0)
+        verify(exactly = 6) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+        manager.loadOcrBlocks(manga, chapter(5L), source, pageIndex = 0)
+        verify(exactly = 6) { downloadProvider.findChapterDir(any(), any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Cached OCR reads did per-page work that scales with chapter size: every `loadOcrBlocks()` call resolved the chapter's download dir (SAF round trips), checked download state, and read + decoded the **entire** chapter's `.ocr_cache.json` under the global mutex, just to return one page. Flipping through an N-page chapter cost N full-chapter parses, and the OCR queue's per-page "already cached?" probes made it O(N²).

### Read path

The file already holds the whole chapter, so the first read's parse is kept in a 4-entry LRU inside `OcrCacheManager`. Reads after the first — including misses for pages with no OCR yet — are in-memory lookups, and per-page saves reuse the memoized parse as their read-modify-write base when it still describes the same target file (locations are compared by a `filePath`-first identity, which is IPC-free).

### Coherence model (per storage side)

The memo is **not** coherent by construction, because `OcrCacheManager` is not the only actor touching these files: `DownloadManager` deletes chapter directories and `.ocr.json` sidecars directly, `Downloader` creates new chapter dirs, and the user can mutate the downloads tree from outside the app. Only internal storage (`filesDir/ocr_cache`) is single-writer.

The memo therefore subscribes to `DownloadCache.changes` and drops every entry on any downloads-index mutation (download completed, chapter/manga deleted, rename, cache renew). App-initiated changes invalidate immediately; external changes are bounded by the existing `DownloadCache` renew interval — the same staleness stance the rest of the app already takes for download state. `DownloadCache.removeFolders` (SY cleanup path) now also emits a change event.

### Queue decisions read disk truth

The OCR queue's persisted decisions — skipping "already cached" pages and setting `isOcrReady` — no longer consult the memo at all. A new `getCachedPageIndexes()` does one fresh location-resolve + parse per chapter (re-priming the memo as a side effect), and the queue checks set membership in the loop. A stale memo can never cause the queue to skip pages or mark a chapter ready without files on disk, and the O(N²) probe pattern is fixed at the source: 2 parses per chapter run instead of 2N (the reader-path memo stays for page flips).

### No phantom writes

`atomicWrite()` now returns whether the data actually reached the target file; its temp-file-creation failure path previously logged and returned as if it had written. Saves abort — and drop the memo entry — when it reports failure, so nothing is ever recorded in memory as persisted that isn't on disk. Corrupt files are still memoized as unreadable and never overwritten by a save.

No disk format change.

### Tests

`OcrCacheManagerTest` now covers the motivating paths, not just internal storage:

- downloaded **directory** and **CBZ sidecar** chapters using real files through `UniFile.fromFile` with `isChapterDownloaded=true` (save target, memo hit, single location resolution, cold-manager read-back)
- delete + re-download with a `DownloadCache.changes` emission: the stale window closes and no ghost OCR survives
- `getCachedPageIndexes()` bypassing a stale memo mid-window (the exact skip-and-mark-ready hazard)
- save discarding the memoized base when the chapter location changes (no cross-location page leakage)
- atomic-write failure leaving no phantom state, corrupt-file guards on both sides
- the original memo-hit / save-refresh / delete-invalidation / LRU pins (the file-deletion trick is now scoped to internal storage, where single-writer actually holds, purely as a no-disk-read proof)

`:app` unit tests enable `returnDefaultValues` for the trivial framework statics (`TextUtils`, `Log`) inside UniFile's raw-file implementation. True SAF (`content://`) behavior remains uncovered by JVM tests.

### Verification

`:app:compileDebugKotlin` passes; `:app:testDebugUnitTest` passes except `SentenceAudioCaptureServiceTest > falls back to original video when external audio probe fails`, which fails identically on the base branch (pre-existing, unrelated). Both touched-file sets are spotless-clean; repo-wide `spotlessCheck` has pre-existing violations in ~140 untouched files.

### Deliberately out of scope

Saves still serialize and rewrite the whole chapter file once per page (write amplification is unchanged); batching/coalescing those writes needs its own crash-semantics design and is left to a follow-up.
