### PR TITLE
Fix sentence audio timing, SRT probing, and episode navigation

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -94,6 +94,7 @@ import eu.kanade.tachiyomi.ui.player.utils.applySubtitleRegexFilters
 import eu.kanade.tachiyomi.ui.player.utils.subtitleRegexFilterOptions
 import eu.kanade.tachiyomi.ui.player.utils.displayName
 import eu.kanade.tachiyomi.ui.player.utils.guessJimakuMedia
+import eu.kanade.tachiyomi.ui.player.utils.inPlaybackOrder
 import eu.kanade.tachiyomi.ui.player.utils.matchedSrtFiles
 import eu.kanade.tachiyomi.ui.player.utils.selectBestJimakuEntry
 import eu.kanade.tachiyomi.ui.reader.SaveImageNotifier
@@ -2114,7 +2115,8 @@ class PlayerViewModel @JvmOverloads constructor(
             episodesForPlayer += listOf(selectedEpisode)
         }
 
-        return episodesForPlayer
+        return episodesForPlayer.sortedWith(getEpisodeSort(anime, sortDescending = false))
+            .inPlaybackOrder(anime.sorting == Anime.EPISODE_SORTING_SOURCE)
     }
 
     fun getCurrentEpisodeIndex(): Int {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -969,7 +969,8 @@ private fun PlayerSubtitleTextLayer(
                         )
                     }
                 }
-                .pointerInput(subtitleText, textLayout, textLayerOrigin, subtitleDelaySeconds) {
+                // Timing can arrive after the text, or change when an identical line repeats.
+                .pointerInput(subtitleText, textLayout, textLayerOrigin, subtitleDelaySeconds, cue) {
                     detectTapGestures(
                         onTap = { position ->
                             val layout = textLayout ?: return@detectTapGestures

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/mining/SentenceAudio.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/mining/SentenceAudio.kt
@@ -275,7 +275,7 @@ internal object SentenceAudioFfmpegArguments {
         if (input.headers.isNotEmpty()) { add("-headers"); add(input.headers.joinToString("") { "${it.first}: ${it.second}\r\n" }) }
     }
     private fun Double.seconds() = String.format(Locale.ROOT, "%.6f", this).trimEnd('0').trimEnd('.')
-    internal const val ALLOWED_INPUT_DECODERS = "aac,aac_fixed,ac3,alac,ass,av1,dca,dvdsub,eac3,eia_608,ffv1,flac,h263,h264,hevc,libdav1d,mjpeg,mov_text,mp3,mp3float,mpeg1video,mpeg2video,mpeg4,opus,pcm_f32le,pcm_s16le,pcm_s24le,pcm_s32le,png,prores,realtext,ssa,subrip,text,theora,truehd,vorbis,vp8,vp9,webvtt"
+    internal const val ALLOWED_INPUT_DECODERS = "aac,aac_fixed,ac3,alac,ass,av1,dca,dvdsub,eac3,eia_608,ffv1,flac,h263,h264,hevc,libdav1d,mjpeg,mov_text,mp3,mp3float,mpeg1video,mpeg2video,mpeg4,opus,pcm_f32le,pcm_s16le,pcm_s24le,pcm_s32le,png,prores,realtext,srt,ssa,subrip,text,theora,truehd,vorbis,vp8,vp9,webvtt"
 }
 
 /** Parses the small, explicitly requested audio subset of ffprobe's key/value output. */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/PlaybackEpisodeOrder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/PlaybackEpisodeOrder.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+import tachiyomi.domain.episode.model.Episode
+
+/** Source lists can arrive in either direction; numbered playback always advances chronologically. */
+internal fun List<Episode>.inPlaybackOrder(useEpisodeNumbers: Boolean): List<Episode> =
+    if (useEpisodeNumbers && all { it.isRecognizedNumber && it.episodeNumber.isFinite() }) {
+        sortedBy { it.episodeNumber }
+    } else {
+        this
+    }

--- a/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/PlaybackEpisodeOrderTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/ui/player/utils/PlaybackEpisodeOrderTest.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.episode.model.Episode
+
+class PlaybackEpisodeOrderTest {
+    private fun episodes(vararg numbers: Double) = numbers.mapIndexed { index, number ->
+        Episode.create().copy(id = index.toLong(), episodeNumber = number)
+    }
+
+    @Test
+    fun `next advances to a higher episode for either source direction`() {
+        for (playlist in listOf(episodes(300.0, 301.0, 302.0), episodes(302.0, 301.0, 300.0))) {
+            val ordered = playlist.inPlaybackOrder(true)
+            val current = ordered.indexOfFirst { it.episodeNumber == 301.0 }
+            assertEquals(302.0, ordered[current + 1].episodeNumber)
+            assertEquals(300.0, ordered[current - 1].episodeNumber)
+        }
+    }
+
+    @Test
+    fun `fractional episodes and duplicate releases keep their order`() {
+        val playlist = episodes(302.0, 301.5, 301.0, 301.0)
+        assertEquals(listOf(2L, 3L, 1L, 0L), playlist.inPlaybackOrder(true).map { it.id })
+    }
+
+    @Test
+    fun `unknown numbers and explicit alternative sorting preserve the supplied order`() {
+        for (playlist in listOf(episodes(2.0, -1.0, 1.0), episodes(2.0, Double.NaN, 1.0))) {
+            assertEquals(playlist, playlist.inPlaybackOrder(true))
+        }
+        val playlist = episodes(2.0, 1.0)
+        assertEquals(playlist, playlist.inPlaybackOrder(false))
+        assertEquals(emptyList<Episode>(), emptyList<Episode>().inPlaybackOrder(true))
+    }
+}


### PR DESCRIPTION
Subtitle lookup can retain a null or stale cue when timing arrives after the displayed text, causing sentence audio to report unavailable timing. Restart the tap handler when the cue changes so taps and long presses capture its updated timing.

Also fix two related player failures:
- Add `srt` to the input decoder whitelist shared by audio probing and extraction. FFprobe opens subtitle tracks before applying its audio stream selector, so an SRT track previously caused the probe to fail even when AAC audio was available.
- Sort fully numbered source-order playlists by ascending episode number, making the right skip button advance (301 to 302) and the left button go back (301 to 300), regardless of source list direction. Preserve other sorting modes and playlists with unknown numbers, and restore filtered-out current episodes to their sorted position.

Validation:
- Three episode-order JUnit regression tests passed through direct Kotlin compilation and JUnit execution: both source directions, fractional/duplicate episodes, and unknown numbers/alternative ordering.
- Generated an MKV with AAC audio and SRT subtitles using desktop FFmpeg. The original whitelist reproduced `Codec (srt) not on whitelist` and FFprobe exit 1. Adding only `srt` made the audio probe and a two-second AAC extraction pass.
- `git diff --check` passed.
- Full Android Gradle validation was not completed; the local Android SDK is incomplete. Physical-device subtitle mining and the bundled Android FFmpeg build still need validation.