### PR TITLE
fix(main): retain active tab after player rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
             android:name=".ui.main.MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
             android:theme="@style/Theme.Tachiyomi.SplashScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Problem

Opening an anime episode rotates the player to landscape. Returning to portrait recreated `MainActivity`, so Home reset to its start tab, Library, instead of returning to History.

## Changes

- Handle orientation and screen-size configuration changes in `MainActivity`.

## Result

Closing a player opened from History keeps the active History tab instead of returning to Library.

