### PR TITLE
feat(ocr): add clear OCR cache option to entry 3-dot menu

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -199,6 +199,7 @@ fun MangaScreen(
     getMangaState: @Composable (Manga) -> State<Manga>,
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
+    onClearOcrCache: (() -> Unit)? = null,
     onOpenMangaFolder: (() -> Unit)?,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
@@ -271,6 +272,7 @@ fun MangaScreen(
             getMangaState = getMangaState,
             onClickSourceSettingsClicked = onClickSourceSettingsClicked,
             onClearManga = onClearManga,
+            onClearOcrCache = onClearOcrCache,
             onOpenMangaFolder = onOpenMangaFolder,
             onRelatedMangasScreenClick = onRelatedMangasScreenClick,
             onRelatedMangaClick = onRelatedMangaClick,
@@ -336,6 +338,7 @@ fun MangaScreen(
             getMangaState = getMangaState,
             onClickSourceSettingsClicked = onClickSourceSettingsClicked,
             onClearManga = onClearManga,
+            onClearOcrCache = onClearOcrCache,
             onOpenMangaFolder = onOpenMangaFolder,
             onRelatedMangasScreenClick = onRelatedMangasScreenClick,
             onRelatedMangaClick = onRelatedMangaClick,
@@ -418,6 +421,7 @@ private fun MangaScreenSmallImpl(
     getMangaState: @Composable ((Manga) -> State<Manga>),
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
+    onClearOcrCache: (() -> Unit)? = null,
     onOpenMangaFolder: (() -> Unit)?,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
@@ -505,6 +509,7 @@ private fun MangaScreenSmallImpl(
                 // KMK -->
                 onClickSourceSettings = onClickSourceSettingsClicked,
                 onClearManga = onClearManga,
+                onClearOcrCache = onClearOcrCache,
                 onOpenMangaFolder = onOpenMangaFolder,
                 onClickRelatedMangas = onRelatedMangasScreenClick.takeIf {
                     !expandRelatedMangas &&
@@ -888,6 +893,7 @@ private fun MangaScreenLargeImpl(
     getMangaState: @Composable ((Manga) -> State<Manga>),
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
+    onClearOcrCache: (() -> Unit)? = null,
     onOpenMangaFolder: (() -> Unit)?,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
@@ -967,6 +973,7 @@ private fun MangaScreenLargeImpl(
                 // KMK -->
                 onClickSourceSettings = onClickSourceSettingsClicked,
                 onClearManga = onClearManga,
+                onClearOcrCache = onClearOcrCache,
                 onOpenMangaFolder = onOpenMangaFolder,
                 onClickRelatedMangas = onRelatedMangasScreenClick.takeIf {
                     !expandRelatedMangas &&

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -127,6 +127,37 @@ fun ClearMangaDialog(
         },
     )
 }
+
+@Composable
+fun ClearOcrCacheDialog(
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDismissRequest()
+                    onConfirm()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        title = {
+            Text(text = stringResource(MR.strings.are_you_sure))
+        },
+        text = {
+            Text(text = stringResource(KMR.strings.confirm_clear_ocr_cache))
+        },
+    )
+}
 // KMK <--
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -54,6 +54,7 @@ fun MangaToolbar(
     onClickRelatedMangas: (() -> Unit)?,
     onClickSourceSettings: (() -> Unit)?,
     onClearManga: () -> Unit,
+    onClearOcrCache: (() -> Unit)? = null,
     onOpenMangaFolder: (() -> Unit)?,
     // KMK <--
     onClickRecommend: (() -> Unit)?,
@@ -252,6 +253,14 @@ fun MangaToolbar(
                             onClick = onClearManga,
                         ),
                     )
+                    if (onClearOcrCache != null) {
+                        add(
+                            AppBar.OverflowAction(
+                                title = stringResource(KMR.strings.action_clear_ocr_cache),
+                                onClick = onClearOcrCache,
+                            ),
+                        )
+                    }
                     if (onClickSourceSettings != null) {
                         add(
                             AppBar.OverflowAction(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/ocr/OcrCacheManager.kt
@@ -227,6 +227,7 @@ class OcrCacheManager(
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
             val mangaDir = downloadProvider.findMangaDir(manga.ogTitle, source)
+                ?: if (source.id == 0L) Injekt.get<tachiyomi.source.local.io.LocalSourceFileSystem>().getMangaDirectory(manga.ogTitle) else null
             mangaDir?.listFiles()?.forEach { chapterEntry ->
                 when {
                     chapterEntry.isDirectory -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -416,6 +416,7 @@ class MangaScreen(
                 }
             }.takeIf { isConfigurableSource },
             onClearManga = { screenModel.showClearMangaDialog() },
+            onClearOcrCache = screenModel::clearOcrCache,
             onOpenMangaFolder = {
                 if (successState.mergedData == null) {
                     screenModel.openMangaFolder(screenModel.source, screenModel.manga)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -52,6 +52,7 @@ import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.manga.EditCoverAction
 import eu.kanade.presentation.manga.MangaScreen
 import eu.kanade.presentation.manga.components.ClearMangaDialog
+import eu.kanade.presentation.manga.components.ClearOcrCacheDialog
 import eu.kanade.presentation.manga.components.DeleteChaptersDialog
 import eu.kanade.presentation.manga.components.MangaCoverDialog
 import eu.kanade.presentation.manga.components.ScanlatorFilterDialog
@@ -416,7 +417,7 @@ class MangaScreen(
                 }
             }.takeIf { isConfigurableSource },
             onClearManga = { screenModel.showClearMangaDialog() },
-            onClearOcrCache = screenModel::clearOcrCache,
+            onClearOcrCache = { screenModel.showClearOcrCacheDialog() },
             onOpenMangaFolder = {
                 if (successState.mergedData == null) {
                     screenModel.openMangaFolder(screenModel.source, screenModel.manga)
@@ -650,8 +651,17 @@ class MangaScreen(
             // KMK -->
             is MangaScreenModel.Dialog.ClearManga -> {
                 ClearMangaDialog(
-                    onDismissRequest = onDismissRequest,
+                    onDismissRequest = screenModel::dismissDialog,
                     onConfirm = screenModel::clearManga,
+                )
+            }
+            is MangaScreenModel.Dialog.ClearOcrCache -> {
+                ClearOcrCacheDialog(
+                    onDismissRequest = screenModel::dismissDialog,
+                    onConfirm = {
+                        screenModel.clearOcrCache()
+                        screenModel.dismissDialog()
+                    },
                 )
             }
             // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1327,6 +1327,25 @@ class MangaScreenModel(
     }
 
     /**
+     * Clear OCR cache for the current manga.
+     */
+    fun clearOcrCache() {
+        val manga = (state.value as? State.Success)?.manga ?: return
+        val chapters = (state.value as? State.Success)?.chapters?.map { it.chapter } ?: return
+        val source = source ?: return
+        screenModelScope.launchIO {
+            Injekt.get<chimahon.ocr.OcrCacheManager>().deleteOcrForManga(manga, source)
+            val chapterUpdates = chapters.filter { it.isOcrReady }.map {
+                tachiyomi.domain.chapter.model.ChapterUpdate(id = it.id, isOcrReady = false)
+            }
+            if (chapterUpdates.isNotEmpty()) {
+                Injekt.get<tachiyomi.domain.chapter.repository.ChapterRepository>().updateAll(chapterUpdates)
+            }
+            snackbarHostState.showSnackbar("OCR cache cleared")
+        }
+    }
+
+    /**
      * Returns the next unread chapter or null if everything is read.
      */
     fun getNextUnreadChapter(): Chapter? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -2035,6 +2035,7 @@ class MangaScreenModel(
 
         // KMK -->
         data object ClearManga : Dialog
+        data object ClearOcrCache : Dialog
         // KMK <--
 
         data class SetDictionaryProfile(val manga: Manga) : Dialog
@@ -2103,6 +2104,10 @@ class MangaScreenModel(
     // KMK -->
     fun showClearMangaDialog() {
         updateSuccessState { it.copy(dialog = Dialog.ClearManga) }
+    }
+
+    fun showClearOcrCacheDialog() {
+        updateSuccessState { it.copy(dialog = Dialog.ClearOcrCache) }
     }
     // KMK <--
 

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -16,6 +16,7 @@
     <string name="action_panorama_cover">Panorama cover</string>
     <string name="action_open_folder">Open folder</string>
     <string name="action_clear_manga">Clear manga</string>
+    <string name="action_clear_ocr_cache">Clear OCR cache</string>
     <string name="action_update">Update</string>
         <!-- History section -->
     <string name="action_filter_unfinished_manga">Unfinished manga</string>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_open_folder">Open folder</string>
     <string name="action_clear_manga">Clear manga</string>
     <string name="action_clear_ocr_cache">Clear OCR cache</string>
+    <string name="confirm_clear_ocr_cache">Are you sure you want to clear the OCR cache? This will delete all cached OCR files for this entry.</string>
     <string name="action_update">Update</string>
         <!-- History section -->
     <string name="action_filter_unfinished_manga">Unfinished manga</string>


### PR DESCRIPTION
### Description
Added a **"Clear OCR cache"** action to the 3-dot overflow menu inside the Manga/Novel entry screen. 

Previously, users could only clear the OCR cache globally via Settings. This update allows users to instantly purge OCR cache files (including local entry sidecars) directly on a per-entry basis.

### Changes Made
- **UI:** Added `Clear OCR cache` overflow action in `MangaToolbar.kt` and wired it through the `MangaScreen` presentation layers.
- **State:** Implemented `MangaScreenModel.clearOcrCache()` which deletes the physical files and immediately batch-updates the `ChapterRepository` (setting `isOcrReady = false`), triggering a seamless UI state refresh.
- **Data (Local Entries):** Updated `OcrCacheManager.deleteOcrForManga` to accurately resolve local source directories (`source.id == 0L`) so that local `.cbz.ocr.json` and `.ocr_cache.json` sidecars are properly purged.
- **i18n:** Added `action_clear_ocr_cache` string resource to `:i18n-kmk`.