### PR TITLE
fix(history): resume most recently viewed media

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/AnimeHistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/AnimeHistoryScreenModel.kt
@@ -109,6 +109,14 @@ class AnimeHistoryScreenModel(
         return withIOContext { getNextEpisodes.await(onlyUnseen = false).firstOrNull() }
     }
 
+    suspend fun getNextEpisode(animeId: Long, episodeId: Long): Episode? {
+        return withIOContext { getNextEpisodes.await(animeId, episodeId, onlyUnseen = false).firstOrNull() }
+    }
+
+    suspend fun getLastHistory(): AnimeHistoryWithRelations? {
+        return withIOContext { getHistory.awaitLast() }
+    }
+
     fun getNextEpisodeForAnime(animeId: Long, episodeId: Long) {
         screenModelScope.launchIO {
             sendNextEpisodeEvent(getNextEpisodes.await(animeId, episodeId, onlyUnseen = false))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -143,6 +143,14 @@ class HistoryScreenModel(
         return withIOContext { getNextChapters.await(onlyUnread = false).firstOrNull() }
     }
 
+    suspend fun getNextChapter(mangaId: Long, chapterId: Long): Chapter? {
+        return withIOContext { getNextChapters.await(mangaId, chapterId, onlyUnread = false).firstOrNull() }
+    }
+
+    suspend fun getLastHistory(): HistoryWithRelations? {
+        return withIOContext { getHistory.awaitLast() }
+    }
+
     fun getNextChapterForManga(mangaId: Long, chapterId: Long) {
         screenModelScope.launchIO {
             sendNextChapterEvent(getNextChapters.await(mangaId, chapterId, onlyUnread = false))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -95,8 +95,7 @@ data object HistoryTab : Tab {
 
     private val snackbarHostState = SnackbarHostState()
 
-    private val resumeLastChapterReadEvent = Channel<Unit>()
-    private val resumeLastEpisodeSeenEvent = Channel<Unit>()
+    private val resumeLastMediaEvent = Channel<Unit>()
 
     override val options: TabOptions
         @Composable
@@ -111,7 +110,7 @@ data object HistoryTab : Tab {
         }
 
     override suspend fun onReselect(navigator: Navigator) {
-        resumeLastChapterReadEvent.send(Unit)
+        resumeLastMediaEvent.send(Unit)
     }
 
     @Composable
@@ -414,14 +413,22 @@ data object HistoryTab : Tab {
         }
 
         LaunchedEffect(Unit) {
-            resumeLastChapterReadEvent.receiveAsFlow().collectLatest {
-                openChapter(context, screenModel.getNextChapter())
-            }
-        }
+            resumeLastMediaEvent.receiveAsFlow().collectLatest {
+                val mangaHistory = screenModel.getLastHistory()
+                val animeHistory = animeScreenModel.getLastHistory()
+                val mangaLastReadAt = mangaHistory?.readAt?.time ?: Long.MIN_VALUE
+                val animeLastWatchedAt = animeHistory?.watchedAt?.time ?: Long.MIN_VALUE
 
-        LaunchedEffect(Unit) {
-            resumeLastEpisodeSeenEvent.receiveAsFlow().collectLatest {
-                openEpisode(context, animeScreenModel.getNextEpisode())
+                when {
+                    mangaHistory == null && animeHistory == null ->
+                        snackbarHostState.showSnackbar(context.stringResource(MR.strings.no_next_chapter))
+                    animeLastWatchedAt > mangaLastReadAt -> animeHistory?.let { history ->
+                        openEpisode(context, animeScreenModel.getNextEpisode(history.animeId, history.episodeId))
+                    }
+                    else -> mangaHistory?.let { history ->
+                        openChapter(context, screenModel.getNextChapter(history.mangaId, history.chapterId))
+                    }
+                }
             }
         }
     }

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/GetAnimeHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/GetAnimeHistory.kt
@@ -13,6 +13,10 @@ class GetAnimeHistory(
         return repository.getHistoryByAnimeId(animeId)
     }
 
+    suspend fun awaitLast(): AnimeHistoryWithRelations? {
+        return repository.getLastAnimeHistory()
+    }
+
     fun subscribe(query: String): Flow<List<AnimeHistoryWithRelations>> {
         return repository.getAnimeHistory(query)
     }


### PR DESCRIPTION
## Problem

Reselecting the History tab always resumed manga history, even when an anime episode had been viewed more recently.

## Result

History reselect now compares the latest manga and anime history timestamps, then resumes the newer item in Reader or Player. The selected history record is retained when resolving its resume chapter or episode.

## Testing

- **Verification Location:** History tab in the bottom navigation.
- **Verification Steps & Expected Results:**
  1 Read a manga, then watch an anime episode; reselect History. The anime episode opens in Player.
  2 Watch an anime episode, then read a manga; reselect History. The manga chapter opens in Reader.
  3 Relaunch the app after either sequence and reselect History. The newer of the two histories resumes.
