### PR TITLE
Popup theme improvments

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDictionaryScreen.kt
@@ -643,6 +643,8 @@ object SettingsDictionaryScreen : SearchableSettings {
 
         val themeModePref = dictionaryPreferences.themeMode()
         val themeMode by themeModePref.collectAsState()
+        val customColorPref = dictionaryPreferences.customColor()
+        val customColor by customColorPref.collectAsState()
 
         // Keep multi-select set prefs aligned with the boolean flags used by the popup.
         val frequencyModesPref = dictionaryPreferences.frequencyDisplayModes()
@@ -897,6 +899,7 @@ object SettingsDictionaryScreen : SearchableSettings {
                             ) {
                                 val chips = listOf(
                                     "system" to stringResource(MR.strings.theme_system),
+                                    "app" to "App",
                                     "light" to stringResource(MR.strings.theme_light),
                                     "dark" to stringResource(MR.strings.theme_dark),
                                     "pure_black" to stringResource(MR.strings.pref_dict_theme_pure_black),
@@ -913,7 +916,7 @@ object SettingsDictionaryScreen : SearchableSettings {
                     ),
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(KMR.strings.pref_custom_color),
-                        subtitle = stringResource(KMR.strings.custom_color_description),
+                        subtitle = if (customColor != 0) "Custom color active (tap to edit)" else stringResource(KMR.strings.custom_color_description),
                         onClick = {
                             navigator.push(AppCustomThemeColorPickerScreen(isDictionary = true))
                         },

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/appearance/AppCustomThemeColorPickerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/appearance/AppCustomThemeColorPickerScreen.kt
@@ -25,6 +25,11 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Restore
+import tachiyomi.i18n.MR
 
 class AppCustomThemeColorPickerScreen(private val isDictionary: Boolean = false) : Screen() {
 
@@ -60,6 +65,13 @@ class AppCustomThemeColorPickerScreen(private val isDictionary: Boolean = false)
                     onItemClick = { color, appTheme ->
                         customColorPref.set(color.toArgb())
                         appThemePref?.set(appTheme)
+                        if (!isDictionary) {
+                            (context as? Activity)?.let { ActivityCompat.recreate(it) }
+                        }
+                        navigator.pop()
+                    },
+                    onResetClick = {
+                        customColorPref.set(0)
                         if (!isDictionary) {
                             (context as? Activity)?.let { ActivityCompat.recreate(it) }
                         }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/ThemeColorPickerWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/ThemeColorPickerWidget.kt
@@ -46,9 +46,11 @@ import com.github.skydoves.colorpicker.compose.ColorPickerController
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import eu.kanade.domain.ui.model.AppTheme
 import kotlinx.coroutines.launch
+import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.components.material.Button
 import tachiyomi.presentation.core.components.material.ButtonDefaults.buttonColors
+import androidx.compose.material3.OutlinedButton
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.math.roundToInt
@@ -59,6 +61,7 @@ internal fun ThemeColorPickerWidget(
     initialColor: Color,
     controller: ColorPickerController,
     onItemClick: (Color, AppTheme) -> Unit,
+    onResetClick: (() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     var selectedColor by remember { mutableStateOf(initialColor) }
@@ -175,26 +178,43 @@ internal fun ThemeColorPickerWidget(
                         )
                     }
                 }
-                Button(
-                    onClick = {
-                        onItemClick(selectedColor, AppTheme.CUSTOM)
-                    },
-                    colors = buttonColors(
-                        containerColor = animateColorAsState(
-                            label = "animateColorAsState",
-                            targetValue = MaterialTheme.colorScheme.primary,
-                            animationSpec = tween(durationMillis = 500),
-                        ).value,
-                    ),
-                    interactionSource = interactionSource,
+                Row(
                     modifier = Modifier
                         .padding(vertical = MaterialTheme.padding.medium)
-                        .fillMaxWidth()
-                        .height(48.dp),
-                    content = {
-                        Text(text = stringResource(KMR.strings.action_confirm_color))
-                    },
-                )
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (onResetClick != null) {
+                        OutlinedButton(
+                            onClick = onResetClick,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(48.dp),
+                            content = {
+                                Text(text = stringResource(MR.strings.action_reset))
+                            },
+                        )
+                    }
+                    Button(
+                        onClick = {
+                            onItemClick(selectedColor, AppTheme.CUSTOM)
+                        },
+                        colors = buttonColors(
+                            containerColor = animateColorAsState(
+                                label = "animateColorAsState",
+                                targetValue = MaterialTheme.colorScheme.primary,
+                                animationSpec = tween(durationMillis = 500),
+                            ).value,
+                        ),
+                        interactionSource = interactionSource,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp),
+                        content = {
+                            Text(text = stringResource(KMR.strings.action_confirm_color))
+                        },
+                    )
+                }
 
                 val colorsPalette = mapOf(
                     KMR.strings.custom_theme_palette_sunset to listOf(

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -125,7 +125,7 @@ val playerRippleConfiguration
         ),
     )
 
-private fun getThemeColorScheme(
+internal fun getThemeColorScheme(
     context: Context,
     appTheme: AppTheme,
     isDark: Boolean,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryBootstrapHtml.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryBootstrapHtml.kt
@@ -4,11 +4,14 @@ import android.content.Context
 import android.webkit.WebView
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import com.canopus.chimareader.data.FontManager
 import com.materialkolor.PaletteStyle
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.presentation.theme.colorscheme.CustomColorScheme
+import eu.kanade.presentation.theme.getThemeColorScheme
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -161,12 +164,73 @@ fun getDictionaryColorScheme(
     isAmoled: Boolean,
     seedColor: Int,
 ): ColorScheme {
-    val uiPreferences = Injekt.get<UiPreferences>()
     val baseScheme = CustomColorScheme(
         seed = Color(seedColor),
         style = PaletteStyle.TonalSpot,
     )
     return baseScheme.getColorScheme(isDark, isAmoled, false)
+}
+
+fun getAppThemeColorScheme(context: Context, isDark: Boolean, isAmoled: Boolean): ColorScheme {
+    return getThemeColorScheme(
+        context = context,
+        appTheme = Injekt.get<UiPreferences>().appTheme().get(),
+        isDark = isDark,
+        isAmoled = isAmoled,
+    )
+}
+
+/**
+ * Colors for the dictionary popup / entry WebView.
+ *
+ * Theme mode `"app"` follows Appearance → App theme, but is overridden by:
+ * - dictionary custom color
+ * - e-ink mode
+ * - [forceDefaultTheme]
+ */
+data class DictionaryThemeResolved(
+    val isDark: Boolean,
+    val isAmoled: Boolean,
+    val seedColor: Int,
+    val useAppTheme: Boolean,
+)
+
+fun resolveDictionaryTheme(
+    themeMode: String,
+    customColor: Int,
+    eInkMode: Boolean,
+    forceDefaultTheme: Boolean,
+    systemIsDark: Boolean,
+    appThemeMode: ThemeMode,
+    appAmoled: Boolean,
+    appColorTheme: Int,
+): DictionaryThemeResolved {
+    val useAppTheme = themeMode == "app" && !eInkMode && !forceDefaultTheme
+    val hasCustomColor = customColor != 0 && !forceDefaultTheme && !useAppTheme
+    val seedColor = if (hasCustomColor) customColor else appColorTheme
+    val appIsDark = when (appThemeMode) {
+        ThemeMode.DARK -> true
+        ThemeMode.LIGHT -> false
+        ThemeMode.SYSTEM -> systemIsDark
+    }
+    val isAmoled = when {
+        useAppTheme -> appAmoled
+        themeMode == "pure_black" -> true
+        else -> false
+    }
+    val isDark = when {
+        useAppTheme -> appIsDark
+        themeMode == "dark" || themeMode == "pure_black" -> true
+        themeMode == "light" -> false
+        hasCustomColor -> Color(seedColor).luminance() < 0.5f
+        else -> systemIsDark
+    }
+    return DictionaryThemeResolved(
+        isDark = isDark,
+        isAmoled = isAmoled,
+        seedColor = seedColor,
+        useAppTheme = useAppTheme,
+    )
 }
 
 internal fun stopDictionaryAudio(webView: WebView) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryEntryWebView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryEntryWebView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -17,14 +18,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import chimahon.DictionaryStyle
 import chimahon.LookupResult
 import eu.kanade.domain.ui.UiPreferences
-import eu.kanade.presentation.theme.colorscheme.*
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -74,19 +73,43 @@ fun DictionaryEntryWebView(
     val prefs = remember { Injekt.get<DictionaryPreferences>() }
     val uiPreferences = remember { Injekt.get<UiPreferences>() }
     val fontFamily by prefs.fontFamily().collectAsState()
-    val seedColor = if (customColor == 0 || forceDefaultTheme) uiPreferences.colorTheme().get() else customColor
+    val eInkMode by prefs.eInkMode().collectAsState()
+    val paginatedScrolling by prefs.paginatedScrolling().collectAsState()
+    val appAmoled by uiPreferences.themeDarkAmoled().collectAsState()
+    val appThemeMode by uiPreferences.themeMode().collectAsState()
+    val appColorTheme by uiPreferences.colorTheme().collectAsState()
 
     val systemIsDark = isSystemInDarkTheme()
-    val isAmoled = themeMode == "pure_black"
-    val isDark = remember(seedColor, customColor, systemIsDark, forceDefaultTheme, themeMode) {
-        when (themeMode) {
-            "dark", "pure_black" -> true
-            "light" -> false
-            else -> if (customColor != 0 && !forceDefaultTheme) Color(seedColor).luminance() < 0.5f else systemIsDark
-        }
+    val resolvedTheme = remember(
+        themeMode,
+        customColor,
+        eInkMode,
+        forceDefaultTheme,
+        systemIsDark,
+        appThemeMode,
+        appAmoled,
+        appColorTheme,
+    ) {
+        resolveDictionaryTheme(
+            themeMode = themeMode,
+            customColor = customColor,
+            eInkMode = eInkMode,
+            forceDefaultTheme = forceDefaultTheme,
+            systemIsDark = systemIsDark,
+            appThemeMode = appThemeMode,
+            appAmoled = appAmoled,
+            appColorTheme = appColorTheme,
+        )
     }
-    val colorScheme = remember(isDark, isAmoled, seedColor) {
-        getDictionaryColorScheme(isDark, isAmoled, seedColor)
+    val isDark = resolvedTheme.isDark
+    val isAmoled = resolvedTheme.isAmoled
+    val seedColor = resolvedTheme.seedColor
+    val colorScheme = if (resolvedTheme.useAppTheme) {
+        MaterialTheme.colorScheme
+    } else {
+        remember(isDark, isAmoled, seedColor) {
+            getDictionaryColorScheme(isDark, isAmoled, seedColor)
+        }
     }
     val BgColor = remember(isDark, isAmoled, seedColor, colorScheme) {
         if (isAmoled && isDark) Color.Black else colorScheme.surface
@@ -94,8 +117,6 @@ fun DictionaryEntryWebView(
     val wordAudioAutoplay by prefs.wordAudioAutoplay().collectAsState()
     val effectiveWordAudioAutoplay = wordAudioAutoplayOverride ?: wordAudioAutoplay
     val showNavigationButtons by prefs.showNavigationButtons().collectAsState()
-    val eInkMode by prefs.eInkMode().collectAsState()
-    val paginatedScrolling by prefs.paginatedScrolling().collectAsState()
     val paginatedScrollStepSize by prefs.paginatedScrollStepSize().collectAsState()
     val scrollBehavior by prefs.scrollBehavior().collectAsState()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryPopupWebViewWarmup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryPopupWebViewWarmup.kt
@@ -8,7 +8,6 @@ import android.os.Looper
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import eu.kanade.domain.ui.UiPreferences
 import uy.kohesive.injekt.Injekt
@@ -90,23 +89,31 @@ internal object DictionaryPopupWebViewWarmup {
         val uiPreferences = Injekt.get<UiPreferences>()
         val themeMode = dictionaryPreferences.themeMode().get()
         val customColor = dictionaryPreferences.customColor().get()
-        val seedColor = if (customColor == 0) uiPreferences.colorTheme().get() else customColor
-        val isAmoled = themeMode == "pure_black"
-        val isDark = when (themeMode) {
-            "dark", "pure_black" -> true
-            "light" -> false
-            else -> if (customColor != 0) Color(seedColor).luminance() < 0.5f else context.isSystemDark()
+        val eInkMode = dictionaryPreferences.eInkMode().get()
+        val resolved = resolveDictionaryTheme(
+            themeMode = themeMode,
+            customColor = customColor,
+            eInkMode = eInkMode,
+            forceDefaultTheme = false,
+            systemIsDark = context.isSystemDark(),
+            appThemeMode = uiPreferences.themeMode().get(),
+            appAmoled = uiPreferences.themeDarkAmoled().get(),
+            appColorTheme = uiPreferences.colorTheme().get(),
+        )
+        val colorScheme = if (resolved.useAppTheme) {
+            getAppThemeColorScheme(context, resolved.isDark, resolved.isAmoled)
+        } else {
+            getDictionaryColorScheme(resolved.isDark, resolved.isAmoled, resolved.seedColor)
         }
-        val colorScheme = getDictionaryColorScheme(isDark, isAmoled, seedColor)
-        val backgroundColor = if (isAmoled && isDark) Color.Black else colorScheme.surface
+        val backgroundColor = if (resolved.isAmoled && resolved.isDark) Color.Black else colorScheme.surface
         val bootstrapHtml = getDictionaryBootstrapHtml(
             context = context,
             colorScheme = colorScheme,
-            isDark = isDark,
-            isAmoled = isAmoled,
-            seedColor = seedColor,
+            isDark = resolved.isDark,
+            isAmoled = resolved.isAmoled,
+            seedColor = resolved.seedColor,
             fontFamily = dictionaryPreferences.fontFamily().get(),
-            eInkMode = dictionaryPreferences.eInkMode().get(),
+            eInkMode = eInkMode,
             paginatedScrolling = dictionaryPreferences.paginatedScrolling().get(),
             paginatedScrollStepSize = dictionaryPreferences.paginatedScrollStepSize().get(),
             languageCode = languageCode,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -702,7 +702,7 @@ data object DictionaryTab : Tab {
                         if (activeTabIndex > 0) activeTabIndex--
                     },
                     groupPitches = groupPitches,
-                    forceDefaultTheme = true,
+                    forceDefaultTheme = false,
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
@@ -51,9 +50,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.text.style.TextOverflow
-import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.domain.ui.UiPreferences
-import eu.kanade.presentation.theme.colorscheme.CustomColorScheme
 import chimahon.DictionaryRepository
 import chimahon.KanjiEntry
 import chimahon.KanjiResult
@@ -71,6 +68,7 @@ import eu.kanade.tachiyomi.ui.dictionary.buildKanjiEntryJson
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryEntryWebView
 import eu.kanade.tachiyomi.ui.dictionary.DictionaryPreferences
 import eu.kanade.tachiyomi.ui.dictionary.getDictionaryColorScheme
+import eu.kanade.tachiyomi.ui.dictionary.resolveDictionaryTheme
 import eu.kanade.tachiyomi.ui.dictionary.TabInfo
 import eu.kanade.tachiyomi.ui.dictionary.getDictionaryPaths
 import eu.kanade.tachiyomi.ui.dictionary.orderLookupResultsForDisplay
@@ -261,17 +259,38 @@ fun OcrLookupPopup(
     val customColor by dictionaryPreferences.customColor().collectAsState()
 
     val uiPreferences = remember { Injekt.get<UiPreferences>() }
-    val seedColor = if (customColor == 0) uiPreferences.colorTheme().get() else customColor
-    val isAmoled = themeMode == "pure_black"
-    val isDark = remember(seedColor, customColor, systemIsDark, themeMode) {
-        when (themeMode) {
-            "dark", "pure_black" -> true
-            "light" -> false
-            else -> if (customColor != 0) Color(seedColor).luminance() < 0.5f else systemIsDark
-        }
+    val appAmoled by uiPreferences.themeDarkAmoled().collectAsState()
+    val appThemeMode by uiPreferences.themeMode().collectAsState()
+    val appColorTheme by uiPreferences.colorTheme().collectAsState()
+    val resolvedTheme = remember(
+        themeMode,
+        customColor,
+        eInkMode,
+        systemIsDark,
+        appThemeMode,
+        appAmoled,
+        appColorTheme,
+    ) {
+        resolveDictionaryTheme(
+            themeMode = themeMode,
+            customColor = customColor,
+            eInkMode = eInkMode,
+            forceDefaultTheme = false,
+            systemIsDark = systemIsDark,
+            appThemeMode = appThemeMode,
+            appAmoled = appAmoled,
+            appColorTheme = appColorTheme,
+        )
     }
-    val colorScheme = remember(isDark, isAmoled, seedColor) {
-        getDictionaryColorScheme(isDark, isAmoled, seedColor)
+    val isDark = resolvedTheme.isDark
+    val isAmoled = resolvedTheme.isAmoled
+    val seedColor = resolvedTheme.seedColor
+    val colorScheme = if (resolvedTheme.useAppTheme) {
+        MaterialTheme.colorScheme
+    } else {
+        remember(isDark, isAmoled, seedColor) {
+            getDictionaryColorScheme(isDark, isAmoled, seedColor)
+        }
     }
     val BgColor = remember(isDark, isAmoled, seedColor, colorScheme) {
         if (isAmoled && isDark) Color.Black else colorScheme.surface
@@ -1172,6 +1191,7 @@ fun OcrLookupPopup(
                     // Consume taps on the popup itself to prevent them from falling through to the reader
                 },
             shape = RoundedCornerShape(if (eInkMode) 0.dp else 8.dp),
+            border = if (eInkMode) BorderStroke(1.dp, if (isDark) Color.White else Color.Black) else null,
             color = BgColor,
             tonalElevation = 0.dp,
             shadowElevation = if (eInkMode) 0.dp else 6.dp,


### PR DESCRIPTION
Adds an App dynamic theme option for dictionary popups, a Reset button to Palette Personalizer, and fixes E-Ink outer borders on lookup popups. (Note: commit separation is not 100% ideal due to iterative refactoring).