### PR TITLE
feat(player): remap subtitle swipe controls and preserve time precision

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
@@ -252,7 +252,7 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet) : BaseMPVView(c
         "chapter-list" to MPVLib.mpvFormat.MPV_FORMAT_NONE,
         "track-list" to MPVLib.mpvFormat.MPV_FORMAT_NONE,
 
-        "time-pos" to MPVLib.mpvFormat.MPV_FORMAT_INT64,
+        "time-pos" to MPVLib.mpvFormat.MPV_FORMAT_DOUBLE,
         "demuxer-cache-time" to MPVLib.mpvFormat.MPV_FORMAT_INT64,
         "duration" to MPVLib.mpvFormat.MPV_FORMAT_INT64,
         "volume" to MPVLib.mpvFormat.MPV_FORMAT_INT64,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -946,10 +946,6 @@ class PlayerActivity : BaseActivity() {
     internal fun onObserverEvent(property: String, value: Long) {
         if (player.isExiting) return
         when (property) {
-            "time-pos" -> {
-                viewModel.updatePlayBackPos(value.toFloat())
-                viewModel.setChapter(value.toFloat())
-            }
             "demuxer-cache-time" -> viewModel.updateReadAhead(value = value)
             "volume" -> viewModel.setMPVVolume(value.toInt())
             "volume-max" -> viewModel.volumeBoostCap = value.toInt() - 100
@@ -1029,6 +1025,10 @@ class PlayerActivity : BaseActivity() {
     internal fun onObserverEvent(property: String, value: Double) {
         if (player.isExiting) return
         when (property) {
+            "time-pos" -> {
+                viewModel.updatePlayBackPos(value.toFloat())
+                viewModel.setChapter(value.toFloat())
+            }
             "speed" -> viewModel.playbackSpeed.update { value.toFloat() }
             "video-params/aspect" -> if (isPipSupportedAndEnabled) createPipParams()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1419,6 +1419,19 @@ class PlayerViewModel @JvmOverloads constructor(
         _activeSubtitleCueIndex.update { target.index }
     }
 
+    fun replayCurrentSubtitle() {
+        val currentCue = activeSubtitleCueIndex.value?.let { activeCueIndex ->
+            subtitleHistory.value.firstOrNull { it.index == activeCueIndex }
+        }
+        if (currentCue == null) {
+            MPVLib.command(arrayOf("sub-seek", "0", "primary"))
+            return
+        }
+
+        seekTo(currentCue.effectiveStartSeconds().coerceAtLeast(0.0))
+        _activeSubtitleCueIndex.update { currentCue.index }
+    }
+
     fun setSubtitlesVisible(visible: Boolean) {
         MPVLib.setPropertyBoolean("sub-visibility", visible)
         _subtitlesVisible.update { visible }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
@@ -84,6 +84,33 @@ import kotlin.math.abs
 private const val SUBTITLE_SWIPE_TIME_LIMIT_MILLIS = 500L
 private const val SUBTITLE_SWIPE_DOMINANCE_RATIO = 1.2f
 
+internal enum class SubtitleSwipeAction {
+    ToggleVisibility,
+    ReplayCurrent,
+    Previous,
+    Next,
+}
+
+internal fun resolveSubtitleSwipeAction(
+    totalDragX: Float,
+    totalDragY: Float,
+    minimumDistance: Float,
+): SubtitleSwipeAction? {
+    val horizontalDistance = abs(totalDragX)
+    val verticalDistance = abs(totalDragY)
+    return when {
+        horizontalDistance >= minimumDistance &&
+            horizontalDistance > verticalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
+            if (totalDragX > 0f) SubtitleSwipeAction.Next else SubtitleSwipeAction.Previous
+        }
+        verticalDistance >= minimumDistance &&
+            verticalDistance > horizontalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
+            if (totalDragY > 0f) SubtitleSwipeAction.ToggleVisibility else SubtitleSwipeAction.ReplayCurrent
+        }
+        else -> null
+    }
+}
+
 @Composable
 fun GestureHandler(
     viewModel: PlayerViewModel,
@@ -266,17 +293,14 @@ fun GestureHandler(
                             return@detectDragGestures
                         }
 
-                        val horizontalDistance = abs(totalDragX)
-                        val verticalDistance = abs(totalDragY)
-                        when {
-                            horizontalDistance >= subtitleSwipeDistance &&
-                                horizontalDistance > verticalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
-                                viewModel.seekToAdjacentSubtitle(forward = totalDragX > 0f)
+                        when (resolveSubtitleSwipeAction(totalDragX, totalDragY, subtitleSwipeDistance)) {
+                            SubtitleSwipeAction.ToggleVisibility -> {
+                                viewModel.setSubtitlesVisible(!viewModel.subtitlesVisible.value)
                             }
-                            verticalDistance >= subtitleSwipeDistance &&
-                                verticalDistance > horizontalDistance * SUBTITLE_SWIPE_DOMINANCE_RATIO -> {
-                                viewModel.setSubtitlesVisible(visible = totalDragY > 0f)
-                            }
+                            SubtitleSwipeAction.ReplayCurrent -> viewModel.replayCurrentSubtitle()
+                            SubtitleSwipeAction.Previous -> viewModel.seekToAdjacentSubtitle(forward = false)
+                            SubtitleSwipeAction.Next -> viewModel.seekToAdjacentSubtitle(forward = true)
+                            null -> Unit
                         }
                     },
                     onDragCancel = {

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/controls/SubtitleSwipeActionTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/controls/SubtitleSwipeActionTest.kt
@@ -1,0 +1,30 @@
+package eu.kanade.tachiyomi.ui.player.controls
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SubtitleSwipeActionTest {
+
+    @Test
+    fun `swipe up replays the current subtitle`() {
+        assertEquals(SubtitleSwipeAction.ReplayCurrent, resolveSubtitleSwipeAction(0f, -31f, 30f))
+    }
+
+    @Test
+    fun `swipe down toggles subtitle visibility`() {
+        assertEquals(SubtitleSwipeAction.ToggleVisibility, resolveSubtitleSwipeAction(0f, 31f, 30f))
+    }
+
+    @Test
+    fun `horizontal swipes move between subtitle cues`() {
+        assertEquals(SubtitleSwipeAction.Previous, resolveSubtitleSwipeAction(-31f, 0f, 30f))
+        assertEquals(SubtitleSwipeAction.Next, resolveSubtitleSwipeAction(31f, 0f, 30f))
+    }
+
+    @Test
+    fun `diagonal and short swipes have no subtitle action`() {
+        assertNull(resolveSubtitleSwipeAction(30f, 30f, 30f))
+        assertNull(resolveSubtitleSwipeAction(0f, 29f, 30f))
+    }
+}


### PR DESCRIPTION
## Problem
- **Inaccurate subtitle seeking:** Previously, MPV's `time-pos` property was observed as `MPV_FORMAT_INT64` (integer seconds). Truncating playback timestamps to whole seconds caused `seekToAdjacentSubtitle` to lose sub-second precision, occasionally causing horizontal swipe seeks to target the current or incorrect subtitle cue.
- **Unintuitive vertical swipe gestures:** Swiping up closed subtitles while swiping down opened subtitles. Users had no quick gesture to re-read or replay the current subtitle line from its start timestamp without manually scrubbing the seekbar.

## Result
- Subtitle swipe seeking now uses high-precision floating-point timestamps, eliminating duplicate cue seeking caused by integer truncation.
- Users can swipe up to replay the active subtitle line from the beginning for better language learning/listening comprehension.
- Vertical swipe down now seamlessly toggles subtitle visibility ON/OFF.
