### PR TITLE
feat(anki): preload screenshot and sentence audio during dictionary lookup popup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFprobeKit
@@ -35,6 +36,11 @@ import java.io.File
 import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
+
+internal data class VideoOcrAnimatedSceneRequest(
+    val startSeconds: Double,
+    val endSeconds: Double,
+)
 
 /**
  * Captures media from the player for Anki mining: still OCR frames, sentence audio slices,
@@ -93,6 +99,15 @@ internal class PlayerMediaCaptureService(
         return createSentenceAudioMediaRequest(center - padding, center + padding)
     }
 
+    fun createVideoOcrAnimatedSceneRequest(): VideoOcrAnimatedSceneRequest {
+        val center = getTimeSeconds()
+        val padding = getOcrPaddingSeconds()
+        return VideoOcrAnimatedSceneRequest(
+            startSeconds = center - padding,
+            endSeconds = center + padding,
+        )
+    }
+
     private fun createSentenceAudioMediaRequest(startSeconds: Double?, endSeconds: Double?): AnkiMediaRequest {
         val video = getVideo()
         val mpv = readMpvSnapshot()
@@ -131,7 +146,7 @@ internal class PlayerMediaCaptureService(
 
         val video = getVideo() ?: return null
         val yuvFile = File(context.cacheDir, "chimahon_scene_${System.currentTimeMillis()}.yuv")
-        return runCatching {
+        return try {
             withIOContext {
                 yuvFile.delete()
                 val rawInput = MPVLib.getPropertyString("path")
@@ -180,8 +195,7 @@ internal class PlayerMediaCaptureService(
                 )
                     .filter { it.isNotBlank() }
                     .joinToString(" ")
-                val session = FFmpegSession.create(FFmpegKitConfig.parseArguments(command))
-                FFmpegKitConfig.ffmpegExecute(session)
+                val session = executeFfmpegCancellable(FFmpegKitConfig.parseArguments(command))
                 if (!ReturnCode.isSuccess(session.returnCode) || !yuvFile.exists() || yuvFile.length() < frameSize) {
                     session.failStackTrace?.let { logcat(LogPriority.WARN) { it } }
                     return@withIOContext null
@@ -202,21 +216,32 @@ internal class PlayerMediaCaptureService(
                     AvifEncoder.SPEED_FASTEST,
                 )
             }
-        }.onFailure {
-            logcat(LogPriority.WARN, it) { "Failed to capture animated scene" }
-        }.getOrNull().also {
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to capture animated scene" }
+            null
+        } finally {
             yuvFile.delete()
         }
     }
 
-    suspend fun captureVideoOcrAnimatedForAnki(): ByteArray? {
-        val centerSeconds = getTimeSeconds()
-        val paddingSeconds = getOcrPaddingSeconds()
+    suspend fun captureVideoOcrAnimatedForAnki(request: VideoOcrAnimatedSceneRequest): ByteArray? {
         return captureAnimatedVideoForAnki(
-            startSeconds = centerSeconds - paddingSeconds,
-            endSeconds = centerSeconds + paddingSeconds,
+            startSeconds = request.startSeconds,
+            endSeconds = request.endSeconds,
         )
     }
+
+    private suspend fun executeFfmpegCancellable(arguments: Array<String>): FFmpegSession =
+        suspendCancellableCoroutine { continuation ->
+            val session = FFmpegKit.executeWithArgumentsAsync(arguments) { completedSession ->
+                if (continuation.isActive) {
+                    continuation.resumeWith(Result.success(completedSession))
+                }
+            }
+            continuation.invokeOnCancellation { session.cancel() }
+        }
 
     private suspend fun probeVideoDimensions(input: String, headerOptions: String): Pair<Int, Int>? =
         suspendCancellableCoroutine<FFprobeSession?> { continuation ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureService.kt
@@ -40,6 +40,14 @@ import kotlin.math.min
 internal data class VideoOcrAnimatedSceneRequest(
     val startSeconds: Double,
     val endSeconds: Double,
+    val input: AnimatedSceneInputSnapshot?,
+)
+
+/** Input needed to recreate an animated scene after the dictionary popup has opened. */
+internal data class AnimatedSceneInputSnapshot(
+    val source: String,
+    val videoUrl: String,
+    val headers: List<Pair<String, String>>,
 )
 
 /**
@@ -54,6 +62,7 @@ internal class PlayerMediaCaptureService(
     private val getTimeSeconds: () -> Double,
     private val getOcrPaddingSeconds: () -> Double,
     private val readMpvSnapshot: () -> SentenceAudioMpvSnapshot,
+    private val readMpvVideoPath: () -> String? = { MPVLib.getPropertyString("path") },
     private val prepareSentenceAudioOverride: (suspend (SentenceAudioCaptureRequest) -> AnkiSentenceAudioPreparation)? = null,
 ) {
 
@@ -105,6 +114,20 @@ internal class PlayerMediaCaptureService(
         return VideoOcrAnimatedSceneRequest(
             startSeconds = center - padding,
             endSeconds = center + padding,
+            input = snapshotAnimatedSceneInput(),
+        )
+    }
+
+    private fun snapshotAnimatedSceneInput(): AnimatedSceneInputSnapshot? {
+        val video = getVideo() ?: return null
+        val source = readMpvVideoPath()
+            ?.takeIf { it.isNotBlank() }
+            ?: video.videoUrl
+        val animeSource = getSource() as? AnimeHttpSource
+        return AnimatedSceneInputSnapshot(
+            source = source,
+            videoUrl = video.videoUrl,
+            headers = (video.headers ?: animeSource?.headers)?.toList().orEmpty(),
         )
     }
 
@@ -140,42 +163,50 @@ internal class PlayerMediaCaptureService(
      * using the bundled libavif encoder. Returns null on failure so callers can fall back to a still.
      */
     suspend fun captureAnimatedVideoForAnki(startSeconds: Double?, endSeconds: Double?): ByteArray? {
+        return captureAnimatedVideoForAnki(
+            input = snapshotAnimatedSceneInput(),
+            startSeconds = startSeconds,
+            endSeconds = endSeconds,
+        )
+    }
+
+    private suspend fun captureAnimatedVideoForAnki(
+        input: AnimatedSceneInputSnapshot?,
+        startSeconds: Double?,
+        endSeconds: Double?,
+    ): ByteArray? {
         val start = startSeconds ?: return null
         val end = endSeconds ?: return null
         if (end <= start) return null
 
-        val video = getVideo() ?: return null
+        val inputSnapshot = input ?: return null
         val yuvFile = File(context.cacheDir, "chimahon_scene_${System.currentTimeMillis()}.yuv")
         return try {
             withIOContext {
                 yuvFile.delete()
-                val rawInput = MPVLib.getPropertyString("path")
-                    ?.takeIf { it.isNotBlank() }
-                    ?: video.videoUrl
-                val input = when {
-                    video.videoUrl.startsWith("content://") -> Uri.parse(video.videoUrl).toFFmpegReadString(context)
+                val rawInput = inputSnapshot.source
+                val ffmpegInput = when {
+                    inputSnapshot.videoUrl.startsWith("content://") -> Uri.parse(inputSnapshot.videoUrl).toFFmpegReadString(context)
                     rawInput.startsWith("file://") -> Uri.parse(rawInput).path ?: rawInput
                     else -> rawInput
                 }.replace("\"", "\\\"")
 
-                val source = getSource() as? AnimeHttpSource
-                val headers = video.headers ?: source?.headers
-                val headerOptions = if (rawInput.startsWith("http") && headers != null) {
-                    headers.joinToString("", "-headers '", "'") {
+                val headerOptions = if (rawInput.startsWith("http") && inputSnapshot.headers.isNotEmpty()) {
+                    inputSnapshot.headers.joinToString("", "-headers '", "'") {
                         "${it.first}: ${it.second.replace("'", "'\\''")}\r\n"
                     }
                 } else {
                     ""
                 }
                 val duration = (end - start).coerceIn(0.25, 10.0)
-                val probe = probeVideoDimensions(input, headerOptions)
+                val probe = probeVideoDimensions(ffmpegInput, headerOptions)
                 val (outWidth, outHeight) = probe ?: return@withIOContext null
                 val frameSize = outWidth * outHeight * 3 / 2
                 val command = listOf(
                     headerOptions,
                     "-ss ${start.coerceAtLeast(0.0).formatSeconds()}",
                     "-t ${duration.formatSeconds()}",
-                    "-i \"$input\"",
+                    "-i \"$ffmpegInput\"",
                     "-an",
                     "-sn",
                     "-dn",
@@ -228,6 +259,7 @@ internal class PlayerMediaCaptureService(
 
     suspend fun captureVideoOcrAnimatedForAnki(request: VideoOcrAnimatedSceneRequest): ByteArray? {
         return captureAnimatedVideoForAnki(
+            input = request.input,
             startSeconds = request.startSeconds,
             endSeconds = request.endSeconds,
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -3136,10 +3136,13 @@ class PlayerViewModel @JvmOverloads constructor(
 
     internal fun createVideoOcrAudioMediaRequest() = mediaCapture.createVideoOcrAudioMediaRequest()
 
+    internal fun createVideoOcrAnimatedSceneRequest() = mediaCapture.createVideoOcrAnimatedSceneRequest()
+
     suspend fun captureAnimatedVideoForAnki(startSeconds: Double?, endSeconds: Double?): ByteArray? =
         mediaCapture.captureAnimatedVideoForAnki(startSeconds, endSeconds)
 
-    suspend fun captureVideoOcrAnimatedForAnki(): ByteArray? = mediaCapture.captureVideoOcrAnimatedForAnki()
+    internal suspend fun captureVideoOcrAnimatedForAnki(request: VideoOcrAnimatedSceneRequest): ByteArray? =
+        mediaCapture.captureVideoOcrAnimatedForAnki(request)
 
     /**
      * Saves the screenshot on the pictures directory and notifies the UI of the result.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerVideoOcrOverlay.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerVideoOcrOverlay.kt
@@ -216,6 +216,9 @@ internal fun PlayerVideoOcrOverlay(
             val mediaRequest = remember(selected, lookupNonce) {
                 viewModel.createVideoOcrAudioMediaRequest()
             }
+            val animatedSceneRequest = remember(selected, lookupNonce) {
+                viewModel.createVideoOcrAnimatedSceneRequest()
+            }
             key(selected.lookupString, lookupNonce) {
                 OcrLookupPopup(
                     visible = true,
@@ -236,7 +239,7 @@ internal fun PlayerVideoOcrOverlay(
                         mangaTitle = anime?.title.orEmpty(),
                         chapterName = episode?.name.orEmpty(),
                     ),
-                    onRequestAnimatedScene = { viewModel.captureVideoOcrAnimatedForAnki() },
+                    onRequestAnimatedScene = { viewModel.captureVideoOcrAnimatedForAnki(animatedSceneRequest) },
                     mediaRequest = mediaRequest,
                     onAnkiMediaWarnings = context::showPlayerAnkiMediaWarnings,
                     usePopup = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
@@ -35,25 +35,57 @@ internal data class PendingPopupAnkiMediaPreload(
     val result: Deferred<PopupPreparedAnkiMedia?>,
 )
 
-internal fun shouldPreloadPopupAnkiMedia(
+internal data class PopupAnkiMediaPreloadPlan(
+    val prepareScreenshot: Boolean,
+    val prepareSentenceAudio: Boolean,
+) {
+    val shouldStart: Boolean
+        get() = prepareScreenshot || prepareSentenceAudio
+}
+
+internal fun planPopupAnkiMediaPreload(
     popupVisible: Boolean,
     duplicateCheckCompleted: Boolean,
     hasNewExpression: Boolean,
     duplicateCheckEnabled: Boolean,
     duplicateAction: String,
     ankiEnabled: Boolean,
-    hasMappedMedia: Boolean,
+    screenshotFieldMapped: Boolean,
+    sentenceAudioFieldMapped: Boolean,
     cropMode: String,
-): Boolean =
-    popupVisible &&
-        duplicateCheckCompleted &&
-        ankiEnabled &&
-        hasMappedMedia &&
-        cropMode != "crop" &&
-        (hasNewExpression || !duplicateCheckEnabled || duplicateAction == "overwrite")
+): PopupAnkiMediaPreloadPlan {
+    val mayAddCard =
+        popupVisible &&
+            duplicateCheckCompleted &&
+            ankiEnabled &&
+            (hasNewExpression || !duplicateCheckEnabled || duplicateAction == "overwrite")
+    if (!mayAddCard) return PopupAnkiMediaPreloadPlan(false, false)
+
+    return PopupAnkiMediaPreloadPlan(
+        prepareScreenshot = screenshotFieldMapped && cropMode != "crop" && cropMode != "no_screenshot",
+        prepareSentenceAudio = sentenceAudioFieldMapped,
+    )
+}
 
 internal suspend fun cancelPopupAnkiMediaPreload(preload: PendingPopupAnkiMediaPreload?) {
     preload?.result?.cancelAndJoin()
+}
+
+internal suspend fun takePopupAnkiMediaForAdd(
+    cachedMedia: PopupPreparedAnkiMedia?,
+    pendingPreload: PendingPopupAnkiMediaPreload?,
+): PopupPreparedAnkiMedia? {
+    if (cachedMedia != null) return cachedMedia
+    val pending = pendingPreload ?: return null
+    if (!pending.nativeCaptureStarted.isCompleted) {
+        pending.result.cancelAndJoin()
+        return null
+    }
+    return try {
+        pending.result.await()
+    } catch (_: kotlinx.coroutines.CancellationException) {
+        null
+    }
 }
 
 internal fun AnkiMediaRequest.withSerializedSentenceAudioPreparation(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
@@ -5,6 +5,7 @@ import chimahon.anki.AnkiSentenceAudioPreparation
 import chimahon.anki.LazyAnkiSentenceAudioProvider
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -33,6 +34,27 @@ internal data class PendingPopupAnkiMediaPreload(
     val nativeCaptureStarted: CompletableDeferred<Unit>,
     val result: Deferred<PopupPreparedAnkiMedia?>,
 )
+
+internal fun shouldPreloadPopupAnkiMedia(
+    popupVisible: Boolean,
+    duplicateCheckCompleted: Boolean,
+    hasNewExpression: Boolean,
+    duplicateCheckEnabled: Boolean,
+    duplicateAction: String,
+    ankiEnabled: Boolean,
+    hasMappedMedia: Boolean,
+    cropMode: String,
+): Boolean =
+    popupVisible &&
+        duplicateCheckCompleted &&
+        ankiEnabled &&
+        hasMappedMedia &&
+        cropMode != "crop" &&
+        (hasNewExpression || !duplicateCheckEnabled || duplicateAction == "overwrite")
+
+internal suspend fun cancelPopupAnkiMediaPreload(preload: PendingPopupAnkiMediaPreload?) {
+    preload?.result?.cancelAndJoin()
+}
 
 internal fun AnkiMediaRequest.withSerializedSentenceAudioPreparation(
     gate: SerializedAnkiMediaPreloadGate,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreload.kt
@@ -1,0 +1,45 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import chimahon.anki.AnkiMediaRequest
+import chimahon.anki.AnkiSentenceAudioPreparation
+import chimahon.anki.LazyAnkiSentenceAudioProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal const val POPUP_ANKI_MEDIA_PRELOAD_DELAY_MS = 500L
+
+/**
+ * Serializes media preparation across replacement dictionary popups. A new popup can wait for
+ * cancellation cleanup of the previous native capture before starting its own capture.
+ */
+internal class SerializedAnkiMediaPreloadGate(
+    private val mutex: Mutex = Mutex(),
+) {
+    suspend fun <T> run(block: suspend () -> T): T = mutex.withLock { block() }
+}
+
+internal val ankiMediaPreloadGate = SerializedAnkiMediaPreloadGate()
+
+internal data class PopupPreparedAnkiMedia(
+    val frameId: String,
+    val screenshotBytes: ByteArray?,
+    val sentenceAudio: AnkiSentenceAudioPreparation?,
+)
+
+internal data class PendingPopupAnkiMediaPreload(
+    val frameId: String,
+    val nativeCaptureStarted: CompletableDeferred<Unit>,
+    val result: Deferred<PopupPreparedAnkiMedia?>,
+)
+
+internal fun AnkiMediaRequest.withSerializedSentenceAudioPreparation(
+    gate: SerializedAnkiMediaPreloadGate,
+): AnkiMediaRequest = copy(
+    sentenceAudioProvider = sentenceAudioProvider?.let { provider ->
+        LazyAnkiSentenceAudioProvider {
+            gate.run { provider.prepare() }
+        }
+    },
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -94,6 +94,8 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import logcat.logcat
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.util.collectAsState
@@ -408,10 +410,9 @@ fun OcrLookupPopup(
                             )
                             lookupStackState = lookupStackState.copy(stack = stack)
                         }
-                        Log.i(
-                            "DictionaryPopup",
-                            "anki_check_ms=${android.os.SystemClock.elapsedRealtime() - phaseStart} expressions=${uniqueExpressions.size}",
-                        )
+                        logcat(LogPriority.DEBUG, "DictionaryPopup") {
+                            "anki_check_ms=${android.os.SystemClock.elapsedRealtime() - phaseStart} expressions=${uniqueExpressions.size}"
+                        }
                     }
                 }
             }
@@ -566,11 +567,19 @@ fun OcrLookupPopup(
     val hasNewExpression = currentFrame?.results?.any {
         it.term.expression !in currentFrame.existingExpressions
     } == true
-    val shouldPreloadAnkiMedia = ankiEnabled &&
-        (screenshotFieldMapped || sentenceAudioFieldMapped) &&
-        cropMode != "crop"
+    val shouldPreloadAnkiMedia = shouldPreloadPopupAnkiMedia(
+        popupVisible = visible,
+        duplicateCheckCompleted = duplicateCheckCompleted,
+        hasNewExpression = hasNewExpression,
+        duplicateCheckEnabled = ankiDupCheck,
+        duplicateAction = ankiDupAction,
+        ankiEnabled = ankiEnabled,
+        hasMappedMedia = screenshotFieldMapped || sentenceAudioFieldMapped,
+        cropMode = cropMode,
+    )
 
     LaunchedEffect(
+        visible,
         preloadFrameId,
         duplicateCheckCompleted,
         hasNewExpression,
@@ -579,31 +588,32 @@ fun OcrLookupPopup(
     ) {
         val previousPreload = pendingAnkiMediaPreload
         if (previousPreload != null) {
-            previousPreload.result.cancelAndJoin()
+            cancelPopupAnkiMediaPreload(previousPreload)
             if (pendingAnkiMediaPreload === previousPreload) {
                 pendingAnkiMediaPreload = null
             }
         }
         preloadedAnkiMedia = null
         val frameId = preloadFrameId ?: return@LaunchedEffect
-        if (!duplicateCheckCompleted || !hasNewExpression || !shouldPreloadAnkiMedia) {
+        if (!shouldPreloadAnkiMedia) {
             return@LaunchedEffect
         }
 
         val operationId = "preload-$frameId"
         val startedAtMillis = SystemClock.elapsedRealtime()
-        Log.i("AnkiCardCreator", "anki_media_preload operation=$operationId stage=scheduled elapsed_ms=0")
+        logcat(LogPriority.DEBUG, "AnkiCardCreator") {
+            "anki_media_preload operation=$operationId stage=scheduled elapsed_ms=0"
+        }
         val nativeCaptureStarted = CompletableDeferred<Unit>()
         val preloadResult = scope.async {
             try {
                 delay(POPUP_ANKI_MEDIA_PRELOAD_DELAY_MS)
                 ankiMediaPreloadGate.run {
                     nativeCaptureStarted.complete(Unit)
-                    Log.i(
-                        "AnkiCardCreator",
+                    logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_media_preload operation=$operationId stage=started " +
-                            "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}",
-                    )
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}"
+                    }
                     val screenshotBytes = if (screenshotFieldMapped && cropMode != "no_screenshot") {
                         if (
                             cropMode == chimahon.anki.AnkiScreenshotMode.ANIMATED_SCENE.storageValue &&
@@ -618,12 +628,11 @@ fun OcrLookupPopup(
                     } else {
                         null
                     }
-                    Log.i(
-                        "AnkiCardCreator",
+                    logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_media_preload operation=$operationId stage=screenshot_prepared " +
                             "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis} " +
-                            "media_bytes=${screenshotBytes?.size ?: 0}",
-                    )
+                            "media_bytes=${screenshotBytes?.size ?: 0}"
+                    }
                     val sentenceAudio = if (sentenceAudioFieldMapped) {
                         val preparation = if (latestMediaRequest != null) {
                             prepareSentenceAudioForMarker(
@@ -642,13 +651,12 @@ fun OcrLookupPopup(
                     } else {
                         null
                     }
-                    Log.i(
-                        "AnkiCardCreator",
+                    logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_media_preload operation=$operationId stage=completed " +
                             "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis} " +
                             "screenshot_bytes=${screenshotBytes?.size ?: 0} " +
-                            "sentence_audio_bytes=${(sentenceAudio as? AnkiSentenceAudioPreparation.Ready)?.source?.data?.size ?: 0}",
-                    )
+                            "sentence_audio_bytes=${(sentenceAudio as? AnkiSentenceAudioPreparation.Ready)?.source?.data?.size ?: 0}"
+                    }
                     PopupPreparedAnkiMedia(
                         frameId = frameId,
                         screenshotBytes = screenshotBytes,
@@ -656,11 +664,10 @@ fun OcrLookupPopup(
                     )
                 }
             } catch (e: CancellationException) {
-                Log.i(
-                    "AnkiCardCreator",
+                logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                     "anki_media_preload operation=$operationId stage=cancelled " +
-                        "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}",
-                )
+                        "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}"
+                }
                 throw e
             } catch (e: Exception) {
                 Log.w("AnkiCardCreator", "anki_media_preload operation=$operationId stage=failed", e)
@@ -806,7 +813,9 @@ fun OcrLookupPopup(
             miningScope.launch {
                 val timingOperationId = "add-${UUID.randomUUID()}"
                 val timingStartedAtMillis = SystemClock.elapsedRealtime()
-                Log.i("AnkiCardCreator", "anki_add operation=$timingOperationId stage=started elapsed_ms=0")
+                logcat(LogPriority.DEBUG, "AnkiCardCreator") {
+                    "anki_add operation=$timingOperationId stage=started elapsed_ms=0"
+                }
                 var cachedMedia = preloadedAnkiMedia?.takeIf { it.frameId == miningFrame?.id }
                 val pendingPreload = pendingAnkiMediaPreload?.takeIf { it.frameId == miningFrame?.id }
                 if (cachedMedia == null && pendingPreload != null) {
@@ -824,14 +833,13 @@ fun OcrLookupPopup(
                     }
                 }
                 val preparedAddMedia = ankiMediaPreloadGate.run {
-                    Log.i(
-                        "AnkiCardCreator",
+                    logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_add operation=$timingOperationId stage=popup_media_cache " +
                             "elapsed_ms=${SystemClock.elapsedRealtime() - timingStartedAtMillis} " +
                             "cache_hit=${cachedMedia != null} " +
                             "screenshot_ready=${cachedMedia?.screenshotBytes != null} " +
-                            "sentence_audio_ready=${cachedMedia?.sentenceAudio != null}",
-                    )
+                            "sentence_audio_ready=${cachedMedia?.sentenceAudio != null}"
+                    }
                     val encoding = if (
                         cachedMedia?.screenshotBytes == null &&
                         screenshotFieldMapped &&
@@ -849,12 +857,11 @@ fun OcrLookupPopup(
                     } else {
                         encoding?.bytes
                     }
-                    Log.i(
-                        "AnkiCardCreator",
+                    logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_add operation=$timingOperationId stage=screenshot_prepared " +
                             "elapsed_ms=${SystemClock.elapsedRealtime() - timingStartedAtMillis} " +
-                            "media_bytes=${screenshotBytes?.size ?: 0}",
-                    )
+                            "media_bytes=${screenshotBytes?.size ?: 0}"
+                    }
                     val sentenceAudioBytes = if (sentenceAudioFieldMapped && mediaRequest == null) {
                         onRequestSentenceAudio?.invoke()
                     } else {
@@ -1563,6 +1570,7 @@ fun OcrLookupPopup(
             mediaInfo = mediaInfo,
             screenshot = screenshot,
             onRequestScreenshot = onRequestScreenshot,
+            onRequestAnimatedScene = onRequestAnimatedScene,
             onRequestSentenceAudio = onRequestSentenceAudio,
             mediaRequest = mediaRequest,
             onAnkiMediaWarnings = onAnkiMediaWarnings,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.reader.viewer
 
 import android.graphics.Bitmap
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import android.webkit.WebView
 import androidx.compose.foundation.BorderStroke
@@ -33,6 +34,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,6 +63,9 @@ import chimahon.anki.AnkiMediaRequest
 import chimahon.anki.AnkiMediaWarning
 import chimahon.anki.AnkiProfile
 import chimahon.anki.AnkiResult
+import chimahon.anki.AnkiSentenceAudioPreparation
+import chimahon.anki.AnkiSentenceAudioSource
+import chimahon.anki.prepareSentenceAudioForMarker
 import chimahon.ocr.effectiveSearchResolution
 import chimahon.ocr.nextWordBoundarySubstring
 import chimahon.util.ImageEncoder
@@ -85,6 +90,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tachiyomi.core.common.i18n.stringResource
@@ -109,6 +116,7 @@ private data class LookupFrame(
     val mediaDataUris: Map<String, String>,
     val existingExpressions: Set<String>,
     val existingCardIds: Map<String, Long> = emptyMap(),
+    val duplicateCheckCompleted: Boolean = false,
     val entryJsons: List<String>? = null,
 )
 
@@ -396,6 +404,7 @@ fun OcrLookupPopup(
                             stack[frameIndex] = stack[frameIndex].copy(
                                 existingExpressions = existingCardIds.keys,
                                 existingCardIds = existingCardIds,
+                                duplicateCheckCompleted = true,
                             )
                             lookupStackState = lookupStackState.copy(stack = stack)
                         }
@@ -546,6 +555,131 @@ fun OcrLookupPopup(
         }
     }
 
+    val latestScreenshotRequest by rememberUpdatedState(onRequestScreenshot)
+    val latestAnimatedSceneRequest by rememberUpdatedState(onRequestAnimatedScene)
+    val latestSentenceAudioRequest by rememberUpdatedState(onRequestSentenceAudio)
+    val latestMediaRequest by rememberUpdatedState(mediaRequest)
+    var preloadedAnkiMedia by remember { mutableStateOf<PopupPreparedAnkiMedia?>(null) }
+    var pendingAnkiMediaPreload by remember { mutableStateOf<PendingPopupAnkiMediaPreload?>(null) }
+    val preloadFrameId = currentFrame?.id
+    val duplicateCheckCompleted = currentFrame?.duplicateCheckCompleted == true
+    val hasNewExpression = currentFrame?.results?.any {
+        it.term.expression !in currentFrame.existingExpressions
+    } == true
+    val shouldPreloadAnkiMedia = ankiEnabled &&
+        (screenshotFieldMapped || sentenceAudioFieldMapped) &&
+        cropMode != "crop"
+
+    LaunchedEffect(
+        preloadFrameId,
+        duplicateCheckCompleted,
+        hasNewExpression,
+        shouldPreloadAnkiMedia,
+        cropMode,
+    ) {
+        val previousPreload = pendingAnkiMediaPreload
+        if (previousPreload != null) {
+            previousPreload.result.cancelAndJoin()
+            if (pendingAnkiMediaPreload === previousPreload) {
+                pendingAnkiMediaPreload = null
+            }
+        }
+        preloadedAnkiMedia = null
+        val frameId = preloadFrameId ?: return@LaunchedEffect
+        if (!duplicateCheckCompleted || !hasNewExpression || !shouldPreloadAnkiMedia) {
+            return@LaunchedEffect
+        }
+
+        val operationId = "preload-$frameId"
+        val startedAtMillis = SystemClock.elapsedRealtime()
+        Log.i("AnkiCardCreator", "anki_media_preload operation=$operationId stage=scheduled elapsed_ms=0")
+        val nativeCaptureStarted = CompletableDeferred<Unit>()
+        val preloadResult = scope.async {
+            try {
+                delay(POPUP_ANKI_MEDIA_PRELOAD_DELAY_MS)
+                ankiMediaPreloadGate.run {
+                    nativeCaptureStarted.complete(Unit)
+                    Log.i(
+                        "AnkiCardCreator",
+                        "anki_media_preload operation=$operationId stage=started " +
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}",
+                    )
+                    val screenshotBytes = if (screenshotFieldMapped && cropMode != "no_screenshot") {
+                        if (
+                            cropMode == chimahon.anki.AnkiScreenshotMode.ANIMATED_SCENE.storageValue &&
+                            latestAnimatedSceneRequest != null
+                        ) {
+                            latestAnimatedSceneRequest?.invoke()
+                        } else {
+                            latestScreenshotRequest?.invoke()?.let { bitmap ->
+                                withContext(Dispatchers.Default) { ImageEncoder.encode(bitmap).bytes }
+                            }
+                        }
+                    } else {
+                        null
+                    }
+                    Log.i(
+                        "AnkiCardCreator",
+                        "anki_media_preload operation=$operationId stage=screenshot_prepared " +
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis} " +
+                            "media_bytes=${screenshotBytes?.size ?: 0}",
+                    )
+                    val sentenceAudio = if (sentenceAudioFieldMapped) {
+                        val preparation = if (latestMediaRequest != null) {
+                            prepareSentenceAudioForMarker(
+                                hasSentenceAudioMarker = true,
+                                provider = latestMediaRequest?.sentenceAudioProvider,
+                                prepared = latestMediaRequest?.preparedSentenceAudio,
+                            )
+                        } else {
+                            latestSentenceAudioRequest?.invoke()?.let { bytes ->
+                                AnkiSentenceAudioPreparation.Ready(
+                                    AnkiSentenceAudioSource.fromBytes(bytes, "m4a"),
+                                )
+                            }
+                        }
+                        preparation
+                    } else {
+                        null
+                    }
+                    Log.i(
+                        "AnkiCardCreator",
+                        "anki_media_preload operation=$operationId stage=completed " +
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis} " +
+                            "screenshot_bytes=${screenshotBytes?.size ?: 0} " +
+                            "sentence_audio_bytes=${(sentenceAudio as? AnkiSentenceAudioPreparation.Ready)?.source?.data?.size ?: 0}",
+                    )
+                    PopupPreparedAnkiMedia(
+                        frameId = frameId,
+                        screenshotBytes = screenshotBytes,
+                        sentenceAudio = sentenceAudio,
+                    )
+                }
+            } catch (e: CancellationException) {
+                Log.i(
+                    "AnkiCardCreator",
+                    "anki_media_preload operation=$operationId stage=cancelled " +
+                        "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}",
+                )
+                throw e
+            } catch (e: Exception) {
+                Log.w("AnkiCardCreator", "anki_media_preload operation=$operationId stage=failed", e)
+                null
+            }
+        }
+        val pendingPreload = PendingPopupAnkiMediaPreload(
+            frameId = frameId,
+            nativeCaptureStarted = nativeCaptureStarted,
+            result = preloadResult,
+        )
+        pendingAnkiMediaPreload = pendingPreload
+        val prepared = preloadResult.await()
+        if (pendingAnkiMediaPreload === pendingPreload) {
+            preloadedAnkiMedia = prepared
+            pendingAnkiMediaPreload = null
+        }
+    }
+
     fun performAnkiLookup(
         index: Int,
         glossaryIndex: Int?,
@@ -670,23 +804,70 @@ fun OcrLookupPopup(
             }
         } else {
             miningScope.launch {
-                val encoding = if (screenshotFieldMapped && cropMode != "no_screenshot") {
-                    onRequestScreenshot?.invoke()?.let { ImageEncoder.encode(it) }
-                } else {
-                    null
+                val timingOperationId = "add-${UUID.randomUUID()}"
+                val timingStartedAtMillis = SystemClock.elapsedRealtime()
+                Log.i("AnkiCardCreator", "anki_add operation=$timingOperationId stage=started elapsed_ms=0")
+                var cachedMedia = preloadedAnkiMedia?.takeIf { it.frameId == miningFrame?.id }
+                val pendingPreload = pendingAnkiMediaPreload?.takeIf { it.frameId == miningFrame?.id }
+                if (cachedMedia == null && pendingPreload != null) {
+                    if (pendingPreload.nativeCaptureStarted.isCompleted) {
+                        cachedMedia = try {
+                            pendingPreload.result.await()
+                        } catch (_: CancellationException) {
+                            null
+                        }
+                    } else {
+                        pendingPreload.result.cancelAndJoin()
+                    }
+                    if (pendingAnkiMediaPreload === pendingPreload) {
+                        pendingAnkiMediaPreload = null
+                    }
                 }
-                val screenshotBytes = if (
-                    cropMode == chimahon.anki.AnkiScreenshotMode.ANIMATED_SCENE.storageValue &&
-                    onRequestAnimatedScene != null
-                ) {
-                    onRequestAnimatedScene.invoke()
-                } else {
-                    encoding?.bytes
+                val preparedAddMedia = ankiMediaPreloadGate.run {
+                    Log.i(
+                        "AnkiCardCreator",
+                        "anki_add operation=$timingOperationId stage=popup_media_cache " +
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - timingStartedAtMillis} " +
+                            "cache_hit=${cachedMedia != null} " +
+                            "screenshot_ready=${cachedMedia?.screenshotBytes != null} " +
+                            "sentence_audio_ready=${cachedMedia?.sentenceAudio != null}",
+                    )
+                    val encoding = if (
+                        cachedMedia?.screenshotBytes == null &&
+                        screenshotFieldMapped &&
+                        cropMode != "no_screenshot"
+                    ) {
+                        onRequestScreenshot?.invoke()?.let { ImageEncoder.encode(it) }
+                    } else {
+                        null
+                    }
+                    val screenshotBytes = cachedMedia?.screenshotBytes ?: if (
+                        cropMode == chimahon.anki.AnkiScreenshotMode.ANIMATED_SCENE.storageValue &&
+                        onRequestAnimatedScene != null
+                    ) {
+                        onRequestAnimatedScene.invoke()
+                    } else {
+                        encoding?.bytes
+                    }
+                    Log.i(
+                        "AnkiCardCreator",
+                        "anki_add operation=$timingOperationId stage=screenshot_prepared " +
+                            "elapsed_ms=${SystemClock.elapsedRealtime() - timingStartedAtMillis} " +
+                            "media_bytes=${screenshotBytes?.size ?: 0}",
+                    )
+                    val sentenceAudioBytes = if (sentenceAudioFieldMapped && mediaRequest == null) {
+                        onRequestSentenceAudio?.invoke()
+                    } else {
+                        null
+                    }
+                    screenshotBytes to sentenceAudioBytes
                 }
-                val sentenceAudioBytes = if (sentenceAudioFieldMapped && mediaRequest == null) {
-                    onRequestSentenceAudio?.invoke()
-                } else {
-                    null
+                val mediaRequestForAdd = mediaRequest
+                    ?.withSerializedSentenceAudioPreparation(ankiMediaPreloadGate)
+                    ?.copy(
+                        preparedSentenceAudio = cachedMedia?.sentenceAudio ?: mediaRequest.preparedSentenceAudio,
+                    ) ?: cachedMedia?.sentenceAudio?.let { preparedSentenceAudio ->
+                    AnkiMediaRequest(preparedSentenceAudio = preparedSentenceAudio)
                 }
                 val ankiResult = AnkiCardCreator.addToAnki(
                     context = context,
@@ -702,8 +883,8 @@ fun OcrLookupPopup(
                     offset = miningOffset,
                     media = mediaInfo,
                     glossaryIndex = glossaryIndex,
-                    screenshotBytes = screenshotBytes,
-                    sentenceAudioBytes = sentenceAudioBytes,
+                    screenshotBytes = preparedAddMedia.first,
+                    sentenceAudioBytes = preparedAddMedia.second,
                     selection = result.matched,
                     selectedDict = selectedDict,
                     popupSelection = popupSelection,
@@ -713,7 +894,9 @@ fun OcrLookupPopup(
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
                     titleId = titleId,
-                    mediaRequest = mediaRequest,
+                    mediaRequest = mediaRequestForAdd,
+                    timingOperationId = timingOperationId,
+                    timingStartedAtMillis = timingStartedAtMillis,
                 )
                 withContext(kotlinx.coroutines.Dispatchers.Main) {
                     when (ankiResult) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/OcrLookupPopup.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -567,14 +566,15 @@ fun OcrLookupPopup(
     val hasNewExpression = currentFrame?.results?.any {
         it.term.expression !in currentFrame.existingExpressions
     } == true
-    val shouldPreloadAnkiMedia = shouldPreloadPopupAnkiMedia(
+    val ankiMediaPreloadPlan = planPopupAnkiMediaPreload(
         popupVisible = visible,
         duplicateCheckCompleted = duplicateCheckCompleted,
         hasNewExpression = hasNewExpression,
         duplicateCheckEnabled = ankiDupCheck,
         duplicateAction = ankiDupAction,
         ankiEnabled = ankiEnabled,
-        hasMappedMedia = screenshotFieldMapped || sentenceAudioFieldMapped,
+        screenshotFieldMapped = screenshotFieldMapped,
+        sentenceAudioFieldMapped = sentenceAudioFieldMapped,
         cropMode = cropMode,
     )
 
@@ -583,8 +583,7 @@ fun OcrLookupPopup(
         preloadFrameId,
         duplicateCheckCompleted,
         hasNewExpression,
-        shouldPreloadAnkiMedia,
-        cropMode,
+        ankiMediaPreloadPlan,
     ) {
         val previousPreload = pendingAnkiMediaPreload
         if (previousPreload != null) {
@@ -595,7 +594,7 @@ fun OcrLookupPopup(
         }
         preloadedAnkiMedia = null
         val frameId = preloadFrameId ?: return@LaunchedEffect
-        if (!shouldPreloadAnkiMedia) {
+        if (!ankiMediaPreloadPlan.shouldStart) {
             return@LaunchedEffect
         }
 
@@ -614,7 +613,7 @@ fun OcrLookupPopup(
                         "anki_media_preload operation=$operationId stage=started " +
                             "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis}"
                     }
-                    val screenshotBytes = if (screenshotFieldMapped && cropMode != "no_screenshot") {
+                    val screenshotBytes = if (ankiMediaPreloadPlan.prepareScreenshot) {
                         if (
                             cropMode == chimahon.anki.AnkiScreenshotMode.ANIMATED_SCENE.storageValue &&
                             latestAnimatedSceneRequest != null
@@ -633,7 +632,7 @@ fun OcrLookupPopup(
                             "elapsed_ms=${SystemClock.elapsedRealtime() - startedAtMillis} " +
                             "media_bytes=${screenshotBytes?.size ?: 0}"
                     }
-                    val sentenceAudio = if (sentenceAudioFieldMapped) {
+                    val sentenceAudio = if (ankiMediaPreloadPlan.prepareSentenceAudio) {
                         val preparation = if (latestMediaRequest != null) {
                             prepareSentenceAudioForMarker(
                                 hasSentenceAudioMarker = true,
@@ -743,12 +742,36 @@ fun OcrLookupPopup(
 
         val shouldUseCropMode = screenshotFieldMapped && cropMode == "crop" && onCropTriggered != null
 
+        suspend fun takePreloadedMediaForCurrentFrame(): PopupPreparedAnkiMedia? {
+            val pendingPreload = pendingAnkiMediaPreload?.takeIf { it.frameId == miningFrame?.id }
+            val cachedMedia = takePopupAnkiMediaForAdd(
+                cachedMedia = preloadedAnkiMedia?.takeIf { it.frameId == miningFrame?.id },
+                pendingPreload = pendingPreload,
+            )
+            if (pendingAnkiMediaPreload === pendingPreload) {
+                pendingAnkiMediaPreload = null
+            }
+            return cachedMedia
+        }
+
         if (shouldUseCropMode) {
             miningScope.launch {
-                val sentenceAudioBytes = if (sentenceAudioFieldMapped && mediaRequest == null) {
+                val cachedMedia = takePreloadedMediaForCurrentFrame()
+                val sentenceAudioBytes = if (
+                    sentenceAudioFieldMapped &&
+                    mediaRequest == null &&
+                    cachedMedia?.sentenceAudio == null
+                ) {
                     onRequestSentenceAudio?.invoke()
                 } else {
                     null
+                }
+                val mediaRequestForAdd = mediaRequest
+                    ?.withSerializedSentenceAudioPreparation(ankiMediaPreloadGate)
+                    ?.copy(
+                        preparedSentenceAudio = cachedMedia?.sentenceAudio ?: mediaRequest.preparedSentenceAudio,
+                    ) ?: cachedMedia?.sentenceAudio?.let { preparedSentenceAudio ->
+                    AnkiMediaRequest(preparedSentenceAudio = preparedSentenceAudio)
                 }
                 val ankiResult = AnkiCardCreator.addToAnki(
                     context = context,
@@ -774,7 +797,7 @@ fun OcrLookupPopup(
                     syncOnCreate = ankiSyncOnCreate,
                     profileId = activeProfile.id,
                     titleId = titleId,
-                    mediaRequest = mediaRequest,
+                    mediaRequest = mediaRequestForAdd,
                 )
                 if (ankiResult is AnkiResult.Success || ankiResult is AnkiResult.CardExists || ankiResult is AnkiResult.OpenCard) {
                     withContext(kotlinx.coroutines.Dispatchers.Main) {
@@ -816,22 +839,7 @@ fun OcrLookupPopup(
                 logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                     "anki_add operation=$timingOperationId stage=started elapsed_ms=0"
                 }
-                var cachedMedia = preloadedAnkiMedia?.takeIf { it.frameId == miningFrame?.id }
-                val pendingPreload = pendingAnkiMediaPreload?.takeIf { it.frameId == miningFrame?.id }
-                if (cachedMedia == null && pendingPreload != null) {
-                    if (pendingPreload.nativeCaptureStarted.isCompleted) {
-                        cachedMedia = try {
-                            pendingPreload.result.await()
-                        } catch (_: CancellationException) {
-                            null
-                        }
-                    } else {
-                        pendingPreload.result.cancelAndJoin()
-                    }
-                    if (pendingAnkiMediaPreload === pendingPreload) {
-                        pendingAnkiMediaPreload = null
-                    }
-                }
+                val cachedMedia = takePreloadedMediaForCurrentFrame()
                 val preparedAddMedia = ankiMediaPreloadGate.run {
                     logcat(LogPriority.DEBUG, "AnkiCardCreator") {
                         "anki_add operation=$timingOperationId stage=popup_media_cache " +

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureServiceTest.kt
@@ -71,23 +71,31 @@ class PlayerMediaCaptureServiceTest {
     fun `OCR animated scene request freezes selection time before capture runs`() {
         var time = 10.0
         var padding = 2.0
+        var video = video("https://media.example/original.m3u8", "original")
+        var mpvPath = "https://media.example/playable.m3u8"
         val service = PlayerMediaCaptureService(
             context = mockk<Context>(relaxed = true),
             cachePath = "cache",
-            getVideo = { video("https://media.example/original.m3u8", "original") },
+            getVideo = { video },
             getSource = { null },
             getTimeSeconds = { time },
             getOcrPaddingSeconds = { padding },
             readMpvSnapshot = { snapshot("https://media.example/playable.m3u8", 7, 1, 3, false, null, true) },
+            readMpvVideoPath = { mpvPath },
         )
 
         val request = service.createVideoOcrAnimatedSceneRequest()
 
         time = 99.0
         padding = 20.0
+        video = video("https://media.example/changed.m3u8", "changed")
+        mpvPath = "https://media.example/changed-playable.m3u8"
 
         assertEquals(8.0, request.startSeconds)
         assertEquals(12.0, request.endSeconds)
+        assertEquals("https://media.example/playable.m3u8", request.input?.source)
+        assertEquals("https://media.example/original.m3u8", request.input?.videoUrl)
+        assertEquals(listOf("Referer" to "original"), request.input?.headers)
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureServiceTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/PlayerMediaCaptureServiceTest.kt
@@ -68,6 +68,29 @@ class PlayerMediaCaptureServiceTest {
     }
 
     @Test
+    fun `OCR animated scene request freezes selection time before capture runs`() {
+        var time = 10.0
+        var padding = 2.0
+        val service = PlayerMediaCaptureService(
+            context = mockk<Context>(relaxed = true),
+            cachePath = "cache",
+            getVideo = { video("https://media.example/original.m3u8", "original") },
+            getSource = { null },
+            getTimeSeconds = { time },
+            getOcrPaddingSeconds = { padding },
+            readMpvSnapshot = { snapshot("https://media.example/playable.m3u8", 7, 1, 3, false, null, true) },
+        )
+
+        val request = service.createVideoOcrAnimatedSceneRequest()
+
+        time = 99.0
+        padding = 20.0
+
+        assertEquals(8.0, request.startSeconds)
+        assertEquals(12.0, request.endSeconds)
+    }
+
+    @Test
     fun `subtitle request preserves missing timing for typed provider diagnostics`() {
         val request = service().createSubtitleAudioMediaRequest(null, 12.0)
 

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
@@ -1,0 +1,99 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import chimahon.anki.AnkiSentenceAudioFailure
+import chimahon.anki.AnkiSentenceAudioPreparation
+import chimahon.anki.AnkiSentenceAudioSource
+import chimahon.anki.AnkiMediaRequest
+import chimahon.anki.LazyAnkiSentenceAudioProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class AnkiPopupMediaPreloadTest {
+
+    @Test
+    fun `popup media retains an unavailable sentence-audio preparation`() {
+        val unavailable = AnkiSentenceAudioPreparation.Unavailable(
+            AnkiSentenceAudioFailure.AUDIO_STREAMS_NOT_FOUND,
+        )
+
+        val media = PopupPreparedAnkiMedia(
+            frameId = "frame",
+            screenshotBytes = null,
+            sentenceAudio = unavailable,
+        )
+
+        assertEquals(unavailable, media.sentenceAudio)
+    }
+
+    @Test
+    fun `sentence-audio provider waits for active popup media preparation`() = runTest {
+        val gate = SerializedAnkiMediaPreloadGate()
+        val firstStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val providerStarted = CompletableDeferred<Unit>()
+        val request = AnkiMediaRequest(
+            sentenceAudioProvider = LazyAnkiSentenceAudioProvider {
+                providerStarted.complete(Unit)
+                AnkiSentenceAudioPreparation.Ready(
+                    AnkiSentenceAudioSource.fromBytes(byteArrayOf(1), "m4a"),
+                )
+            },
+        ).withSerializedSentenceAudioPreparation(gate)
+
+        val first = launch {
+            gate.run {
+                firstStarted.complete(Unit)
+                releaseFirst.await()
+            }
+        }
+        firstStarted.await()
+
+        val preparation = async { request.sentenceAudioProvider?.prepare() }
+        runCurrent()
+
+        assertFalse(providerStarted.isCompleted)
+
+        releaseFirst.complete(Unit)
+
+        val prepared = preparation.await() as? AnkiSentenceAudioPreparation.Ready
+        assertEquals(listOf<Byte>(1), prepared?.source?.data?.toList())
+        first.join()
+    }
+
+    @Test
+    fun `next preload waits until the active preload releases the shared gate`() = runTest {
+        val gate = SerializedAnkiMediaPreloadGate()
+        val firstStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+
+        val first = launch {
+            gate.run {
+                firstStarted.complete(Unit)
+                releaseFirst.await()
+            }
+        }
+        firstStarted.await()
+
+        val second = async {
+            gate.run {
+                secondStarted.complete(Unit)
+                "second"
+            }
+        }
+        runCurrent()
+
+        assertFalse(secondStarted.isCompleted)
+
+        releaseFirst.complete(Unit)
+
+        assertEquals("second", second.await())
+        first.join()
+    }
+}

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
@@ -21,16 +21,17 @@ class AnkiPopupMediaPreloadTest {
     @Test
     fun `hidden popup is not eligible for media preload`() {
         assertFalse(
-            shouldPreloadPopupAnkiMedia(
+            planPopupAnkiMediaPreload(
                 popupVisible = false,
                 duplicateCheckCompleted = true,
                 hasNewExpression = true,
                 duplicateCheckEnabled = true,
                 duplicateAction = "prevent",
                 ankiEnabled = true,
-                hasMappedMedia = true,
+                screenshotFieldMapped = true,
+                sentenceAudioFieldMapped = true,
                 cropMode = "full",
-            ),
+            ).shouldStart,
         )
     }
 
@@ -38,16 +39,17 @@ class AnkiPopupMediaPreloadTest {
     fun `duplicate expression preloads when duplicate checking is disabled`() {
         assertEquals(
             true,
-            shouldPreloadPopupAnkiMedia(
+            planPopupAnkiMediaPreload(
                 popupVisible = true,
                 duplicateCheckCompleted = true,
                 hasNewExpression = false,
                 duplicateCheckEnabled = false,
                 duplicateAction = "prevent",
                 ankiEnabled = true,
-                hasMappedMedia = true,
+                screenshotFieldMapped = true,
+                sentenceAudioFieldMapped = true,
                 cropMode = "full",
-            ),
+            ).shouldStart,
         )
     }
 
@@ -55,33 +57,71 @@ class AnkiPopupMediaPreloadTest {
     fun `duplicate expression preloads when duplicate action overwrites`() {
         assertEquals(
             true,
-            shouldPreloadPopupAnkiMedia(
+            planPopupAnkiMediaPreload(
                 popupVisible = true,
                 duplicateCheckCompleted = true,
                 hasNewExpression = false,
                 duplicateCheckEnabled = true,
                 duplicateAction = "overwrite",
                 ankiEnabled = true,
-                hasMappedMedia = true,
+                screenshotFieldMapped = true,
+                sentenceAudioFieldMapped = true,
                 cropMode = "full",
-            ),
+            ).shouldStart,
         )
     }
 
     @Test
     fun `duplicate expression skips preload when duplicate action prevents add`() {
         assertFalse(
-            shouldPreloadPopupAnkiMedia(
+            planPopupAnkiMediaPreload(
                 popupVisible = true,
                 duplicateCheckCompleted = true,
                 hasNewExpression = false,
                 duplicateCheckEnabled = true,
                 duplicateAction = "prevent",
                 ankiEnabled = true,
-                hasMappedMedia = true,
+                screenshotFieldMapped = true,
+                sentenceAudioFieldMapped = true,
                 cropMode = "full",
-            ),
+            ).shouldStart,
         )
+    }
+
+    @Test
+    fun `crop mode preloads sentence audio without preloading a screenshot`() {
+        val plan = planPopupAnkiMediaPreload(
+            popupVisible = true,
+            duplicateCheckCompleted = true,
+            hasNewExpression = true,
+            duplicateCheckEnabled = true,
+            duplicateAction = "prevent",
+            ankiEnabled = true,
+            screenshotFieldMapped = true,
+            sentenceAudioFieldMapped = true,
+            cropMode = "crop",
+        )
+
+        assertTrue(plan.shouldStart)
+        assertFalse(plan.prepareScreenshot)
+        assertTrue(plan.prepareSentenceAudio)
+    }
+
+    @Test
+    fun `no screenshot mode skips a screenshot-only preload`() {
+        val plan = planPopupAnkiMediaPreload(
+            popupVisible = true,
+            duplicateCheckCompleted = true,
+            hasNewExpression = true,
+            duplicateCheckEnabled = true,
+            duplicateAction = "prevent",
+            ankiEnabled = true,
+            screenshotFieldMapped = true,
+            sentenceAudioFieldMapped = false,
+            cropMode = "no_screenshot",
+        )
+
+        assertFalse(plan.shouldStart)
     }
 
     @Test
@@ -99,10 +139,36 @@ class AnkiPopupMediaPreloadTest {
         )
         runCurrent()
 
-        cancelPopupAnkiMediaPreload(pending)
+        val prepared = takePopupAnkiMediaForAdd(
+            cachedMedia = null,
+            pendingPreload = pending,
+        )
 
+        assertEquals(null, prepared)
         assertTrue(result.isCancelled)
         assertFalse(nativeCaptureStarted.isCompleted)
+    }
+
+    @Test
+    fun `add reuses a pending preload after native capture starts`() = runTest {
+        val expected = PopupPreparedAnkiMedia(
+            frameId = "frame",
+            screenshotBytes = byteArrayOf(1),
+            sentenceAudio = null,
+        )
+        val nativeCaptureStarted = CompletableDeferred<Unit>().apply { complete(Unit) }
+        val pending = PendingPopupAnkiMediaPreload(
+            frameId = "frame",
+            nativeCaptureStarted = nativeCaptureStarted,
+            result = async { expected },
+        )
+
+        val prepared = takePopupAnkiMediaForAdd(
+            cachedMedia = null,
+            pendingPreload = pending,
+        )
+
+        assertEquals(expected, prepared)
     }
 
     @Test

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/reader/viewer/AnkiPopupMediaPreloadTest.kt
@@ -7,14 +7,103 @@ import chimahon.anki.AnkiMediaRequest
 import chimahon.anki.LazyAnkiSentenceAudioProvider
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class AnkiPopupMediaPreloadTest {
+
+    @Test
+    fun `hidden popup is not eligible for media preload`() {
+        assertFalse(
+            shouldPreloadPopupAnkiMedia(
+                popupVisible = false,
+                duplicateCheckCompleted = true,
+                hasNewExpression = true,
+                duplicateCheckEnabled = true,
+                duplicateAction = "prevent",
+                ankiEnabled = true,
+                hasMappedMedia = true,
+                cropMode = "full",
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate expression preloads when duplicate checking is disabled`() {
+        assertEquals(
+            true,
+            shouldPreloadPopupAnkiMedia(
+                popupVisible = true,
+                duplicateCheckCompleted = true,
+                hasNewExpression = false,
+                duplicateCheckEnabled = false,
+                duplicateAction = "prevent",
+                ankiEnabled = true,
+                hasMappedMedia = true,
+                cropMode = "full",
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate expression preloads when duplicate action overwrites`() {
+        assertEquals(
+            true,
+            shouldPreloadPopupAnkiMedia(
+                popupVisible = true,
+                duplicateCheckCompleted = true,
+                hasNewExpression = false,
+                duplicateCheckEnabled = true,
+                duplicateAction = "overwrite",
+                ankiEnabled = true,
+                hasMappedMedia = true,
+                cropMode = "full",
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate expression skips preload when duplicate action prevents add`() {
+        assertFalse(
+            shouldPreloadPopupAnkiMedia(
+                popupVisible = true,
+                duplicateCheckCompleted = true,
+                hasNewExpression = false,
+                duplicateCheckEnabled = true,
+                duplicateAction = "prevent",
+                ankiEnabled = true,
+                hasMappedMedia = true,
+                cropMode = "full",
+            ),
+        )
+    }
+
+    @Test
+    fun `cancelling a pending preload before its delay prevents native capture`() = runTest {
+        val nativeCaptureStarted = CompletableDeferred<Unit>()
+        val result = async {
+            delay(POPUP_ANKI_MEDIA_PRELOAD_DELAY_MS)
+            nativeCaptureStarted.complete(Unit)
+            null
+        }
+        val pending = PendingPopupAnkiMediaPreload(
+            frameId = "frame",
+            nativeCaptureStarted = nativeCaptureStarted,
+            result = result,
+        )
+        runCurrent()
+
+        cancelPopupAnkiMediaPreload(pending)
+
+        assertTrue(result.isCancelled)
+        assertFalse(nativeCaptureStarted.isCompleted)
+    }
 
     @Test
     fun `popup media retains an unavailable sentence-audio preparation`() {

--- a/chimahon/src/main/java/chimahon/anki/AnkiAddDiagnostics.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiAddDiagnostics.kt
@@ -1,0 +1,72 @@
+package chimahon.anki
+
+internal enum class AnkiAddTimingStage {
+    STARTED,
+    CONFIGURATION_READY,
+    PREFLIGHT_FINISHED,
+    SCREENSHOT_PREPARED,
+    SENTENCE_AUDIO_PREPARED,
+    WORD_AUDIO_PREPARED,
+    FIELDS_RENDERED,
+    TAGS_RENDERED,
+    DICTIONARY_MEDIA_PREPARED,
+    MEDIA_PREPARED,
+    FINAL_DUPLICATE_FINISHED,
+    MEDIA_STORED,
+    FIELDS_RESOLVED,
+    NOTE_SAVED,
+    STATS_RECORDED,
+    SYNC_DISPATCHED,
+    COMPLETED,
+}
+
+internal data class AnkiAddTimingEvent(
+    val operationId: String,
+    val stage: AnkiAddTimingStage,
+    val elapsedMillis: Long,
+    val fieldCount: Int? = null,
+    val tagCount: Int? = null,
+    val dictionaryMediaCount: Int? = null,
+    val mediaBytes: Int? = null,
+    val outcome: String? = null,
+)
+
+internal class AnkiAddTimingTrace(
+    private val operationId: String,
+    private val nowMillis: () -> Long,
+    private val emit: (AnkiAddTimingEvent) -> Unit,
+    startedAtMillis: Long? = null,
+) {
+    private val startedAt = startedAtMillis ?: nowMillis()
+
+    fun mark(
+        stage: AnkiAddTimingStage,
+        fieldCount: Int? = null,
+        tagCount: Int? = null,
+        dictionaryMediaCount: Int? = null,
+        mediaBytes: Int? = null,
+        outcome: String? = null,
+    ) {
+        emit(
+            AnkiAddTimingEvent(
+                operationId = operationId,
+                stage = stage,
+                elapsedMillis = (nowMillis() - startedAt).coerceAtLeast(0L),
+                fieldCount = fieldCount,
+                tagCount = tagCount,
+                dictionaryMediaCount = dictionaryMediaCount,
+                mediaBytes = mediaBytes,
+                outcome = outcome,
+            ),
+        )
+    }
+}
+
+internal fun formatAnkiAddTimingEvent(event: AnkiAddTimingEvent): String = buildString {
+    append("anki_add operation=${event.operationId} stage=${event.stage.name.lowercase()} elapsed_ms=${event.elapsedMillis}")
+    event.fieldCount?.let { append(" fields=$it") }
+    event.tagCount?.let { append(" tags=$it") }
+    event.dictionaryMediaCount?.let { append(" dictionary_media=$it") }
+    event.mediaBytes?.let { append(" media_bytes=$it") }
+    event.outcome?.let { append(" outcome=$it") }
+}

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -20,6 +20,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CancellationException
+import java.util.concurrent.atomic.AtomicLong
 
 // =============================================================================
 // Legacy FieldType enum for UI backwards compatibility
@@ -220,10 +221,17 @@ object AnkiCardCreator {
     private const val WORD_AUDIO_MEDIA_PLACEHOLDER = "chimahon_word_audio_pending.mp3"
     private const val SENTENCE_AUDIO_MEDIA_PLACEHOLDER = "chimahon_sentence_audio_pending.m4a"
     private val duplicateGate = AnkiDuplicateGate()
+    private val addTimingOperationSequence = AtomicLong()
     @Volatile
     internal var bridgeFactory: (Context) -> AnkiCardBridge = ::AnkiDroidBridge
     @Volatile
     internal var fieldMapParser: (String) -> Map<String, String> = ::parseFieldMap
+    @Volatile
+    internal var timingClock: () -> Long = android.os.SystemClock::elapsedRealtime
+    @Volatile
+    internal var timingEventSink: (AnkiAddTimingEvent) -> Unit = { event ->
+        android.util.Log.i(TAG, formatAnkiAddTimingEvent(event))
+    }
 
     internal fun resetBridgeFactoryForTests() {
         bridgeFactory = ::AnkiDroidBridge
@@ -231,6 +239,11 @@ object AnkiCardCreator {
 
     internal fun resetFieldMapParserForTests() {
         fieldMapParser = ::parseFieldMap
+    }
+
+    internal fun resetTimingDiagnosticsForTests() {
+        timingClock = android.os.SystemClock::elapsedRealtime
+        timingEventSink = { event -> android.util.Log.i(TAG, formatAnkiAddTimingEvent(event)) }
     }
 
     private data class DictionaryMediaReference(
@@ -289,11 +302,20 @@ object AnkiCardCreator {
         profileId: String = "",
         titleId: String? = null,
         mediaRequest: AnkiMediaRequest? = null,
+        timingOperationId: String? = null,
+        timingStartedAtMillis: Long? = null,
     ): AnkiResult {
-        android.util.Log.d(TAG, "addToAnki: deck=$deck, model=$model, forceOpen=$forceOpen, glossaryIndex=$glossaryIndex")
+        val timing = AnkiAddTimingTrace(
+            operationId = timingOperationId ?: "add-${addTimingOperationSequence.incrementAndGet()}",
+            nowMillis = timingClock,
+            emit = timingEventSink,
+            startedAtMillis = timingStartedAtMillis,
+        )
+        if (timingStartedAtMillis == null) timing.mark(AnkiAddTimingStage.STARTED)
 
         val bridge = bridgeFactory(context)
         if (!bridge.hasPermission()) {
+            timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "permission_denied")
             return AnkiResult.PermissionDenied
         }
         return try {
@@ -313,12 +335,12 @@ object AnkiCardCreator {
             }
 
             if (effectiveDeck.isBlank() || effectiveModel.isBlank()) {
-                android.util.Log.w(TAG, "addToAnki: NotConfigured - deck or model is blank")
+                timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "not_configured")
                 return AnkiResult.NotConfigured
             }
 
             val fieldMap = fieldMapParser(effectiveFieldMapJson)
-            android.util.Log.d(TAG, "addToAnki: parsed fieldMap=$fieldMap")
+            timing.mark(AnkiAddTimingStage.CONFIGURATION_READY, fieldCount = fieldMap.size)
             val cloze = if (sentence.isNotEmpty() && offset >= 0) {
                 // Use result.matched (the exact surface form the dictionary engine consumed)
                 // so the bold window is precisely the word that was looked up, not the base form.
@@ -359,11 +381,16 @@ object AnkiCardCreator {
             }
 
             val firstDecision = duplicateGate.preflight(lockKey, ::duplicateDecision)
-            if (firstDecision is AnkiDuplicateDecision.Return) return firstDecision.result
+            timing.mark(AnkiAddTimingStage.PREFLIGHT_FINISHED, outcome = firstDecision.timingOutcome())
+            if (firstDecision is AnkiDuplicateDecision.Return) {
+                timing.mark(AnkiAddTimingStage.COMPLETED, outcome = firstDecision.timingOutcome())
+                return firstDecision.result
+            }
 
             val sentenceAudioPreparation = prepareSentenceAudioForMarker(
                 hasSentenceAudioMarker,
                 mediaRequest?.sentenceAudioProvider,
+                mediaRequest?.preparedSentenceAudio,
             ) ?: when {
                 hasSentenceAudioMarker && sentenceAudioBytes != null -> {
                     AnkiSentenceAudioPreparation.Ready(
@@ -372,6 +399,10 @@ object AnkiCardCreator {
                 }
                 else -> null
             }
+            timing.mark(
+                AnkiAddTimingStage.SENTENCE_AUDIO_PREPARED,
+                mediaBytes = (sentenceAudioPreparation as? AnkiSentenceAudioPreparation.Ready)?.source?.data?.size,
+            )
             val exportMedia = ExportMediaContext()
             val fieldsWithPlaceholders = withContext(Dispatchers.Default) {
                 buildFields(
@@ -388,7 +419,7 @@ object AnkiCardCreator {
                     styles,
                     exportMedia,
                 )
-            }
+            }.also { timing.mark(AnkiAddTimingStage.FIELDS_RENDERED, fieldCount = it.size) }
             val tagsWithPlaceholders = withContext(Dispatchers.Default) {
                 // Split configured tags before rendering markers so commas from a
                 // resolved value (for example a title) stay inside one tag.
@@ -408,17 +439,25 @@ object AnkiCardCreator {
                             styles, exportMedia,
                         )
                     }
-            }
+            }.also { timing.mark(AnkiAddTimingStage.TAGS_RENDERED, tagCount = it.size) }
+            val wordAudio = if (hasWordAudioMarker) prepareWordAudioPayload(result) else null
+            timing.mark(AnkiAddTimingStage.WORD_AUDIO_PREPARED, mediaBytes = wordAudio?.data?.size)
+            val dictionaryMedia = prepareDictionaryMedia(exportMedia)
+            timing.mark(AnkiAddTimingStage.DICTIONARY_MEDIA_PREPARED, dictionaryMediaCount = dictionaryMedia.size)
             val preparedMedia = PreparedAnkiCardMedia(
                 screenshot = screenshotBytes
                     ?.let { PreparedAnkiMediaPayload(generateScreenshotFilename(it), it) },
-                wordAudio = if (hasWordAudioMarker) prepareWordAudioPayload(result) else null,
-                dictionaryMedia = prepareDictionaryMedia(exportMedia),
+                wordAudio = wordAudio,
+                dictionaryMedia = dictionaryMedia,
                 sentenceAudio = sentenceAudioPreparation,
             )
+            timing.mark(AnkiAddTimingStage.MEDIA_PREPARED, dictionaryMediaCount = dictionaryMedia.size)
 
-            duplicateGate.commit(lockKey, ::duplicateDecision) { finalDecision ->
+            duplicateGate.commit(lockKey, {
+                duplicateDecision().also { timing.mark(AnkiAddTimingStage.FINAL_DUPLICATE_FINISHED, outcome = it.timingOutcome()) }
+            }) { finalDecision ->
                 if (finalDecision is AnkiDuplicateDecision.Return) {
+                    timing.mark(AnkiAddTimingStage.COMPLETED, outcome = finalDecision.timingOutcome())
                     return@commit finalDecision.result
                 }
                 val committedMedia = commitPreparedAnkiCardMedia(
@@ -426,6 +465,7 @@ object AnkiCardCreator {
                     storeBytes = bridge::storeMedia,
                     storeSentenceAudio = bridge::storeMedia,
                 )
+                timing.mark(AnkiAddTimingStage.MEDIA_STORED, dictionaryMediaCount = dictionaryMedia.size)
                 val fields = resolveMediaPlaceholders(
                     resolveDictionaryMediaPlaceholders(fieldsWithPlaceholders, committedMedia.dictionaryReplacementByPlaceholder),
                     committedMedia,
@@ -433,7 +473,7 @@ object AnkiCardCreator {
                 val tagList = tagsWithPlaceholders
                     .map { value -> resolveMediaPlaceholders(value, committedMedia) }
                     .mapNotNull(::normalizeAnkiTag)
-                android.util.Log.d(TAG, "addToAnki: built fields=$fields")
+                timing.mark(AnkiAddTimingStage.FIELDS_RESOLVED, fieldCount = fields.size, tagCount = tagList.size)
 
                 val noteId = when (finalDecision) {
                     is AnkiDuplicateDecision.Overwrite -> {
@@ -448,21 +488,41 @@ object AnkiCardCreator {
                     )
                     is AnkiDuplicateDecision.Return -> error("handled above")
                 }
+                timing.mark(AnkiAddTimingStage.NOTE_SAVED)
                 com.canopus.chimareader.data.AnkiStatsStorage.addCard(
                     context,
                     type,
                     profileId = profileId,
                     titleId = titleId,
                 )
-                if (syncOnCreate) bridge.triggerSync()
-                AnkiResult.Success(noteId, committedMedia.sentenceAudio.warnings)
+                timing.mark(AnkiAddTimingStage.STATS_RECORDED)
+                if (syncOnCreate) {
+                    bridge.triggerSync()
+                    timing.mark(AnkiAddTimingStage.SYNC_DISPATCHED)
+                }
+                AnkiResult.Success(noteId, committedMedia.sentenceAudio.warnings).also {
+                    timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "success")
+                }
             }
         } catch (e: CancellationException) {
+            timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "cancelled")
             throw e
         } catch (e: SecurityException) {
+            timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "permission_denied")
             AnkiResult.PermissionDenied
         } catch (e: Exception) {
+            timing.mark(AnkiAddTimingStage.COMPLETED, outcome = "error")
             AnkiResult.Error(e.message ?: "Unknown error")
+        }
+    }
+
+    private fun AnkiDuplicateDecision.timingOutcome(): String = when (this) {
+        AnkiDuplicateDecision.Insert -> "insert"
+        is AnkiDuplicateDecision.Overwrite -> "overwrite"
+        is AnkiDuplicateDecision.Return -> when (result) {
+            is AnkiResult.CardExists -> "card_exists"
+            is AnkiResult.OpenCard -> "open_card"
+            else -> "return"
         }
     }
 

--- a/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiCardCreator.kt
@@ -1,6 +1,7 @@
 package chimahon.anki
 
 import android.content.Context
+import android.util.Log
 import chimahon.Cloze
 import chimahon.DictionaryRepository
 import chimahon.HoshiDicts
@@ -230,7 +231,7 @@ object AnkiCardCreator {
     internal var timingClock: () -> Long = android.os.SystemClock::elapsedRealtime
     @Volatile
     internal var timingEventSink: (AnkiAddTimingEvent) -> Unit = { event ->
-        android.util.Log.i(TAG, formatAnkiAddTimingEvent(event))
+        Log.d(TAG, formatAnkiAddTimingEvent(event))
     }
 
     internal fun resetBridgeFactoryForTests() {
@@ -243,7 +244,7 @@ object AnkiCardCreator {
 
     internal fun resetTimingDiagnosticsForTests() {
         timingClock = android.os.SystemClock::elapsedRealtime
-        timingEventSink = { event -> android.util.Log.i(TAG, formatAnkiAddTimingEvent(event)) }
+        timingEventSink = { event -> Log.d(TAG, formatAnkiAddTimingEvent(event)) }
     }
 
     private data class DictionaryMediaReference(

--- a/chimahon/src/main/java/chimahon/anki/AnkiSentenceAudio.kt
+++ b/chimahon/src/main/java/chimahon/anki/AnkiSentenceAudio.kt
@@ -87,6 +87,7 @@ fun interface LazyAnkiSentenceAudioProvider {
 
 data class AnkiMediaRequest(
     val sentenceAudioProvider: LazyAnkiSentenceAudioProvider? = null,
+    val preparedSentenceAudio: AnkiSentenceAudioPreparation? = null,
 )
 
 sealed interface AnkiMediaWarning {
@@ -128,11 +129,14 @@ internal class AnkiSentenceAudioCommitter(
         }
 }
 
-internal suspend fun prepareSentenceAudioForMarker(
+suspend fun prepareSentenceAudioForMarker(
     hasSentenceAudioMarker: Boolean,
     provider: LazyAnkiSentenceAudioProvider?,
+    prepared: AnkiSentenceAudioPreparation? = null,
 ): AnkiSentenceAudioPreparation? {
-    if (!hasSentenceAudioMarker || provider == null) return null
+    if (!hasSentenceAudioMarker) return null
+    if (prepared != null) return prepared
+    if (provider == null) return null
     return try {
         provider.prepare()
     } catch (e: CancellationException) {

--- a/chimahon/src/test/java/chimahon/anki/AnkiSentenceAudioCommitterTest.kt
+++ b/chimahon/src/test/java/chimahon/anki/AnkiSentenceAudioCommitterTest.kt
@@ -61,6 +61,26 @@ class AnkiSentenceAudioCommitterTest {
     }
 
     @Test
+    fun `prepared sentence audio is reused without invoking its provider`() = runTest {
+        var invoked = false
+        val prepared = AnkiSentenceAudioPreparation.Ready(
+            AnkiSentenceAudioSource.fromBytes(byteArrayOf(9), "m4a"),
+        )
+
+        val actual = prepareSentenceAudioForMarker(
+            hasSentenceAudioMarker = true,
+            provider = LazyAnkiSentenceAudioProvider {
+                invoked = true
+                error("must not be invoked")
+            },
+            prepared = prepared,
+        )
+
+        assertEquals(prepared, actual)
+        assertFalse(invoked)
+    }
+
+    @Test
     fun `provider exception becomes unavailable unknown`() = runTest {
         val preparation = prepareSentenceAudioForMarker(true, LazyAnkiSentenceAudioProvider {
             error("native failure")


### PR DESCRIPTION
## Problem
Previously, screenshot capture and sentence audio extraction were only triggered *after* the user tapped the "Add to Anki" button inside the dictionary lookup popup. This created a noticeable latency and UI pause during card creation while heavy operations (such as native viewport frame rendering, SAF read/write, or FFmpeg audio extraction in the anime player) executed synchronously.

## Result
Tapping the "Add to Anki" button inside the dictionary popup now creates cards near-instantaneously because screenshots and audio cues are already prepared in the background while the user reads definitions. If the popup is dismissed in 500 ms or card creation is skipped, pending preloads are cancelled without unnecessary overhead.
