### PR TITLE
fix(anki): open cached duplicate cards directly

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -87,8 +87,23 @@ private data class TabLookupFrame(
     val styles: List<DictionaryStyle>,
     val mediaDataUris: Map<String, String>,
     val existingExpressions: Set<String>,
+    val existingCardIds: Map<String, Long>,
     val entryJsons: List<String>? = null,
 )
+
+internal fun cacheAnkiResultNoteId(
+    existingCardIds: Map<String, Long>,
+    expression: String,
+    ankiResult: AnkiResult,
+): Map<String, Long> {
+    val noteId = when (ankiResult) {
+        is AnkiResult.Success -> ankiResult.noteId
+        is AnkiResult.CardExists -> ankiResult.noteId
+        is AnkiResult.OpenCard -> ankiResult.noteId
+        else -> return existingCardIds
+    }
+    return existingCardIds + (expression to noteId)
+}
 
 
 private var cachedDictionaryPaths: chimahon.DictionaryPaths? = null
@@ -293,6 +308,7 @@ data object DictionaryTab : Tab {
                         styles = emptyList(),
                         mediaDataUris = emptyMap(),
                         existingExpressions = emptySet(),
+                        existingCardIds = emptyMap(),
                         entryJsons = jsonStrings,
                     )
                     lookupError = null
@@ -310,6 +326,7 @@ data object DictionaryTab : Tab {
                         styles = lookupResult.styles,
                         mediaDataUris = lookupResult.mediaDataUris,
                         existingExpressions = emptySet(),
+                        existingCardIds = emptyMap(),
                     )
                     lookupError = lookupResult.error
                 }
@@ -344,7 +361,7 @@ data object DictionaryTab : Tab {
                 if (ankiEnabled && type != "kanji" && initialFrame.results.isNotEmpty()) {
                     val unique = initialFrame.results.map { it.term.expression }.distinct()
                     scope.launch(Dispatchers.IO) {
-                        val existing = AnkiCardCreator.checkExistingCards(
+                        val existingCardIds = AnkiCardCreator.checkExistingCardIds(
                             context = context,
                             expressions = unique,
                             deckName = ankiDeck,
@@ -353,7 +370,10 @@ data object DictionaryTab : Tab {
                         withContext(Dispatchers.Main) {
                             // Only update if we are still on the same frame
                             if (activeTabIndex < lookupStack.size && lookupStack[activeTabIndex].query == rawQuery) {
-                                lookupStack[activeTabIndex] = lookupStack[activeTabIndex].copy(existingExpressions = existing)
+                                lookupStack[activeTabIndex] = lookupStack[activeTabIndex].copy(
+                                    existingExpressions = existingCardIds.keys,
+                                    existingCardIds = existingCardIds,
+                                )
                             }
                         }
                     }
@@ -418,6 +438,25 @@ data object DictionaryTab : Tab {
                     val frameIndex = activeTabIndex
                     val expression = result.term.expression
                     scope.launch {
+                        if (forceOpen) {
+                            val cachedNoteId = lookupStack.getOrNull(frameIndex)?.existingCardIds?.get(expression)
+                            val noteId = cachedNoteId ?: AnkiCardCreator.findExistingCardId(
+                                context = context,
+                                expression = expression,
+                                deckName = ankiDeck,
+                                dupScope = ankiDupScope,
+                            ) ?: return@launch
+                            val frame = lookupStack.getOrNull(frameIndex)
+                            if (frame?.results?.getOrNull(resultIndex)?.term?.expression == expression) {
+                                lookupStack[frameIndex] = frame.copy(
+                                    existingExpressions = frame.existingExpressions + expression,
+                                    existingCardIds = frame.existingCardIds + (expression to noteId),
+                                )
+                            }
+                            AnkiDroidBridge(context).guiEditNote(noteId)
+                            return@launch
+                        }
+
                         val ankiResult = AnkiCardCreator.addToAnki(
                             context = context,
                             result = result,
@@ -441,7 +480,14 @@ data object DictionaryTab : Tab {
                             val frame = lookupStack.getOrNull(frameIndex)
                             if (frame?.results?.getOrNull(resultIndex)?.term?.expression == expression) {
                                 val newExisting = frame.existingExpressions + expression
-                                lookupStack[frameIndex] = frame.copy(existingExpressions = newExisting)
+                                lookupStack[frameIndex] = frame.copy(
+                                    existingExpressions = newExisting,
+                                    existingCardIds = cacheAnkiResultNoteId(
+                                        frame.existingCardIds,
+                                        expression,
+                                        ankiResult,
+                                    ),
+                                )
                             }
                         }
                         when (ankiResult) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -110,6 +110,7 @@ private data class LookupFrame(
     val styles: List<chimahon.DictionaryStyle>,
     val mediaDataUris: Map<String, String>,
     val existingExpressions: Set<String>,
+    val existingCardIds: Map<String, Long> = emptyMap(),
     val entryJsons: List<String>? = null,
 )
 
@@ -363,7 +364,7 @@ fun OcrLookupPopup(
             if (ankiEnabled && orderedResults.isNotEmpty()) {
                 val uniqueExpressions = orderedResults.map { it.term.expression }.distinct()
                 scope.launch(Dispatchers.IO) {
-                    val existing = AnkiCardCreator.checkExistingCards(
+                    val existingCardIds = AnkiCardCreator.checkExistingCardIds(
                         context = context,
                         expressions = uniqueExpressions,
                         deckName = ankiDeck,
@@ -373,7 +374,10 @@ fun OcrLookupPopup(
                         val stack = lookupStackState.stack.toMutableList()
                         val frameIndex = stack.indexOfFirst { it.id == frame.id }
                         if (frameIndex >= 0) {
-                            stack[frameIndex] = stack[frameIndex].copy(existingExpressions = existing)
+                            stack[frameIndex] = stack[frameIndex].copy(
+                                existingExpressions = existingCardIds.keys,
+                                existingCardIds = existingCardIds,
+                            )
                             lookupStackState = lookupStackState.copy(stack = stack)
                         }
                         Log.i(
@@ -540,15 +544,25 @@ fun OcrLookupPopup(
             ?: (miningFrame?.sentenceOffset ?: charOffset)
 
         // Local helper to update the state, which triggers the optimized JS call via DictionaryEntryWebView
-        fun updateStatus(expression: String) {
+        fun updateStatus(expression: String, noteId: Long? = null) {
             val frame = currentFrame ?: return
             val stack = lookupStackState.stack.toMutableList()
             val frameIndex = stack.indexOfFirst { it.id == frame.id }
             if (frameIndex >= 0) {
                 val newExisting = frame.existingExpressions + expression
-                stack[frameIndex] = stack[frameIndex].copy(existingExpressions = newExisting)
+                val newCardIds = noteId?.let { frame.existingCardIds + (expression to it) } ?: frame.existingCardIds
+                stack[frameIndex] = stack[frameIndex].copy(
+                    existingExpressions = newExisting,
+                    existingCardIds = newCardIds,
+                )
                 lookupStackState = lookupStackState.copy(stack = stack)
             }
+        }
+
+        if (forceOpen) {
+            val noteId = currentFrame?.existingCardIds?.get(result.term.expression) ?: return
+            chimahon.anki.AnkiDroidBridge(context).guiEditNote(noteId)
+            return
         }
 
         val shouldUseCropMode = screenshotFieldMapped && cropMode == "crop" && onCropTriggered != null
@@ -590,7 +604,7 @@ fun OcrLookupPopup(
                     withContext(kotlinx.coroutines.Dispatchers.Main) {
                         when (ankiResult) {
                             is AnkiResult.Success -> {
-                                updateStatus(result.term.expression)
+                                updateStatus(result.term.expression, ankiResult.noteId)
                                 onAnkiMediaWarnings(ankiResult.mediaWarnings)
                                 dismissPopup()
                                 onCropTriggered.invoke(ankiResult.noteId, glossaryIndex)
@@ -669,7 +683,7 @@ fun OcrLookupPopup(
                 withContext(kotlinx.coroutines.Dispatchers.Main) {
                     when (ankiResult) {
                         is AnkiResult.Success -> {
-                            updateStatus(result.term.expression)
+                            updateStatus(result.term.expression, ankiResult.noteId)
                             onAnkiMediaWarnings(ankiResult.mediaWarnings)
                             context.toast(MR.strings.anki_card_added)
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -560,8 +560,24 @@ fun OcrLookupPopup(
         }
 
         if (forceOpen) {
-            val noteId = currentFrame?.existingCardIds?.get(result.term.expression) ?: return
-            chimahon.anki.AnkiDroidBridge(context).guiEditNote(noteId)
+            val expression = result.term.expression
+            val noteId = currentFrame?.existingCardIds?.get(expression)
+            if (noteId != null) {
+                chimahon.anki.AnkiDroidBridge(context).guiEditNote(noteId)
+                return
+            }
+            miningScope.launch {
+                val fallbackNoteId = AnkiCardCreator.findExistingCardId(
+                    context = context,
+                    expression = expression,
+                    deckName = ankiDeck,
+                    dupScope = ankiDupScope,
+                ) ?: return@launch
+                withContext(kotlinx.coroutines.Dispatchers.Main) {
+                    updateStatus(expression, fallbackNoteId)
+                    chimahon.anki.AnkiDroidBridge(context).guiEditNote(fallbackNoteId)
+                }
+            }
             return
         }
 
@@ -610,11 +626,11 @@ fun OcrLookupPopup(
                                 onCropTriggered.invoke(ankiResult.noteId, glossaryIndex)
                             }
                             is AnkiResult.CardExists -> {
-                                updateStatus(result.term.expression)
+                                updateStatus(result.term.expression, ankiResult.noteId)
                                 context.toast(MR.strings.anki_card_exists)
                             }
                             is AnkiResult.OpenCard -> {
-                                updateStatus(result.term.expression)
+                                updateStatus(result.term.expression, ankiResult.noteId)
                                 chimahon.anki.AnkiDroidBridge(context).guiEditNote(ankiResult.noteId)
                             }
                             else -> {}
@@ -688,11 +704,11 @@ fun OcrLookupPopup(
                             context.toast(MR.strings.anki_card_added)
                         }
                         is AnkiResult.CardExists -> {
-                            updateStatus(result.term.expression)
+                            updateStatus(result.term.expression, ankiResult.noteId)
                             context.toast(MR.strings.anki_card_exists)
                         }
                         is AnkiResult.OpenCard -> {
-                            updateStatus(result.term.expression)
+                            updateStatus(result.term.expression, ankiResult.noteId)
                             chimahon.anki.AnkiDroidBridge(context).guiEditNote(ankiResult.noteId)
                         }
                         is AnkiResult.PermissionDenied -> context.toast(MR.strings.pref_anki_permission_denied)

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/dictionary/DictionaryAnkiCacheTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/dictionary/DictionaryAnkiCacheTest.kt
@@ -1,0 +1,15 @@
+package eu.kanade.tachiyomi.ui.dictionary
+
+import chimahon.anki.AnkiResult
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class DictionaryAnkiCacheTest {
+
+    @Test
+    fun `caches note IDs returned by every successful Anki outcome`() {
+        cacheAnkiResultNoteId(emptyMap(), "見る", AnkiResult.Success(11)) shouldBe mapOf("見る" to 11L)
+        cacheAnkiResultNoteId(emptyMap(), "聞く", AnkiResult.CardExists(12)) shouldBe mapOf("聞く" to 12L)
+        cacheAnkiResultNoteId(emptyMap(), "読む", AnkiResult.OpenCard(13)) shouldBe mapOf("読む" to 13L)
+    }
+}

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -480,10 +480,22 @@ object AnkiCardCreator {
         expressions: List<String>,
         deckName: String = "",
         dupScope: String = "collection",
-    ): Set<String> {
-        val existing = mutableSetOf<String>()
+    ): Set<String> = checkExistingCardIds(
+        context = context,
+        expressions = expressions,
+        deckName = deckName,
+        dupScope = dupScope,
+    ).keys
 
-        val bridge = AnkiDroidBridge(context)
+    suspend fun checkExistingCardIds(
+        context: Context,
+        expressions: List<String>,
+        deckName: String = "",
+        dupScope: String = "collection",
+    ): Map<String, Long> {
+        val existing = linkedMapOf<String, Long>()
+
+        val bridge = bridgeFactory(context)
         if (!bridge.hasPermission()) return existing
 
         val targetDeckId = if (dupScope == "deck" && deckName.isNotBlank()) {
@@ -499,9 +511,7 @@ object AnkiCardCreator {
         for (expr in expressions.distinct()) {
             try {
                 val notes = bridge.findNotes(expr, null, targetDeckId)
-                if (notes.isNotEmpty()) {
-                    existing.add(expr)
-                }
+                notes.firstOrNull()?.let { noteId -> existing[expr] = noteId }
             } catch (e: Exception) {
                 android.util.Log.w(TAG, "checkExistingCards failed for expr=$expr", e)
             }

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -519,6 +519,33 @@ object AnkiCardCreator {
         return existing
     }
 
+    suspend fun findExistingCardId(
+        context: Context,
+        expression: String,
+        deckName: String = "",
+        dupScope: String = "collection",
+    ): Long? {
+        val bridge = bridgeFactory(context)
+        if (!bridge.hasPermission()) return null
+
+        val targetDeckId = if (dupScope == "deck" && deckName.isNotBlank()) {
+            try {
+                bridge.getDeckId(deckName)
+            } catch (_: Exception) {
+                null
+            }
+        } else {
+            null
+        }
+
+        return try {
+            bridge.findNotes(expression, null, targetDeckId).firstOrNull()
+        } catch (e: Exception) {
+            android.util.Log.w(TAG, "findExistingCardId failed for expr=$expression", e)
+            null
+        }
+    }
+
     fun parseFieldMap(json: String): Map<String, String> {
         if (json.isBlank() || json == "{}") return emptyMap()
         return try {

--- a/chimahon/src/test/java/chimahon/anki/AnkiCardCreatorSentenceAudioTest.kt
+++ b/chimahon/src/test/java/chimahon/anki/AnkiCardCreatorSentenceAudioTest.kt
@@ -101,6 +101,20 @@ class AnkiCardCreatorSentenceAudioTest {
     }
 
     @Test
+    fun `single card lookup returns no ID without creating a note`() = runTest {
+        val bridge = FakeBridge(listOf(emptyList()))
+        AnkiCardCreator.bridgeFactory = { bridge }
+
+        val noteId = AnkiCardCreator.findExistingCardId(
+            context = TestContext,
+            expression = "missing",
+        )
+
+        assertEquals(null, noteId)
+        assertEquals(0, bridge.addNoteCalls)
+    }
+
+    @Test
     fun `final duplicate recheck overwrites only after storing prepared media`() = runTest {
         val bridge = FakeBridge(listOf(emptyList(), listOf(44L)))
         AnkiCardCreator.bridgeFactory = { bridge }

--- a/chimahon/src/test/java/chimahon/anki/AnkiCardCreatorSentenceAudioTest.kt
+++ b/chimahon/src/test/java/chimahon/anki/AnkiCardCreatorSentenceAudioTest.kt
@@ -88,6 +88,19 @@ class AnkiCardCreatorSentenceAudioTest {
     }
 
     @Test
+    fun `duplicate lookup returns the first Anki note ID for each existing expression`() = runTest {
+        val bridge = FakeBridge(listOf(listOf(41L, 42L), emptyList(), listOf(73L)))
+        AnkiCardCreator.bridgeFactory = { bridge }
+
+        val existing = AnkiCardCreator.checkExistingCardIds(
+            context = TestContext,
+            expressions = listOf("existing", "missing", "existing", "another"),
+        )
+
+        assertEquals(mapOf("existing" to 41L, "another" to 73L), existing)
+    }
+
+    @Test
     fun `final duplicate recheck overwrites only after storing prepared media`() = runTest {
         val bridge = FakeBridge(listOf(emptyList(), listOf(44L)))
         AnkiCardCreator.bridgeFactory = { bridge }


### PR DESCRIPTION
## Problem

The reader popup could know that a term already existed in Anki but still lack its `noteId`: `CardExists` and `OpenCard` results updated only the duplicate-expression status. If the ID was missing when “Open in Anki” was pressed, the popup returned without opening anything.

The Dictionary tab also retained only duplicate expressions. Its Open action therefore re-entered the Add-to-Anki preflight to query Anki again before it could open the existing note.

## Result

“Open in Anki” now opens an existing card directly when its ID is cached. If the asynchronous duplicate check has not finished or the cache is missing an ID, the app performs only a note lookup as fallback.

The Add-to-Anki flow remains unchanged: a new card still prepares media and creates the card only when appropriate.

## Before vs after

```mermaid
flowchart LR
    subgraph Before
        A1["Tap word"] --> B1["Popup checks duplicate expressions"]
        B1 --> C1["Open in Anki"]
        C1 --> D1["Enter Add-to-Anki flow"]
        D1 --> E1["Capture screenshot / animated scene"]
        E1 --> F1["Query Anki again for the note ID"]
        F1 --> G1["Open AnkiDroid"]
    end

    subgraph After
        A2["Tap word"] --> B2["Popup checks duplicates and caches note IDs"]
        B2 --> C2{"Action"}
        C2 -- "Open in Anki" --> D2["Open cached note ID in AnkiDroid"]
        C2 -- "Add to Anki" --> E2{"Duplicate exists?"}
        E2 -- "No" --> F2["Capture media and create card"]
        E2 -- "Yes" --> G2["Apply duplicate-card behavior"]
    end