### PR TITLE
feat(dictionary): add OCR full-text and meaning copy actions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryBootstrapHtml.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryBootstrapHtml.kt
@@ -141,6 +141,13 @@ internal fun getDictionaryBootstrapHtml(
                 }
               }
             };
+            window.DictionaryClipboard = {
+              copyTranslation: function(content) {
+                if (typeof DictionaryClipboardBridge !== 'undefined') {
+                  DictionaryClipboardBridge.copyTranslation(String(content || ''));
+                }
+              }
+            };
           </script>
         </head>
         <body>

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryWebView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryWebView.kt
@@ -59,6 +59,7 @@ internal fun prepareDictionaryWebViewShell(
         addJavascriptInterface(state.readyBridge, "DictionaryReadyBridge")
         addJavascriptInterface(state.payloadBridge, "PayloadBridge")
         addJavascriptInterface(state.ankiJsBridge, "AnkiJsBridge")
+        addJavascriptInterface(state.clipboardBridge, "DictionaryClipboardBridge")
 
 
         webViewClient = object : WebViewClient() {
@@ -129,6 +130,7 @@ internal class DictionaryWebViewState(
     val readyBridge: DictionaryReadyBridge = DictionaryReadyBridge(webViewProvider) { this }
     val payloadBridge: PayloadBridge = PayloadBridge()
     val ankiJsBridge: AnkiJsBridge = AnkiJsBridge(webViewProvider)
+    val clipboardBridge: DictionaryClipboardBridge = DictionaryClipboardBridge(context)
     var pageReady: Boolean = false
     var fontSize: Int = 16
     @Volatile var contentReadyGeneration: Long = 0

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryWebViewBridges.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryWebViewBridges.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
@@ -96,6 +97,20 @@ internal class AnkiJsBridge(
         val gloss = glossary.toIntOrNull()
         scope.launch {
             onAnkiLookup?.invoke(idx, gloss, selectedDict, popupSelection, true)
+        }
+    }
+}
+
+/** JavaScript bridge for copying a rendered dictionary translation. */
+internal class DictionaryClipboardBridge(
+    private val context: Context,
+) {
+    private val scope = CoroutineScope(Dispatchers.Main + Job())
+
+    @JavascriptInterface
+    fun copyTranslation(content: String) {
+        scope.launch {
+            context.copyToClipboard("Dictionary translation", content)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -31,6 +31,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -51,6 +52,10 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -1011,6 +1016,13 @@ class ReaderActivity : BaseActivity() {
             val textColor = MaterialTheme.colorScheme.onSurface.toArgb()
             val highlightColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.32f).toArgb()
             val textPaddingPx = with(density) { 14.dp.toPx().toInt() }
+            var copied by remember(state.text) { mutableStateOf(false) }
+            LaunchedEffect(copied) {
+                if (copied) {
+                    delay(1_000)
+                    copied = false
+                }
+            }
 
             Surface(
                 modifier = Modifier
@@ -1057,9 +1069,24 @@ class ReaderActivity : BaseActivity() {
                             copyOcrPopupFullText(state.text) { label, content ->
                                 this@ReaderActivity.copyToClipboard(label, content)
                             }
+                            copied = true
                         },
                     ) {
-                        Text(stringResource(MR.strings.action_copy_to_clipboard))
+                        AnimatedContent(
+                            targetState = copied,
+                            label = "OCR text copy feedback",
+                        ) { wasCopied ->
+                            Icon(
+                                imageVector = if (wasCopied) Icons.Default.Check else Icons.Default.ContentCopy,
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(
+                                if (copied) MR.strings.copied_to_clipboard_plain else MR.strings.action_copy_to_clipboard,
+                            ),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -141,6 +142,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.OcrLookupPopup
+import eu.kanade.tachiyomi.ui.reader.viewer.copyOcrPopupFullText
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerConfig
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerPageHolder
@@ -150,6 +152,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonPageHolder
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.isNightMode
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
@@ -1019,34 +1022,46 @@ class ReaderActivity : BaseActivity() {
                 contentColor = MaterialTheme.colorScheme.onSurface,
                 shadowElevation = 8.dp,
             ) {
-                AndroidView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = panelMaxHeight),
-                    factory = { context ->
-                        TextView(context).apply {
-                            setTextIsSelectable(true)
-                            textSize = 18f
-                            setLineSpacing(0f, 1.12f)
-                            setPadding(textPaddingPx, textPaddingPx, textPaddingPx, textPaddingPx)
-                            setBackgroundColor(Color.TRANSPARENT)
-                            isFocusable = true
-                            isFocusableInTouchMode = true
-                        }
-                    },
-                    update = { textView ->
-                        if (textView.text.toString() != state.text) {
-                            textView.text = state.text
-                        }
-                        textView.setTextColor(textColor)
-                        textView.highlightColor = highlightColor
-                        textView.post {
-                            if (!textView.hasFocus()) {
-                                textView.requestFocus()
+                Column {
+                    AndroidView(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = panelMaxHeight - 48.dp),
+                        factory = { context ->
+                            TextView(context).apply {
+                                setTextIsSelectable(true)
+                                textSize = 18f
+                                setLineSpacing(0f, 1.12f)
+                                setPadding(textPaddingPx, textPaddingPx, textPaddingPx, textPaddingPx)
+                                setBackgroundColor(Color.TRANSPARENT)
+                                isFocusable = true
+                                isFocusableInTouchMode = true
                             }
-                        }
-                    },
-                )
+                        },
+                        update = { textView ->
+                            if (textView.text.toString() != state.text) {
+                                textView.text = state.text
+                            }
+                            textView.setTextColor(textColor)
+                            textView.highlightColor = highlightColor
+                            textView.post {
+                                if (!textView.hasFocus()) {
+                                    textView.requestFocus()
+                                }
+                            }
+                        },
+                    )
+                    TextButton(
+                        modifier = Modifier.align(Alignment.End),
+                        onClick = {
+                            copyOcrPopupFullText(state.text) { label, content ->
+                                this@ReaderActivity.copyToClipboard(label, content)
+                            }
+                        },
+                    ) {
+                        Text(stringResource(MR.strings.action_copy_to_clipboard))
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -23,6 +23,10 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -73,6 +77,7 @@ import eu.kanade.tachiyomi.ui.dictionary.TabInfo
 import eu.kanade.tachiyomi.ui.dictionary.getDictionaryPaths
 import eu.kanade.tachiyomi.ui.dictionary.orderLookupResultsForDisplay
 import eu.kanade.tachiyomi.ui.dictionary.stopDictionaryAudio
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.toast
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -85,11 +90,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.i18n.stringResource as contextStringResource
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.util.collectAsState
+import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.UUID
@@ -660,7 +667,7 @@ fun OcrLookupPopup(
                         when (ankiResult) {
                             is AnkiResult.PermissionDenied -> context.toast(MR.strings.pref_anki_permission_denied)
                             is AnkiResult.Error -> context.toast(
-                                context.stringResource(MR.strings.anki_card_error, ankiResult.message),
+                                context.contextStringResource(MR.strings.anki_card_error, ankiResult.message),
                             )
                             is AnkiResult.NotConfigured -> context.toast(MR.strings.anki_not_configured)
                             else -> {}
@@ -732,7 +739,7 @@ fun OcrLookupPopup(
                         }
                         is AnkiResult.PermissionDenied -> context.toast(MR.strings.pref_anki_permission_denied)
                         is AnkiResult.Error -> context.toast(
-                            context.stringResource(MR.strings.anki_card_error, ankiResult.message),
+                            context.contextStringResource(MR.strings.anki_card_error, ankiResult.message),
                         )
                         is AnkiResult.NotConfigured -> context.toast(MR.strings.anki_not_configured)
                     }
@@ -1017,6 +1024,7 @@ fun OcrLookupPopup(
         "popup" -> false
         else -> recursiveTabs.size > 1
     }
+    val popupActionChromeHeight = 36.dp
 
     @Composable
     fun RecursiveLookupChrome() {
@@ -1113,7 +1121,14 @@ fun OcrLookupPopup(
     }
 
     @Composable
-    fun PopupCloseChrome() {
+    fun PopupActionChrome() {
+        var copied by remember { mutableStateOf(false) }
+        LaunchedEffect(copied) {
+            if (copied) {
+                delay(1_000)
+                copied = false
+            }
+        }
         val chromeBackground = if (eInkMode) {
             if (isDark) Color.Black else Color.White
         } else {
@@ -1148,7 +1163,7 @@ fun OcrLookupPopup(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = lookupString.take(20) + if (lookupString.length > 20) "…" else "",
+                    text = fullText.take(20) + if (fullText.length > 20) "…" else "",
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelMedium,
@@ -1161,15 +1176,20 @@ fun OcrLookupPopup(
                         .clickable(
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },
-                        ) { dismissPopup() },
+                        ) {
+                            copyOcrPopupFullText(fullText) { label, content ->
+                                context.copyToClipboard(label, content)
+                            }
+                            copied = true
+                        },
                     shape = RoundedCornerShape(if (eInkMode) 0.dp else 14.dp),
                     color = Color.Transparent,
                     contentColor = chromeText,
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            text = "\u2715",
-                            style = MaterialTheme.typography.labelMedium,
+                        Icon(
+                            imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                            contentDescription = stringResource(MR.strings.action_copy_to_clipboard),
                         )
                     }
                 }
@@ -1228,9 +1248,7 @@ fun OcrLookupPopup(
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 RecursiveLookupChrome()
-                if (recursiveNavMode == "popup" && dismissOnOutsideTap) {
-                    PopupCloseChrome()
-                }
+                PopupActionChrome()
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1348,13 +1366,10 @@ fun OcrLookupPopup(
     }
 
     childPopupRequest?.let { request ->
-        val closeChromePx = if (dismissOnOutsideTap && recursiveNavMode == "popup") {
-            with(density) { 32.dp.toPx() }
-        } else {
-            0f
-        }
+        val actionChromePx = with(density) { popupActionChromeHeight.toPx() }
+        val fallbackY = (layoutResult.heightPx - actionChromePx).coerceAtLeast(0f) / 2f
         val tapScreenX = layoutResult.x + (request.tapX ?: layoutResult.widthPx / 2f)
-        val tapScreenY = layoutResult.y + closeChromePx + (request.tapY ?: layoutResult.heightPx / 2f)
+        val tapScreenY = layoutResult.y + actionChromePx + (request.tapY ?: fallbackY)
         OcrLookupPopup(
             visible = visible,
             lookupString = request.query,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrPopupClipboard.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrPopupClipboard.kt
@@ -1,0 +1,10 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+internal const val OCR_POPUP_CLIPBOARD_LABEL = "OCR text"
+
+internal fun copyOcrPopupFullText(
+    fullText: String,
+    copy: (label: String, content: String) -> Unit,
+) {
+    copy(OCR_POPUP_CLIPBOARD_LABEL, fullText)
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/OcrPopupClipboardTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/OcrPopupClipboardTest.kt
@@ -1,0 +1,21 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OcrPopupClipboardTest {
+
+    @Test
+    fun `copies complete OCR text instead of the lookup term`() {
+        var label = ""
+        var copiedText = ""
+
+        copyOcrPopupFullText("A full OCR text block") { copiedLabel, content ->
+            label = copiedLabel
+            copiedText = content
+        }
+
+        assertEquals("OCR text", label)
+        assertEquals("A full OCR text block", copiedText)
+    }
+}

--- a/chimahon/src/main/assets/dictionary/base.css
+++ b/chimahon/src/main/assets/dictionary/base.css
@@ -737,7 +737,7 @@ table {
 .gloss-image-link[data-appearance=monochrome] .gloss-image { opacity: 0; }
 
 /* ── Icons & Buttons ─────────────────────────────────── */
-.word-audio-btn, .anki-add-btn, .anki-open-btn {
+.word-audio-btn, .anki-add-btn, .anki-open-btn, .dictionary-copy-btn {
   background: none;
   border: none;
   padding: 4px;
@@ -752,7 +752,7 @@ table {
   width: 28px;
   height: 28px;
 }
-.word-audio-btn:hover, .anki-add-btn:hover, .anki-open-btn:hover {
+.word-audio-btn:hover, .anki-add-btn:hover, .anki-open-btn:hover, .dictionary-copy-btn:hover {
   background: var(--hover-bg);
   color: var(--fg);
 }
@@ -766,7 +766,7 @@ table {
 }
 
 /* Only constrain SVGs inside icon buttons, not pitch diagrams */
-.word-audio-btn svg, .anki-add-btn svg, .anki-open-btn svg, .dict-arrow svg {
+.word-audio-btn svg, .anki-add-btn svg, .anki-open-btn svg, .dictionary-copy-btn svg, .dict-arrow svg {
   display: block; flex-shrink: 0;
   width: 20px; height: 20px;
   fill: currentColor;
@@ -949,13 +949,15 @@ html[data-chima-eink-mode="true"] .dict-arrow {
 
 html[data-chima-eink-mode="true"] .word-audio-btn,
 html[data-chima-eink-mode="true"] .anki-add-btn,
-html[data-chima-eink-mode="true"] .anki-open-btn {
+html[data-chima-eink-mode="true"] .anki-open-btn,
+html[data-chima-eink-mode="true"] .dictionary-copy-btn {
   border-radius: 0 !important;
 }
 
 html[data-chima-eink-mode="true"] .word-audio-btn:hover,
 html[data-chima-eink-mode="true"] .anki-add-btn:hover,
-html[data-chima-eink-mode="true"] .anki-open-btn:hover {
+html[data-chima-eink-mode="true"] .anki-open-btn:hover,
+html[data-chima-eink-mode="true"] .dictionary-copy-btn:hover {
   background: transparent !important;
   opacity: 1 !important;
 }
@@ -1090,7 +1092,8 @@ html[data-theme="dark"][data-chima-eink-mode="true"] .entry + .entry {
 
 html[data-theme="dark"][data-chima-eink-mode="true"] .word-audio-btn:hover,
 html[data-theme="dark"][data-chima-eink-mode="true"] .anki-add-btn:hover,
-html[data-theme="dark"][data-chima-eink-mode="true"] .anki-open-btn:hover {
+html[data-theme="dark"][data-chima-eink-mode="true"] .anki-open-btn:hover,
+html[data-theme="dark"][data-chima-eink-mode="true"] .dictionary-copy-btn:hover {
   background: transparent !important;
 }
 

--- a/chimahon/src/main/assets/dictionary/base.css
+++ b/chimahon/src/main/assets/dictionary/base.css
@@ -1106,6 +1106,11 @@ html[data-theme="dark"][data-chima-eink-mode="true"] .dictionary-copy-btn:hover 
 }
 .kanji-tag-list {
   margin: 4px 0;
+  display: flex;
+  align-items: center;
+}
+.kanji-tag-list .dictionary-copy-btn {
+  margin-left: auto;
 }
 .kanji-section-header {
   font-size: 0.85em;

--- a/chimahon/src/main/assets/dictionary/kanji-renderer.js
+++ b/chimahon/src/main/assets/dictionary/kanji-renderer.js
@@ -4,6 +4,7 @@
   function createEntryArticle(character, entry) {
     var article = document.createElement('article');
     article.className = 'entry kanji-entry';
+    var definitions = Array.isArray(entry.definitions) ? entry.definitions : [];
 
     // ── Glyph ──
     var glyphRow = document.createElement('div');
@@ -38,10 +39,23 @@
     inner.appendChild(content);
     tag.appendChild(inner);
     tagList.appendChild(tag);
+    if ((entry.dictName || '').toUpperCase().startsWith('KANJIDIC') && definitions.length > 0) {
+      var copyButton = document.createElement('button');
+      copyButton.className = 'dictionary-copy-btn';
+      copyButton.innerHTML = '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M19 21H8c-1.1 0-2-.9-2-2V7h2v12h11v2zM16 3H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H4V5h12v10z"/></svg>';
+      copyButton.title = 'Copy meanings';
+      copyButton.onclick = function(e) {
+        e.stopPropagation();
+        if (!window.DictionaryClipboard) return;
+        window.DictionaryClipboard.copyTranslation(definitions.join('\n'));
+        copyButton.innerHTML = '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>';
+        setTimeout(function() { copyButton.innerHTML = '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M19 21H8c-1.1 0-2-.9-2-2V7h2v12h11v2zM16 3H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H4V5h12v10z"/></svg>'; }, 1000);
+      };
+      tagList.appendChild(copyButton);
+    }
     body.appendChild(tagList);
 
     // ── Definitions (meanings) ──
-    var definitions = Array.isArray(entry.definitions) ? entry.definitions : [];
     if (definitions.length > 0) {
       var glossHeader = document.createElement('div');
       glossHeader.className = 'kanji-section-header';

--- a/chimahon/src/main/assets/dictionary/renderer.js
+++ b/chimahon/src/main/assets/dictionary/renderer.js
@@ -1959,6 +1959,7 @@
     volume_up: '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>',
     add_circle: '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v5h-2v-5H7v-2h4V7h2v4h4v2z"/></svg>',
     check_circle: '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>',
+    content_copy: '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path d="M19 21H8c-1.1 0-2-.9-2-2V7h2v12h11v2zM16 3H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H4V5h12v10z"/></svg>',
     expand_more: '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>',
     menu_book: '<svg viewBox="0 0 24 24" width="20" height="24" fill="currentColor"><path transform="translate(0, 24) scale(0.025)" d="M260-320q47 0 91.5 10.5T440-278v-394q-41-24-87-36t-93-12q-36 0-71.5 7T120-692v396q35-12 69.5-18t70.5-6Zm260 42q44-21 88.5-31.5T700-320q36 0 70.5 6t69.5 18v-396q-33-14-68.5-21t-71.5-7q-47 0-93 12t-87 36v394Zm-40 118q-48-38-104-59t-116-21q-42 0-82.5 11T100-198q-21 11-40.5-1T40-234v-482q0-11 5.5-21T62-752q46-24 96-36t102-12q58 0 113.5 15T480-740q51-30 106.5-45T700-800q52 0 102 12t96 36q11 5 16.5 15t5.5 21v482q0 23-19.5 35t-40.5 1q-37-20-77.5-31T700-240q-60 0-116 21t-104 59ZM280-494Z"/></svg>',
     arrow_upward: '<svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"/></svg>',
@@ -2121,6 +2122,31 @@
       const cancelPress = () => { clearTimeout(_pressTimer); };
       dictHeader.addEventListener('pointerup', cancelPress);
       dictHeader.addEventListener('pointercancel', cancelPress);
+
+      const copyButton = document.createElement('button');
+      copyButton.className = 'dictionary-copy-btn';
+      copyButton.innerHTML = ICONS.content_copy;
+      copyButton.title = 'Copy translations';
+      copyButton.addEventListener('pointerdown', (e) => {
+        e.stopPropagation();
+        cancelPress();
+      });
+      copyButton.onclick = (e) => {
+        e.stopPropagation();
+        const translations = Array.from(ol.querySelectorAll('.gloss-content'))
+          .flatMap((content) => {
+            const glossaryNodes = content.querySelectorAll('[data-sc-content="glossary"]');
+            const textNodes = glossaryNodes.length > 0 ? glossaryNodes : [content];
+            return Array.from(textNodes, (node) => node.innerText.trim());
+          })
+          .filter(Boolean)
+          .join('\n');
+        if (!translations || !window.DictionaryClipboard) return;
+        window.DictionaryClipboard.copyTranslation(translations);
+        copyButton.innerHTML = ICONS.check_circle;
+        setTimeout(() => { copyButton.innerHTML = ICONS.content_copy; }, 1000);
+      };
+      dictHeader.appendChild(copyButton);
       
       dictSection.appendChild(dictHeader);
 


### PR DESCRIPTION
## Problem

The OCR popup has no direct way to copy the full text. Dictionary and KANJIDIC entries also have no direct way to copy only their meanings.

## Result

Users can copy the full OCR text from both the dictionary popup and the long-press full-text popup. Users can also copy dictionary glossary meanings and KANJIDIC meanings.

<img width="269" height="327" alt="Screenshot 2026-08-10 002422" src="https://github.com/user-attachments/assets/fa35ed8c-a56f-4e92-96e1-83ccf3714f0c" />
<img width="270" height="328" alt="Screenshot 2026-08-10 002430" src="https://github.com/user-attachments/assets/835fd537-8afa-4659-8bb0-413a4b2f0209" />
