### PR TITLE
fix(anki): return to Chimahon after opening a card

### DIFF
--- a/chimahon/src/main/java/chimahon/anki/AnkiDroidBridge.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiDroidBridge.kt
@@ -306,9 +306,6 @@ class AnkiDroidBridge(private val context: Context) : AnkiCardBridge {
             val uri = Uri.parse("anki://x-callback-url/browser?search=${Uri.encode(query)}")
             val intent = Intent(Intent.ACTION_VIEW, uri).apply {
                 setPackage("com.ichi2.anki")
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                    Intent.FLAG_ACTIVITY_TASK_ON_HOME
             }
             context.startActivity(intent)
         } catch (e: Exception) {

--- a/chimahon/src/test/kotlin/chimahon/anki/AnkiDroidBridgeTest.kt
+++ b/chimahon/src/test/kotlin/chimahon/anki/AnkiDroidBridgeTest.kt
@@ -1,0 +1,41 @@
+package chimahon.anki
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AnkiDroidBridgeTest {
+
+    @Test
+    fun `opening Anki browser keeps the caller task as the Back destination`() {
+        val context = mockk<Context>()
+        val uri = mockk<Uri>()
+        var launchFlags = 0
+
+        mockkStatic(Uri::class)
+        every { Uri.encode("nid:42") } returns "nid%3A42"
+        every { Uri.parse("anki://x-callback-url/browser?search=nid%3A42") } returns uri
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setPackage("com.ichi2.anki") } answers { self as Intent }
+        every { anyConstructed<Intent>().flags = any() } answers {
+            launchFlags = firstArg()
+        }
+        every { context.startActivity(any()) } just runs
+
+        AnkiDroidBridge(context).guiBrowse("nid:42")
+
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertEquals(0, launchFlags and Intent.FLAG_ACTIVITY_NEW_TASK)
+        assertEquals(0, launchFlags and Intent.FLAG_ACTIVITY_TASK_ON_HOME)
+    }
+}


### PR DESCRIPTION
## Problem

Opening an existing Anki card from Chimahon launched AnkiDroid in a separate task configured to return to the device Home screen. Pressing Back therefore did not return to Chimahon.

## Result

Pressing Back after opening an Anki card returns to Chimahon instead of the device Home screen.

## Testing

**Verification Location:** Chimahon word lookup popup > Open in Anki

**Verification Steps & Expected Results:**

1. Open an existing Anki card from a lookup popup.
2. Press Android Back in AnkiDroid.
3. Confirm the device returns to Chimahon, not Home.
