### PR TITLE
Add two-way AniList sync: pull progress + auto-add entries to library

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -32,6 +32,7 @@ import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.domain.track.interactor.RefreshTracks
+import eu.kanade.domain.track.interactor.SyncAniListToLibrary
 import eu.kanade.domain.track.interactor.SyncChapterProgressWithTrack
 import eu.kanade.domain.track.interactor.TrackChapter
 import mihon.data.extension.repository.ExtensionStoreRepositoryImpl
@@ -208,6 +209,7 @@ class DomainModule : InjektModule {
         addFactory { GetTracks(get()) }
         addFactory { InsertTrack(get()) }
         addFactory { SyncChapterProgressWithTrack(get(), get(), get()) }
+        addFactory { SyncAniListToLibrary() }
 
         addSingletonFactory<ChapterRepository> { ChapterRepositoryImpl(get()) }
         addFactory { GetChapter(get()) }

--- a/app/src/main/java/eu/kanade/domain/track/interactor/AniListTitleMatcher.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/AniListTitleMatcher.kt
@@ -1,0 +1,13 @@
+package eu.kanade.domain.track.interactor
+
+internal object AniListTitleMatcher {
+
+    private val nonAlphanumeric = Regex("[\\W_]+")
+
+    fun normalize(title: String): String = title.lowercase().replace(nonAlphanumeric, "")
+
+    fun matches(a: String, b: String): Boolean {
+        val normalized = normalize(a)
+        return normalized.isNotEmpty() && normalized == normalize(b)
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/track/interactor/SyncAniListToLibrary.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/SyncAniListToLibrary.kt
@@ -1,0 +1,288 @@
+package eu.kanade.domain.track.interactor
+
+import eu.kanade.domain.entries.anime.interactor.UpdateAnime
+import eu.kanade.domain.entries.anime.model.toSAnime
+import eu.kanade.domain.episode.interactor.SyncEpisodesWithSource
+import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.track.anime.interactor.AddAnimeTracks
+import eu.kanade.domain.track.anime.model.toDbTrack
+import eu.kanade.domain.track.anime.model.toDomainTrack
+import eu.kanade.domain.track.model.toDbTrack
+import eu.kanade.domain.track.model.toDomainTrack
+import eu.kanade.tachiyomi.animesource.AnimeSource
+import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.anilist.Anilist
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALMediaListEntry
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.online.LoginSource
+import logcat.LogPriority
+import mihon.domain.source.interactor.UpdateMangaFromRemote
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.source.NoResultsException
+import tachiyomi.domain.category.interactor.SetAnimeCategories
+import tachiyomi.domain.category.interactor.SetMangaCategories
+import tachiyomi.domain.entries.anime.interactor.GetAnime
+import tachiyomi.domain.entries.anime.interactor.NetworkToLocalAnime
+import tachiyomi.domain.entries.anime.model.Anime
+import tachiyomi.domain.episode.interactor.GetEpisodesByAnimeId
+import tachiyomi.domain.episode.interactor.UpdateEpisode
+import tachiyomi.domain.episode.model.toEpisodeUpdate
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.track.anime.interactor.GetAnimeTracks
+import tachiyomi.domain.track.anime.interactor.InsertAnimeTrack
+import tachiyomi.domain.track.anime.model.AnimeTrack
+import tachiyomi.domain.track.interactor.GetTracks
+import tachiyomi.domain.track.interactor.InsertTrack
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class SyncAniListToLibrary {
+
+    private val trackerManager: TrackerManager = Injekt.get()
+    private val getTracks: GetTracks = Injekt.get()
+    private val getAnimeTracks: GetAnimeTracks = Injekt.get()
+    private val insertTrack: InsertTrack = Injekt.get()
+    private val insertAnimeTrack: InsertAnimeTrack = Injekt.get()
+    private val syncChapterProgressWithTrack: SyncChapterProgressWithTrack = Injekt.get()
+    private val getManga: GetManga = Injekt.get()
+    private val getAnime: GetAnime = Injekt.get()
+    private val networkToLocalManga: NetworkToLocalManga = Injekt.get()
+    private val networkToLocalAnime: NetworkToLocalAnime = Injekt.get()
+    private val updateManga: UpdateManga = Injekt.get()
+    private val updateAnime: UpdateAnime = Injekt.get()
+    private val updateMangaFromRemote: UpdateMangaFromRemote = Injekt.get()
+    private val setMangaCategories: SetMangaCategories = Injekt.get()
+    private val setAnimeCategories: SetAnimeCategories = Injekt.get()
+    private val addTracks: AddTracks = Injekt.get()
+    private val addAnimeTracks: AddAnimeTracks = Injekt.get()
+    private val sourceManager: SourceManager = Injekt.get()
+    private val animeSourceManager: AnimeSourceManager = Injekt.get()
+    private val syncEpisodesWithSource: SyncEpisodesWithSource = Injekt.get()
+    private val getEpisodesByAnimeId: GetEpisodesByAnimeId = Injekt.get()
+    private val updateEpisode: UpdateEpisode = Injekt.get()
+
+    /**
+     * Pulls progress from AniList into all tracked library entries (manga & anime),
+     * and adds new AniList list entries to the library when an exact title match
+     * is found in an installed source.
+     */
+    suspend fun await() = withIOContext {
+        val aniList = trackerManager.aniList
+        if (!aniList.isLoggedIn) return@withIOContext
+
+        val mangaTracks = getTracks.await().filter { it.trackerId == TrackerManager.ANILIST }
+        val animeTracks = getAnimeTracks.awaitAll().filter { it.trackerId == TrackerManager.ANILIST }
+
+        // Pull progress for already tracked entries
+        mangaTracks.forEach { track ->
+            try {
+                val updated = aniList.refresh(track.toDbTrack())
+                insertTrack.await(updated.toDomainTrack()!!)
+                syncChapterProgressWithTrack.sync(track.mangaId, updated.toDomainTrack()!!, aniList)
+            } catch (e: Throwable) {
+                logcat(LogPriority.WARN, e) { "Could not refresh AniList track for manga ${track.mangaId}" }
+            }
+        }
+        animeTracks.forEach { track ->
+            try {
+                val updated = aniList.refresh(track.toDbTrack())
+                insertAnimeTrack.await(updated.toDomainTrack(idRequired = false)!!)
+                markEpisodesSeen(track.animeId, updated.toDomainTrack(idRequired = false)!!, aniList)
+            } catch (e: Throwable) {
+                logcat(LogPriority.WARN, e) { "Could not refresh AniList track for anime ${track.animeId}" }
+            }
+        }
+
+        // Auto-add new AniList entries found in sources by exact title
+        try {
+            val boundMangaIds = mangaTracks.map { it.remoteId }.toSet()
+            aniList.getFullMangaList()
+                .filter { it.media.id !in boundMangaIds }
+                .forEach { entry ->
+                    try {
+                        addMangaEntry(entry, aniList)
+                    } catch (e: Throwable) {
+                        logcat(LogPriority.WARN, e) { "Could not add AniList manga ${entry.media.title.userPreferred}" }
+                    }
+                }
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN, e) { "Could not fetch AniList manga list" }
+        }
+        try {
+            val boundAnimeIds = animeTracks.map { it.remoteId }.toSet()
+            aniList.getFullAnimeList()
+                .filter { it.media.id !in boundAnimeIds }
+                .forEach { entry ->
+                    try {
+                        addAnimeEntry(entry, aniList)
+                    } catch (e: Throwable) {
+                        logcat(LogPriority.WARN, e) { "Could not add AniList anime ${entry.media.title.userPreferred}" }
+                    }
+                }
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN, e) { "Could not fetch AniList anime list" }
+        }
+    }
+
+    private suspend fun addMangaEntry(entry: ALMediaListEntry, aniList: Anilist) {
+        val title = entry.media.title.userPreferred
+        val (networkManga, source) = findMangaInSources(title) ?: return
+
+        val existing = getManga.await(networkManga.url, source.id)
+        val isNew = existing == null
+        val wasUnfavorited = existing?.favorite == false
+        val dbManga = when {
+            existing == null -> networkToLocalManga(networkManga)
+            wasUnfavorited -> {
+                updateManga.awaitUpdateFavorite(existing.id, true)
+                getManga.await(networkManga.url, source.id) ?: existing
+            }
+            else -> existing
+        }
+
+        if (isNew || wasUnfavorited) {
+            setMangaCategories.await(dbManga.id, emptyList())
+        }
+
+        updateMangaFromRemote(
+            manga = dbManga,
+            fetchDetails = true,
+            fetchChapters = true,
+            manualFetch = true,
+        )
+
+        val item = aniList.searchById(entry.media.id.toString()) ?: return
+        addTracks.bind(aniList, item, dbManga.id)
+
+        val track = getTracks.await(dbManga.id)
+            .firstOrNull { it.trackerId == TrackerManager.ANILIST } ?: return
+        syncChapterProgressWithTrack.sync(dbManga.id, track, aniList)
+        logcat(LogPriority.INFO) { "Synced AniList manga \"$title\" with source ${source.name}" }
+    }
+
+    private suspend fun addAnimeEntry(entry: ALMediaListEntry, aniList: Anilist) {
+        val title = entry.media.title.userPreferred
+        val (networkAnime, source) = findAnimeInSources(title) ?: return
+
+        val existing = getAnime.await(networkAnime.url, source.id)
+        val isNew = existing == null
+        val wasUnfavorited = existing?.favorite == false
+        val dbAnime = when {
+            existing == null -> networkToLocalAnime(networkAnime)
+            wasUnfavorited -> {
+                updateAnime.awaitUpdateFavorite(existing.id, true)
+                getAnime.await(networkAnime.url, source.id) ?: existing
+            }
+            else -> existing
+        }
+
+        if (isNew || wasUnfavorited) {
+            setAnimeCategories.await(dbAnime.id, emptyList())
+        }
+
+        try {
+            val details = source.getAnimeDetails(dbAnime.toSAnime())
+            updateAnime.awaitUpdateFromSource(dbAnime, details, manualFetch = true)
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN, e) { "Could not fetch details for AniList anime \"$title\"" }
+        }
+        val initialized = getAnime.await(networkAnime.url, source.id) ?: dbAnime
+
+        try {
+            val rawEpisodes = source.getEpisodeList(initialized.toSAnime())
+            if (rawEpisodes.isNotEmpty()) {
+                syncEpisodesWithSource.await(rawEpisodes, initialized, source, manualFetch = false)
+            }
+        } catch (e: NoResultsException) {
+            // No episodes available yet
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN, e) { "Could not fetch episodes for AniList anime \"$title\"" }
+        }
+
+        val item = aniList.searchAnimeById(entry.media.id) ?: return
+        item.anime_id = initialized.id
+        addAnimeTracks.bind(aniList, item, initialized.id)
+
+        val track = getAnimeTracks.await(initialized.id)
+            .firstOrNull { it.trackerId == TrackerManager.ANILIST } ?: return
+        markEpisodesSeen(initialized.id, track, aniList)
+        logcat(LogPriority.INFO) { "Synced AniList anime \"$title\" with source ${source.name}" }
+    }
+
+    private suspend fun findMangaInSources(title: String): Pair<Manga, Source>? {
+        for (source in sourceManager.getOnlineSources()) {
+            if (source is LoginSource && source.requiresLogin && !source.isLogged()) continue
+            val results = try {
+                source.getSearchManga(1, title, FilterList())
+            } catch (e: Throwable) {
+                continue
+            }
+            val match = results.mangas
+                .firstOrNull { AniListTitleMatcher.matches(title, it.title) }
+                ?: continue
+            val manga = Manga.create().copy(
+                url = match.url,
+                ogTitle = match.title,
+                source = source.id,
+                favorite = true,
+                dateAdded = System.currentTimeMillis(),
+            )
+            return manga to source
+        }
+        return null
+    }
+
+    private suspend fun findAnimeInSources(title: String): Pair<Anime, AnimeSource>? {
+        for (source in animeSourceManager.getCatalogueSources()) {
+            val results = try {
+                source.getSearchAnime(1, title, AnimeFilterList())
+            } catch (e: Throwable) {
+                continue
+            }
+            val match = results.animes
+                .firstOrNull { AniListTitleMatcher.matches(title, it.title) }
+                ?: continue
+            val anime = Anime.create().copy(
+                url = match.url,
+                ogTitle = match.title,
+                source = source.id,
+                favorite = true,
+                dateAdded = System.currentTimeMillis(),
+            )
+            return anime to source
+        }
+        return null
+    }
+
+    private suspend fun markEpisodesSeen(animeId: Long, remoteTrack: AnimeTrack, aniList: Anilist) {
+        if (remoteTrack.status == AniList.PLAN_TO_WATCH || remoteTrack.status == AniList.PLAN_TO_READ) return
+
+        val dbEpisodes = getEpisodesByAnimeId.await(animeId)
+            .sortedByDescending { it.sourceOrder }
+            .filter { it.isRecognizedNumber }
+
+        var lastCheckChapter: Double
+        var checkingChapter = 0.0
+
+        // Only continuous incremental episodes, abnormal numbering stops propagation
+        val episodeUpdates = dbEpisodes
+            .takeWhile { episode ->
+                lastCheckChapter = checkingChapter
+                checkingChapter = episode.episodeNumber
+                episode.episodeNumber >= lastCheckChapter && episode.episodeNumber <= remoteTrack.lastEpisodeSeen
+            }
+            .filter { !it.seen }
+            .map { it.copy(seen = true).toEpisodeUpdate() }
+
+        if (episodeUpdates.isNotEmpty()) {
+            updateEpisode.awaitAll(episodeUpdates)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/track/service/AniListSyncJob.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/AniListSyncJob.kt
@@ -1,0 +1,110 @@
+package eu.kanade.domain.track.service
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkerParameters
+import eu.kanade.domain.track.interactor.SyncAniListToLibrary
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import exh.util.WorkerUtil
+import logcat.LogPriority
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class AniListSyncJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val syncAniListToLibrary: SyncAniListToLibrary = Injekt.get()
+
+    override suspend fun doWork(): Result {
+        setForegroundSafely()
+        return withIOContext {
+            try {
+                syncAniListToLibrary.await()
+                Result.success()
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e)
+                Result.failure()
+            }
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val builder = NotificationCompat.Builder(context, Notifications.CHANNEL_LIBRARY_PROGRESS)
+            .setSmallIcon(R.drawable.ic_refresh_24dp)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setContentTitle(context.stringResource(MR.strings.syncing_ani_list))
+        return ForegroundInfo(
+            Notifications.ID_ANILIST_SYNC,
+            builder.build(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        private const val TAG = "AniListSync"
+        private const val WORK_NAME_AUTO = "AniListSync-auto"
+        private const val WORK_NAME_MANUAL = "AniListSync-manual"
+
+        fun setupTask(context: Context) {
+            val constraints = Constraints(
+                requiredNetworkType = NetworkType.CONNECTED,
+            )
+            val request = PeriodicWorkRequestBuilder<AniListSyncJob>(6, TimeUnit.HOURS, 15, TimeUnit.MINUTES)
+                .addTag(TAG)
+                .addTag(WORK_NAME_AUTO)
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+                .build()
+
+            context.workManager.enqueueUniquePeriodicWork(
+                WORK_NAME_AUTO,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request,
+            )
+        }
+
+        fun startNow(context: Context): Boolean {
+            val wm = context.workManager
+            if (wm.isRunning(TAG)) {
+                return false
+            }
+
+            val request = OneTimeWorkRequestBuilder<AniListSyncJob>()
+                .addTag(TAG)
+                .addTag(WORK_NAME_MANUAL)
+                .setConstraints(Constraints(requiredNetworkType = NetworkType.CONNECTED))
+                .build()
+            wm.enqueueUniqueWork(WORK_NAME_MANUAL, ExistingWorkPolicy.KEEP, request)
+
+            return true
+        }
+
+        suspend fun isPeriodicSyncScheduled(context: Context): Boolean {
+            return WorkerUtil.isPeriodicJobScheduled(context, WORK_NAME_AUTO)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -39,6 +39,10 @@ object Notifications {
     const val ID_EHENTAI_PROGRESS = -199
     const val ID_EHENTAI_ERROR = -198
 
+    // KMK -->
+    const val ID_ANILIST_SYNC = -107
+    // KMK <--
+
     /**
      * Notification channel and ids used by the downloader.
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.track.AnimeTracker
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableAnimeTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALMediaListEntry
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
@@ -318,6 +319,14 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker, AnimeTra
         return api.searchAnime(query)
     }
 
+    suspend fun getFullMangaList(): List<ALMediaListEntry> {
+        return api.getMangaList(getUsername().toInt())
+    }
+
+    suspend fun getFullAnimeList(): List<ALMediaListEntry> {
+        return api.getAnimeList(getUsername().toInt())
+    }
+
     override suspend fun refresh(track: Track): Track {
         val remoteTrack = api.getLibManga(track, getUsername().toInt())
         track.copyPersonalFrom(remoteTrack)
@@ -364,6 +373,15 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker, AnimeTra
             api.searchById(id)
         } catch (e: Exception) {
             xLogW("Error during searchById '$id': ${e.message}", e)
+            null
+        }
+    }
+
+    suspend fun searchAnimeById(id: Long): AnimeTrackSearch? {
+        return try {
+            api.searchAnimeById(id)
+        } catch (e: Exception) {
+            xLogW("Error during searchAnimeById '$id': ${e.message}", e)
             null
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -9,6 +9,8 @@ import eu.kanade.tachiyomi.data.track.anilist.dto.ALCurrentUserResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALError
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALIdSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALMediaListCollectionResult
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALMediaListEntry
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListMangaQueryResult
@@ -573,6 +575,58 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         }
     }
 
+    suspend fun getMangaList(userId: Int): List<ALMediaListEntry> {
+        return getMediaListCollection(userId, "MANGA")
+    }
+
+    suspend fun getAnimeList(userId: Int): List<ALMediaListEntry> {
+        return getMediaListCollection(userId, "ANIME")
+    }
+
+    private suspend fun getMediaListCollection(userId: Int, type: String): List<ALMediaListEntry> {
+        return withIOContext {
+            val query = $$"""
+            |query ($userId: Int, $type: MediaType) {
+                |MediaListCollection(userId: $userId, type: $type) {
+                    |lists {
+                        |entries {
+                            |id
+                            |status
+                            |progress
+                            |media {
+                                |id
+                                |title {
+                                    |userPreferred
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            |
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("userId", userId)
+                    put("type", type)
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitALSuccess()
+                    .parseAs<ALMediaListCollectionResult>()
+                    .data.mediaListCollection.lists
+                    .flatMap { it.entries }
+            }
+        }
+    }
+
     suspend fun getLibManga(track: Track, userId: Int): Track {
         return findLibManga(track, userId) ?: throw Exception("Could not find manga")
     }
@@ -736,6 +790,62 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     .parseAs<ALIdSearchResult>()
                     .data.media
                     .toALManga()
+                    .toTrack()
+            }
+        }
+    }
+
+    suspend fun searchAnimeById(id: Long): AnimeTrackSearch {
+        return withIOContext {
+            val query = $$"""
+            |query ($animeId: Int!) {
+                |Media (id: $animeId) {
+                    |id
+                    |studios {
+                        |edges {
+                            |isMain
+                            |node {
+                                |name
+                            |}
+                        |}
+                    |}
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |format
+                    |status
+                    |episodes
+                    |description
+                    |startDate {
+                        |year
+                        |month
+                        |day
+                    |}
+                    |averageScore
+                |}
+            |}
+            |
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("animeId", id)
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitALSuccess()
+                    .parseAs<ALIdSearchResult>()
+                    .data.media
+                    .toALAnime()
                     .toTrack()
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALMediaListCollection.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALMediaListCollection.kt
@@ -1,0 +1,39 @@
+package eu.kanade.tachiyomi.data.track.anilist.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALMediaListCollectionResult(
+    val data: ALMediaListCollectionData,
+)
+
+@Serializable
+data class ALMediaListCollectionData(
+    @SerialName("MediaListCollection")
+    val mediaListCollection: ALMediaListCollection,
+)
+
+@Serializable
+data class ALMediaListCollection(
+    val lists: List<ALMediaListGroup> = emptyList(),
+)
+
+@Serializable
+data class ALMediaListGroup(
+    val entries: List<ALMediaListEntry> = emptyList(),
+)
+
+@Serializable
+data class ALMediaListEntry(
+    val id: Long,
+    val status: String,
+    val progress: Int,
+    val media: ALMediaListEntryMedia,
+)
+
+@Serializable
+data class ALMediaListEntryMedia(
+    val id: Long,
+    val title: ALItemTitle,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -57,6 +57,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.connections.service.ConnectionsPreferences
 import eu.kanade.domain.source.interactor.GetIncognitoState
+import eu.kanade.domain.track.service.AniListSyncJob
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.presentation.components.AppStateBanners
@@ -521,6 +522,12 @@ class MainActivity : BaseActivity() {
                     if (!AnimeLibraryUpdateJob.isPeriodicUpdateScheduled(context)) {
                         AnimeLibraryUpdateJob.setupTask(context)
                     }
+                    // KMK -->
+                    if (!AniListSyncJob.isPeriodicSyncScheduled(context)) {
+                        AniListSyncJob.setupTask(context)
+                    }
+                    AniListSyncJob.startNow(context)
+                    // KMK <--
                 } catch (e: Exception) {
                     logcat(LogPriority.ERROR, e)
                     withContext(Dispatchers.Main) {

--- a/app/src/test/kotlin/eu/kanade/domain/track/interactor/AniListTitleMatcherTest.kt
+++ b/app/src/test/kotlin/eu/kanade/domain/track/interactor/AniListTitleMatcherTest.kt
@@ -1,0 +1,34 @@
+package eu.kanade.domain.track.interactor
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AniListTitleMatcherTest {
+
+    @Test
+    fun `normalize strips punctuation and case`() {
+        assertEquals("rezerostartinglifeinanotherworld", AniListTitleMatcher.normalize("Re:Zero − Starting Life in Another World!"))
+        assertEquals("onepiece", AniListTitleMatcher.normalize("One Piece"))
+        assertEquals("ワンピース", AniListTitleMatcher.normalize("ワンピース"))
+    }
+
+    @Test
+    fun `matches ignores casing and punctuation`() {
+        assertTrue(AniListTitleMatcher.matches("One Piece", "one piece"))
+        assertTrue(AniListTitleMatcher.matches("Frieren: Beyond Journey's End", "Frieren – Beyond Journeys End"))
+    }
+
+    @Test
+    fun `matches unicode titles`() {
+        assertTrue(AniListTitleMatcher.matches("葬送のフリーレン", "葬送のフリーレン"))
+        assertFalse(AniListTitleMatcher.matches("葬送のフリーレン", "ワンピース"))
+    }
+
+    @Test
+    fun `empty normalized titles never match`() {
+        assertFalse(AniListTitleMatcher.matches(":", "!?"))
+        assertFalse(AniListTitleMatcher.matches(":", "One Piece"))
+    }
+}

--- a/data/src/main/java/tachiyomi/data/track/anime/AnimeTrackRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/track/anime/AnimeTrackRepositoryImpl.kt
@@ -19,6 +19,12 @@ class AnimeTrackRepositoryImpl(
         }
     }
 
+    override suspend fun getAllAnime(): List<AnimeTrack> {
+        return handler.awaitList {
+            anime_syncQueries.getAnimeTracks(AnimeTrackMapper::mapTrack)
+        }
+    }
+
     override fun getAnimeTracksAsFlow(): Flow<List<AnimeTrack>> {
         return handler.subscribeToList {
             anime_syncQueries.getAnimeTracks(AnimeTrackMapper::mapTrack)

--- a/domain/src/main/java/tachiyomi/domain/track/anime/interactor/GetAnimeTracks.kt
+++ b/domain/src/main/java/tachiyomi/domain/track/anime/interactor/GetAnimeTracks.kt
@@ -28,6 +28,15 @@ class GetAnimeTracks(
         }
     }
 
+    suspend fun awaitAll(): List<AnimeTrack> {
+        return try {
+            animeTrackRepository.getAllAnime()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            emptyList()
+        }
+    }
+
     fun subscribe(): Flow<List<AnimeTrack>> {
         return animeTrackRepository.getAnimeTracksAsFlow()
     }

--- a/domain/src/main/java/tachiyomi/domain/track/anime/repository/AnimeTrackRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/track/anime/repository/AnimeTrackRepository.kt
@@ -9,6 +9,8 @@ interface AnimeTrackRepository {
 
     suspend fun getTracksByAnimeId(animeId: Long): List<AnimeTrack>
 
+    suspend fun getAllAnime(): List<AnimeTrack>
+
     fun getAnimeTracksAsFlow(): Flow<List<AnimeTrack>>
 
     fun getTracksByAnimeIdAsFlow(animeId: Long): Flow<List<AnimeTrack>>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -897,6 +897,7 @@
 
     <!-- Sync section -->
     <string name="syncing_library">Syncing library</string>
+    <string name="syncing_ani_list">Syncing AniList</string>
     <string name="library_sync_complete">Library sync complete</string>
 
       <!-- Advanced section -->


### PR DESCRIPTION
- Background AniListSyncJob (periodic 6h + on app open) pulls chapter/episode progress from AniList into tracked library entries
- New AniList list entries are auto-added to the library when an exact normalized title match is found in an installed source

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
